### PR TITLE
Clear metadata panel on load.

### DIFF
--- a/viewer/src/main/java/org/jmisb/viewer/MetadataPanel.java
+++ b/viewer/src/main/java/org/jmisb/viewer/MetadataPanel.java
@@ -26,6 +26,7 @@ public class MetadataPanel extends JTextPane implements IMetadataListener
         setEditable(false);
         setContentType("text/html");
         setFont(new Font("Dialog", PLAIN, 12));
+        clear();
     }
 
     @Override
@@ -70,5 +71,9 @@ public class MetadataPanel extends JTextPane implements IMetadataListener
 
             previous = current;
         }
+    }
+
+    public final void clear() {
+        this.setText("<html><head/><body/></html>");
     }
 }

--- a/viewer/src/main/java/org/jmisb/viewer/MisbViewer.java
+++ b/viewer/src/main/java/org/jmisb/viewer/MisbViewer.java
@@ -293,6 +293,7 @@ public class MisbViewer extends JFrame implements ActionListener
             }
         }
         videoPanel.clear();
+        metadataPanel.clear();
     }
 
     /**


### PR DESCRIPTION
## Motivation and Context

This avoids confusion when the previous file did have metadata, but the new
file doesn't have (valid) metadata, so you see the old metadata with the new
video stream.

## Description
Modifies viewer to clear metadata.

## How Has This Been Tested?
Manual testing:
 - load file with metadata
 - load file without metadata
 - check metadata pane does not have old data
 - load file with metadata, ensure it shows up OK.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

