### PR TITLE
Fix typo on OffsetCornerLongitudePoint3 factory method test.

### DIFF
--- a/api/src/test/java/org/jmisb/api/klv/st0601/CornerOffsetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/CornerOffsetTest.java
@@ -120,7 +120,7 @@ public class CornerOffsetTest
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLatitudePoint3, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
 
-        v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLongitudePoint4, bytes);
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLongitudePoint3, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLatitudePoint4, bytes);


### PR DESCRIPTION
## Motivation and Context
The LongitudePoint4 is just below this, its a typo fix.

## Description
This is a minor fix for test coverage. It has no functional impact.

## How Has This Been Tested?
Ran unit tests, inspected test coverage.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

