### PR TITLE
Add ST0601 types for pressure and wind speed / direction.

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/AirfieldBarometricPressure.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AirfieldBarometricPressure.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 West Ridge Systems.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmisb.api.klv.st0601;
+
+/*
+ * Airfield Barometric Pressure (ST 0601 tag 53)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Airfield Barometric Pressure. Local pressure at airfield of known height.
+ * <p>
+ * Map 0..(2^16-1) to 0..5000
+ * <p>
+ * Resolution: ~0.08 millibar
+ * </blockquote>
+ */
+public class AirfieldBarometricPressure extends UasPressureMillibars {
+
+    public AirfieldBarometricPressure(double pressureMillibars) {
+        super(pressureMillibars);
+    }
+
+    public AirfieldBarometricPressure(byte[] bytes) {
+        super(bytes);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/DifferentialPressure.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/DifferentialPressure.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 West Ridge Systems.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmisb.api.klv.st0601;
+
+/*
+ * Differential Pressure (ST 0601 tag 49)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Differential Pressure. Differential pressure at aircraft location. Measured as
+ * the Stagnation/impact/total pressure minus static pressure
+ * <p>
+ * Map 0..(2^16-1) to 0..5000
+ * <p>
+ * Resolution: ~0.08 millibar
+ * </blockquote>
+ */
+public class DifferentialPressure extends UasPressureMillibars {
+
+    public DifferentialPressure(double pressureMillibars) {
+        super(pressureMillibars);
+    }
+
+    public DifferentialPressure(byte[] bytes) {
+        super(bytes);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/StaticPressure.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/StaticPressure.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 West Ridge Systems.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmisb.api.klv.st0601;
+
+/*
+ * Static Pressure (ST 0601 tag 37)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Static Pressure. Static pressure at aircraft location. The static pressure is
+ * the pressure of the air that surrounds the aircraft. Static pressure is measured
+ * by a sensor mounted out of the air stream on the side of the fuselage. This is
+ * used with impact pressure to compute indicated airspeed, true airspeed, and
+ * density altitude.
+ * <p>
+ * Map 0..(2^16-1) to 0..5000
+ * <p>
+ * Resolution: ~0.08 millibar
+ * </blockquote>
+ */
+public class StaticPressure extends UasPressureMillibars {
+
+    public StaticPressure(double pressureMillibars) {
+        super(pressureMillibars);
+    }
+
+    public StaticPressure(byte[] bytes) {
+        super(bytes);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -89,14 +89,11 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case WindDirection:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new WindDirectionAngle(bytes);
             case WindSpeed:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new WindSpeed(bytes);
             case StaticPressure:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new StaticPressure(bytes);
             case DensityAltitude:
                 return new DensityAltitude(bytes);
             case OutsideAirTemp:
@@ -126,8 +123,7 @@ public class UasDatalinkFactory
             case SecurityLocalMetadataSet:
                 return new NestedSecurityMetadata(bytes);
             case DifferentialPressure:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new DifferentialPressure(bytes);
             case PlatformAngleOfAttack:
                 // TODO
                 return new OpaqueValue(bytes);
@@ -138,8 +134,7 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case AirfieldBarometricPressure:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new AirfieldBarometricPressure(bytes);
             case AirfieldElevation:
                 // TODO
                 return new OpaqueValue(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -77,11 +77,11 @@ public enum UasDatalinkTag
     OffsetCornerLongitudePoint4(33),
     /** Tag 34; Flag for icing detected at aircraft location; Value is a {@link OpaqueValue} */
     IcingDetected(34),
-    /** Tag 35; Wind direction at aircraft location; Value is a {@link OpaqueValue} */
+    /** Tag 35; Wind direction at aircraft location; Value is a {@link WindDirectionAngle} */
     WindDirection(35),
-    /** Tag 36; Wind speed at aircraft location; Value is a {@link OpaqueValue} */
+    /** Tag 36; Wind speed at aircraft location; Value is a {@link WindSpeed} */
     WindSpeed(36),
-    /** Tag 37; Static pressure at aircraft location; Value is a {@link OpaqueValue} */
+    /** Tag 37; Static pressure at aircraft location; Value is a {@link StaticPressure} */
     StaticPressure(37),
     /** Tag 38; Density altitude at aircraft location; Value is a {@link DensityAltitude} */
     DensityAltitude(38),
@@ -105,7 +105,7 @@ public enum UasDatalinkTag
     GenericFlagData01(47),
     /** Tag 48; MISB ST 0102 local let Security Metadata items; Value is a {@link NestedSecurityMetadata} */
     SecurityLocalMetadataSet(48),
-    /** Tag 49; Differential pressure at aircraft location; Value is a {@link OpaqueValue} */
+    /** Tag 49; Differential pressure at aircraft location; Value is a {@link DifferentialPressure} */
     DifferentialPressure(49),
     /** Tag 50; Platform attack angle; Value is a {@link OpaqueValue} */
     PlatformAngleOfAttack(50),
@@ -113,7 +113,7 @@ public enum UasDatalinkTag
     PlatformVerticalSpeed(51),
     /** Tag 52; Angle between the platform longitudinal axis and relative wind; Value is a {@link OpaqueValue} */
     PlatformSideslipAngle(52),
-    /** Tag 53; Local pressure at airfield of known height; Value is a {@link OpaqueValue} */
+    /** Tag 53; Local pressure at airfield of known height; Value is a {@link AirfieldBarometricPressure} */
     AirfieldBarometricPressure(53),
     /** Tag 54; Elevation of airfield corresponding to Airfield Barometric Pressure; Value is a {@link OpaqueValue} */
     AirfieldElevation(54),

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasPressureMillibars.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasPressureMillibars.java
@@ -1,0 +1,70 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * Abstract base class for pressure values in ST 0601
+ * <p>
+ * Used by tags: 37, 49, 53.
+ * <blockquote>
+ * Map 0..(2^16-1) to 0..5000 millibars.
+ * <p>
+ * Resolution: ~0.08 millibar
+ * </blockquote>
+ */
+abstract public class UasPressureMillibars implements IUasDatalinkValue
+{
+    private double pressure;
+    private static double RANGE = 5000.0;
+    private static double MAXINT = 65535.0; // 2^16 - 1
+
+    /**
+     * Create from value
+     * @param pressureMillibars pressure in millibars
+     */
+    public UasPressureMillibars(double pressureMillibars)
+    {
+        if (pressureMillibars < 0 || pressureMillibars > RANGE)
+        {
+            throw new IllegalArgumentException("Pressure must be in range [0,5000]");
+        }
+        pressure = pressureMillibars;
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes Encoded byte array
+     */
+    public UasPressureMillibars(byte[] bytes)
+    {
+        if (bytes.length != 2)
+        {
+            throw new IllegalArgumentException("Pressure encoding is a 2-byte unsigned int");
+        }
+
+        int intVal = PrimitiveConverter.toUint16(bytes);
+        pressure = (intVal / MAXINT) * RANGE;
+    }
+
+    /**
+     * Get the value in millibars
+     * @return pressure, in millibars
+     */
+    public double getMillibars()
+    {
+        return pressure;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        int intVal = (int) Math.round((pressure / RANGE) * MAXINT);
+        return PrimitiveConverter.uint16ToBytes(intVal);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return String.format("%.2fmB", pressure);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WindDirectionAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WindDirectionAngle.java
@@ -1,0 +1,72 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * Wind Direction (ST 0601 tag 35)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Wind Direction. The direction the air body around the aircraft is coming from relative to true north
+ * <p>
+ * Map 0..(2^16-1) to 0..360
+ * <p>
+ * Resolution: ~5.5 milli degrees
+ * </blockquote>
+ */
+public class WindDirectionAngle implements IUasDatalinkValue
+{
+    private double degrees;
+    private static double RANGE = 360.0;
+    private static double MAXINT = 65535.0; // 2^16 - 1
+
+    /**
+     * Create from value
+     * @param degrees wind direction, in degrees
+     */
+    public WindDirectionAngle(double degrees)
+    {
+        if (degrees < 0 || degrees > 360)
+        {
+            throw new IllegalArgumentException("Wind Direction must be in range [0,360]");
+        }
+        this.degrees = degrees;
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes Encoded byte array
+     */
+    public WindDirectionAngle(byte[] bytes)
+    {
+        if (bytes.length != 2)
+        {
+            throw new IllegalArgumentException("Wind Direction encoding is a 2-byte unsigned int");
+        }
+
+        int intVal = PrimitiveConverter.toUint16(bytes);
+        this.degrees = (intVal / MAXINT) * RANGE;
+    }
+
+    /**
+     * Get the value in degrees
+     * @return wind direction, in degrees
+     */
+    public double getDegrees()
+    {
+        return degrees;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        int intVal = (int) Math.round((degrees / RANGE) * MAXINT);
+        return PrimitiveConverter.uint16ToBytes(intVal);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return String.format("%.4f\u00B0", degrees);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WindSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WindSpeed.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 West Ridge Systems.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * Wind Speed (ST 0601 tag 36)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Wind speed at aircraft location.
+ * <p>
+ * Map 0..(2^8-1) to 0..100 meters/second.
+ * <p>
+ * Resolution: ~0.4 meters/second.
+ * </blockquote>
+ */
+public class WindSpeed implements IUasDatalinkValue {
+
+    private double windspeed;
+    private static double MIN_VALUE = 0;
+    private static double MAX_VALUE = 100;
+    private static double RANGE = 100;
+    private static double MAXINT = 255.0; // 2^8 - 1
+
+    /**
+     * Create from value
+     *
+     * @param speed Wind speed in meters/second. Legal values are in [0, 100].
+     */
+    public WindSpeed(double speed) {
+        if (speed > MAX_VALUE || speed < MIN_VALUE)
+        {
+            throw new IllegalArgumentException("Wind speed must be in range [0,100]");
+        }
+        windspeed = speed;
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes The byte array of length 1
+     */
+    public WindSpeed(byte[] bytes)
+    {
+        if (bytes.length != 1)
+        {
+            throw new IllegalArgumentException("Wind speed encoding is a 1-byte unsigned int");
+        }
+
+        int intVal = PrimitiveConverter.toUint8(bytes);
+        windspeed = ((intVal / MAXINT) * RANGE) + MIN_VALUE;
+    }
+
+    /**
+     * Get the wind speed
+     * @return The wind speed in meters/second
+     */
+    public double getMetersPerSecond()
+    {
+        return windspeed;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        short intVal = (short) Math.round(((windspeed - MIN_VALUE) / RANGE) * MAXINT);
+        return PrimitiveConverter.uint8ToBytes(intVal);
+    }
+
+    @Override
+    public String getDisplayableValue() {
+        return String.format("%.1fm/s", windspeed);
+    }
+
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/AirfieldBarometricPressureTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/AirfieldBarometricPressureTest.java
@@ -1,0 +1,69 @@
+package org.jmisb.api.klv.st0601;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AirfieldBarometricPressureTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        AirfieldBarometricPressure pressure = new AirfieldBarometricPressure(0.0);
+        byte[] bytes = pressure.getBytes();
+        Assert.assertEquals(bytes, new byte[]{0x00, 0x00});
+        Assert.assertEquals(pressure.getMillibars(), 0.0);
+
+        pressure = new AirfieldBarometricPressure(5000.0);
+        bytes = pressure.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff});
+        Assert.assertEquals(pressure.getMillibars(), 5000.0);
+
+        // Example from standard
+        pressure = new AirfieldBarometricPressure(2088.96010);
+        bytes = pressure.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0x6A, (byte)0xF4});
+        Assert.assertEquals(pressure.getMillibars(), 2088.96010);
+        Assert.assertEquals("2088.96mB", pressure.getDisplayableValue());
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        byte[] bytes = new byte[]{0x00, 0x00};
+        AirfieldBarometricPressure pressure = new AirfieldBarometricPressure(bytes);
+        Assert.assertEquals(pressure.getMillibars(), 0.0);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff};
+        pressure = new AirfieldBarometricPressure(bytes);
+        Assert.assertEquals(pressure.getMillibars(), 5000.0);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+
+        // Some random byte arrays
+        bytes = new byte[]{(byte)0xa8, (byte)0x73};
+        pressure = new AirfieldBarometricPressure(bytes);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+
+        bytes = new byte[]{(byte)0x34, (byte)0x9d};
+        pressure = new AirfieldBarometricPressure(bytes);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new AirfieldBarometricPressure(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new AirfieldBarometricPressure(5000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new AirfieldBarometricPressure(new byte[]{0x00, 0x00, 0x00, 0x00});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/DifferentialPressureTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/DifferentialPressureTest.java
@@ -1,0 +1,69 @@
+package org.jmisb.api.klv.st0601;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DifferentialPressureTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        DifferentialPressure pressure = new DifferentialPressure(0.0);
+        byte[] bytes = pressure.getBytes();
+        Assert.assertEquals(bytes, new byte[]{0x00, 0x00});
+        Assert.assertEquals(pressure.getMillibars(), 0.0);
+
+        pressure = new DifferentialPressure(5000.0);
+        bytes = pressure.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff});
+        Assert.assertEquals(pressure.getMillibars(), 5000.0);
+
+        // Example from standard
+        pressure = new DifferentialPressure(1191.95850);
+        bytes = pressure.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0x3D, (byte)0x07});
+        Assert.assertEquals(pressure.getMillibars(), 1191.95850);
+        Assert.assertEquals("1191.96mB", pressure.getDisplayableValue());
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        byte[] bytes = new byte[]{0x00, 0x00};
+        DifferentialPressure pressure = new DifferentialPressure(bytes);
+        Assert.assertEquals(pressure.getMillibars(), 0.0);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff};
+        pressure = new DifferentialPressure(bytes);
+        Assert.assertEquals(pressure.getMillibars(), 5000.0);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+
+        // Some random byte arrays
+        bytes = new byte[]{(byte)0xa8, (byte)0x73};
+        pressure = new DifferentialPressure(bytes);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+
+        bytes = new byte[]{(byte)0x34, (byte)0x9d};
+        pressure = new DifferentialPressure(bytes);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new DifferentialPressure(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new DifferentialPressure(5000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new DifferentialPressure(new byte[]{0x00, 0x00, 0x00, 0x00});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/StaticPressureTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/StaticPressureTest.java
@@ -1,0 +1,69 @@
+package org.jmisb.api.klv.st0601;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class StaticPressureTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        StaticPressure pressure = new StaticPressure(0.0);
+        byte[] bytes = pressure.getBytes();
+        Assert.assertEquals(bytes, new byte[]{0x00, 0x00});
+        Assert.assertEquals(pressure.getMillibars(), 0.0);
+
+        pressure = new StaticPressure(5000.0);
+        bytes = pressure.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff});
+        Assert.assertEquals(pressure.getMillibars(), 5000.0);
+
+        // Example from standard
+        pressure = new StaticPressure(3725.18502);
+        bytes = pressure.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0xBE, (byte)0xBA});
+        Assert.assertEquals(pressure.getMillibars(),3725.18502);
+        Assert.assertEquals("3725.19mB", pressure.getDisplayableValue());
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        byte[] bytes = new byte[]{0x00, 0x00};
+        StaticPressure pressure = new StaticPressure(bytes);
+        Assert.assertEquals(pressure.getMillibars(), 0.0);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff};
+        pressure = new StaticPressure(bytes);
+        Assert.assertEquals(pressure.getMillibars(), 5000.0);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+
+        // Some random byte arrays
+        bytes = new byte[]{(byte)0xa8, (byte)0x73};
+        pressure = new StaticPressure(bytes);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+
+        bytes = new byte[]{(byte)0x34, (byte)0x9d};
+        pressure = new StaticPressure(bytes);
+        Assert.assertEquals(pressure.getBytes(), bytes);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new StaticPressure(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new StaticPressure(5000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new StaticPressure(new byte[]{0x00, 0x00, 0x00, 0x00});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/WindDirectionAngleTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/WindDirectionAngleTest.java
@@ -1,0 +1,69 @@
+package org.jmisb.api.klv.st0601;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class WindDirectionAngleTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        WindDirectionAngle angle = new WindDirectionAngle(0.0);
+        byte[] bytes = angle.getBytes();
+        Assert.assertEquals(bytes, new byte[]{0x00, 0x00});
+        Assert.assertEquals(angle.getDegrees(), 0.0);
+
+        angle = new WindDirectionAngle(360.0);
+        bytes = angle.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff});
+        Assert.assertEquals(angle.getDegrees(), 360.0);
+
+        // Example from standard
+        angle = new WindDirectionAngle(235.924010);
+        bytes = angle.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0xA7, (byte)0xC4});
+        Assert.assertEquals(angle.getDegrees(), 235.924010);
+        Assert.assertEquals("235.9240\u00B0", angle.getDisplayableValue());
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        byte[] bytes = new byte[]{0x00, 0x00};
+        WindDirectionAngle angle = new WindDirectionAngle(bytes);
+        Assert.assertEquals(angle.getDegrees(), 0.0);
+        Assert.assertEquals(angle.getBytes(), bytes);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff};
+        angle = new WindDirectionAngle(bytes);
+        Assert.assertEquals(angle.getDegrees(), 360.0);
+        Assert.assertEquals(angle.getBytes(), bytes);
+
+        // Some random byte arrays
+        bytes = new byte[]{(byte)0xa8, (byte)0x73};
+        angle = new WindDirectionAngle(bytes);
+        Assert.assertEquals(angle.getBytes(), bytes);
+
+        bytes = new byte[]{(byte)0x34, (byte)0x9d};
+        angle = new WindDirectionAngle(bytes);
+        Assert.assertEquals(angle.getBytes(), bytes);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new WindDirectionAngle(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new WindDirectionAngle(360.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new WindDirectionAngle(new byte[]{0x00, 0x00, 0x00, 0x00});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/WindSpeedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/WindSpeedTest.java
@@ -1,0 +1,63 @@
+package org.jmisb.api.klv.st0601;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class WindSpeedTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // Min
+        WindSpeed range = new WindSpeed(0.0);
+        Assert.assertEquals(range.getBytes(), new byte[]{(byte)0x00});
+
+        // Max
+        range = new WindSpeed(100.0);
+        Assert.assertEquals(range.getBytes(), new byte[]{(byte)0xff});
+
+        // From ST:
+        range = new WindSpeed(69.8039216);
+        Assert.assertEquals(range.getBytes(), new byte[]{(byte)0xB2});
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // Min
+        WindSpeed range = new WindSpeed(new byte[]{(byte)0x00});
+        Assert.assertEquals(range.getMetersPerSecond(), 0.0);
+        Assert.assertEquals(range.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals("0.0m/s", range.getDisplayableValue());
+
+        // Max
+        range = new WindSpeed(new byte[]{(byte)0xff});
+        Assert.assertEquals(range.getMetersPerSecond(), 100.0);
+        Assert.assertEquals(range.getBytes(), new byte[]{(byte)0xff});
+        Assert.assertEquals("100.0m/s", range.getDisplayableValue());
+
+        // From ST:
+        range = new WindSpeed(new byte[]{(byte)0xB2});
+        Assert.assertEquals(range.getMetersPerSecond(), 69.8039216, 0.0001);
+        Assert.assertEquals(range.getBytes(), new byte[]{(byte)0xB2});
+        Assert.assertEquals("69.8m/s", range.getDisplayableValue());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new WindSpeed(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new WindSpeed(100.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new WindSpeed(new byte[]{0x00, 0x00});
+    }
+}

--- a/api/testng.xml
+++ b/api/testng.xml
@@ -26,8 +26,10 @@
     </test>
     <test name = "st0601">
         <classes>
+            <class name = "org.jmisb.api.klv.st0601.AirfieldBarometricPressureTest"/>
             <class name = "org.jmisb.api.klv.st0601.ChecksumTest"/>
             <class name = "org.jmisb.api.klv.st0601.CornerOffsetTest"/>
+            <class name = "org.jmisb.api.klv.st0601.DifferentialPressureTest"/>
             <class name = "org.jmisb.api.klv.st0601.HorizontalFovTest"/>
             <class name = "org.jmisb.api.klv.st0601.OnBoardMiStorageCapacityTest"/>
             <class name = "org.jmisb.api.klv.st0601.PlatformAngleOfAttackFullTest"/>
@@ -45,6 +47,7 @@
             <class name = "org.jmisb.api.klv.st0601.SensorRelativeRollTest"/>
             <class name = "org.jmisb.api.klv.st0601.SensorTrueAltitudeTest"/>
             <class name = "org.jmisb.api.klv.st0601.SlantRangeTest"/>
+            <class name = "org.jmisb.api.klv.st0601.StaticPressureTest"/>
             <class name = "org.jmisb.api.klv.st0601.TargetWidthTest"/>
             <class name = "org.jmisb.api.klv.st0601.UasDatalinkAltitudeTest"/>
             <class name = "org.jmisb.api.klv.st0601.UasDatalinkLatitudeTest"/>
@@ -52,6 +55,8 @@
             <class name = "org.jmisb.api.klv.st0601.UasDatalinkMessageTest"/>
             <class name = "org.jmisb.api.klv.st0601.UasDatalinkStringTest"/>
             <class name = "org.jmisb.api.klv.st0601.VerticalFovTest"/>
+            <class name = "org.jmisb.api.klv.st0601.WindDirectionAngleTest"/>
+            <class name = "org.jmisb.api.klv.st0601.WindSpeedTest"/>
         </classes>
     </test>
     <test name = "video">


### PR DESCRIPTION
## Motivation and Context
There are a few ST0601 tags that are only supported as opaque values. They show up as N/A in the viewer.

## Description
Implement support for Tag 35 and 36 (wind), and 37/49/53 (pressure variations).

## How Has This Been Tested?
Added unit tests, ran with one of the MISB samples that has those tags (HD_H264_0903_TS_SYN_V1_001.mpg  - requires ignoring checksums).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document..
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

