### PR TITLE
Complete handling for ST0601 PlatformRollAngle special case.

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformRollAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformRollAngle.java
@@ -72,6 +72,11 @@ public class PlatformRollAngle implements IUasDatalinkValue
     @Override
     public byte[] getBytes()
     {
+        if (degrees == Double.POSITIVE_INFINITY)
+        {
+            return invalidBytes;
+        }
+
         short shortVal = (short) Math.round((degrees / FLOAT_RANGE) * INT_RANGE);
         return PrimitiveConverter.int16ToBytes(shortVal);
     }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformRollAngleTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformRollAngleTest.java
@@ -61,8 +61,14 @@ public class PlatformRollAngleTest
     @Test
     public void testOutOfRange()
     {
+        byte[] error = new byte[]{(byte) 0x80, (byte) 0x00};
         PlatformRollAngle platformRollAngle = new PlatformRollAngle(Double.POSITIVE_INFINITY);
         Assert.assertEquals(platformRollAngle.getDegrees(), Double.POSITIVE_INFINITY);
+        Assert.assertEquals(platformRollAngle.getBytes(), error);
+
+        platformRollAngle = new PlatformRollAngle(error);
+        Assert.assertEquals(platformRollAngle.getDegrees(), Double.POSITIVE_INFINITY);
+        Assert.assertEquals(platformRollAngle.getBytes(), error);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
Implementation borrowed from PlatformPitchAngle.

## Motivation and Context
Platform Roll Angle (Tag 7) has a special case for "out of range": `0x80 0x00`. That is partly implemented.

## Description
Completes the implementation based on the PlatformPitchAngle impl.

## How Has This Been Tested?
Added new unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

