### PR TITLE
Add support for Platform True Airspeed, Indicated Airspeed and Ground Speed

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformGroundSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformGroundSpeed.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 West Ridge Systems.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Platform Ground Speed (ST 0601 tag 56)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Speed projected to the ground of an airborne platform passing overhead. 
+ * <p>
+ * Map 0..(2^8-1) to 0..255 meters/second.
+ * <p>
+ * Resolution: 1 metre/second.
+ * </blockquote>
+ */
+public class PlatformGroundSpeed extends UasDatalinkSpeed implements IUasDatalinkValue {
+
+    /**
+     * Create from value
+     *
+     * @param speed Ground speed in meters/second. Legal values are in [0, 255].
+     */
+    public PlatformGroundSpeed(int speed) {
+        super(speed);
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes The byte array of length 1
+     */
+    public PlatformGroundSpeed(byte[] bytes)
+    {
+        super(bytes);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformIndicatedAirspeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformIndicatedAirspeed.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 West Ridge Systems.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Platform Indicated Airspeed (ST 0601 tag 9)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Indicated airspeed (IAS) of platform. Derived from Pitot tube and static pressure sensors.
+ * <p>
+ * Map 0..(2^8-1) to 0..255 meters/second.
+ * <p>
+ * Resolution: 1 metre/second.
+ * </blockquote>
+ */
+public class PlatformIndicatedAirspeed extends UasDatalinkSpeed implements IUasDatalinkValue {
+
+    /**
+     * Create from value
+     *
+     * @param speed Air speed in meters/second. Legal values are in [0, 255].
+     */
+    public PlatformIndicatedAirspeed(int speed) {
+        super(speed);
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes The byte array of length 1
+     */
+    public PlatformIndicatedAirspeed(byte[] bytes)
+    {
+        super(bytes);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformTrueAirspeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformTrueAirspeed.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 West Ridge Systems.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Platform True Speed (ST 0601 tag 8)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * True airspeed (TAS) of platform. Indicated Airspeed adjusted for temperature and altitude.
+ * <p>
+ * Map 0..(2^8-1) to 0..255 meters/second.
+ * <p>
+ * Resolution: 1 metre/second.
+ * </blockquote>
+ */
+public class PlatformTrueAirspeed extends UasDatalinkSpeed implements IUasDatalinkValue {
+
+    /**
+     * Create from value
+     *
+     * @param speed Air speed in meters/second. Legal values are in [0, 255].
+     */
+    public PlatformTrueAirspeed(int speed) {
+        super(speed);
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes The byte array of length 1
+     */
+    public PlatformTrueAirspeed(byte[] bytes)
+    {
+        super(bytes);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -39,11 +39,9 @@ public class UasDatalinkFactory
             case PlatformRollAngle:
                 return new PlatformRollAngle(bytes);
             case PlatformTrueAirspeed:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new PlatformTrueAirspeed(bytes);
             case PlatformIndicatedAirspeed:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new PlatformIndicatedAirspeed(bytes);
             case PlatformDesignation:
                 return new UasDatalinkString(bytes);
             case ImageSourceSensor:
@@ -149,8 +147,7 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case PlatformGroundSpeed:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new PlatformGroundSpeed(bytes);
             case GroundRange:
                 // TODO
                 return new OpaqueValue(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkSpeed.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 West Ridge Systems.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * UAS Datalink Speed (used by ST 0601 tag 8, 9 and 56)
+ * <p>
+ * Map 0..(2^8-1) to 0..255 meters/second.
+ * <p>
+ * Resolution: 1 metre/second.
+ */
+public class UasDatalinkSpeed implements IUasDatalinkValue {
+
+    private int speed;
+    private static double MIN_VALUE = 0;
+    private static double MAX_VALUE = 255;
+
+    /**
+     * Create from value
+     *
+     * @param speed speed in meters/second. Legal values are in [0, 255].
+     */
+    public UasDatalinkSpeed(int speed) {
+        if (speed > MAX_VALUE || speed < MIN_VALUE)
+        {
+            throw new IllegalArgumentException("Speed must be in range [0, 255]");
+        }
+        this.speed = speed;
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes The byte array of length 1
+     */
+    public UasDatalinkSpeed(byte[] bytes)
+    {
+        if (bytes.length != 1)
+        {
+            throw new IllegalArgumentException("Speed encoding is a 1-byte unsigned int");
+        }
+
+        int intVal = PrimitiveConverter.toUint8(bytes);
+        speed = intVal;
+    }
+
+    /**
+     * Get the speed
+     * @return The speed in meters/second
+     */
+    public int getMetersPerSecond()
+    {
+        return speed;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        short intVal = (short)speed;
+        return PrimitiveConverter.uint8ToBytes(intVal);
+    }
+
+    @Override
+    public String getDisplayableValue() {
+        return String.format("%dm/s", speed);
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -23,9 +23,9 @@ public enum UasDatalinkTag
     PlatformPitchAngle(6),
     /** Tag 7; Platform roll angle; Value is a {@link PlatformRollAngle} */
     PlatformRollAngle(7),
-    /** Tag 8; True airspeed (TAS) of platform; Value is a {@link OpaqueValue} */
+    /** Tag 8; True airspeed (TAS) of platform; Value is a {@link PlatformTrueAirspeed} */
     PlatformTrueAirspeed(8),
-    /** Tag 9; Indicated airspeed (IAS) of platform; Value is a {@link OpaqueValue} */
+    /** Tag 9; Indicated airspeed (IAS) of platform; Value is a {@link PlatformIndicatedAirspeed} */
     PlatformIndicatedAirspeed(9),
     /** Tag 10; Model name for the platform; Value is a {@link UasDatalinkString} */
     PlatformDesignation(10),
@@ -119,7 +119,7 @@ public enum UasDatalinkTag
     AirfieldElevation(54),
     /** Tag 55; Relative humidity at aircraft location; Value is a {@link OpaqueValue} */
     RelativeHumidity(55),
-    /** Tag 56; Speed projected to the ground of an airborne platform passing overhead; Value is a {@link OpaqueValue} */
+    /** Tag 56; Speed projected to the ground of an airborne platform passing overhead; Value is a {@link PlatformGroundSpeed} */
     PlatformGroundSpeed(56),
     /** Tag 57; Horizontal distance from ground position of aircraft relative to nadir, and target of interest; Value is a {@link OpaqueValue} */
     GroundRange(57),

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformGroundSpeedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformGroundSpeedTest.java
@@ -1,0 +1,92 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PlatformGroundSpeedTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // Min
+        PlatformGroundSpeed speed = new PlatformGroundSpeed(0);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+
+        // Max
+        speed = new PlatformGroundSpeed(255);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff});
+
+        // From ST:
+        speed = new PlatformGroundSpeed(140);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x8c});
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // Min
+        PlatformGroundSpeed speed = new PlatformGroundSpeed(new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getMetersPerSecond(), 0.0);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0m/s");
+
+        // Max
+        speed = new PlatformGroundSpeed(new byte[]{(byte)0xff});
+        Assert.assertEquals(speed.getMetersPerSecond(), 255);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff});
+        Assert.assertEquals(speed.getDisplayableValue(), "255m/s");
+
+        // From ST:
+        speed = new PlatformGroundSpeed(new byte[]{(byte)0x8c});
+        Assert.assertEquals(speed.getMetersPerSecond(), 140);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x8c});
+        Assert.assertEquals(speed.getDisplayableValue(), "140m/s");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformGroundSpeed, bytes);
+        Assert.assertTrue(v instanceof PlatformGroundSpeed);
+        PlatformGroundSpeed speed = (PlatformGroundSpeed)v;
+        Assert.assertEquals(speed.getMetersPerSecond(), 0.0);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0m/s");
+
+        bytes = new byte[]{(byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformGroundSpeed, bytes);
+        Assert.assertTrue(v instanceof PlatformGroundSpeed);
+        speed = (PlatformGroundSpeed)v;
+        Assert.assertEquals(speed.getMetersPerSecond(), 255);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff});
+        Assert.assertEquals(speed.getDisplayableValue(), "255m/s");
+
+        bytes = new byte[]{(byte)0x8c};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformGroundSpeed, bytes);
+        Assert.assertTrue(v instanceof PlatformGroundSpeed);
+        speed = (PlatformGroundSpeed)v;
+        Assert.assertEquals(speed.getMetersPerSecond(), 140);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x8c});
+        Assert.assertEquals(speed.getDisplayableValue(), "140m/s");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new PlatformGroundSpeed(-1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new PlatformGroundSpeed(256);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new PlatformGroundSpeed(new byte[]{0x00, 0x00});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformIndicatedAirspeedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformIndicatedAirspeedTest.java
@@ -1,0 +1,92 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PlatformIndicatedAirspeedTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // Min
+        PlatformIndicatedAirspeed speed = new PlatformIndicatedAirspeed(0);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+
+        // Max
+        speed = new PlatformIndicatedAirspeed(255);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff});
+
+        // From ST:
+        speed = new PlatformIndicatedAirspeed(159);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x9f});
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // Min
+        PlatformIndicatedAirspeed speed = new PlatformIndicatedAirspeed(new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getMetersPerSecond(), 0.0);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0m/s");
+
+        // Max
+        speed = new PlatformIndicatedAirspeed(new byte[]{(byte)0xff});
+        Assert.assertEquals(speed.getMetersPerSecond(), 255);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff});
+        Assert.assertEquals(speed.getDisplayableValue(), "255m/s");
+
+        // From ST:
+        speed = new PlatformIndicatedAirspeed(new byte[]{(byte)0x9f});
+        Assert.assertEquals(speed.getMetersPerSecond(), 159);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x9f});
+        Assert.assertEquals(speed.getDisplayableValue(), "159m/s");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformIndicatedAirspeed, bytes);
+        Assert.assertTrue(v instanceof PlatformIndicatedAirspeed);
+        PlatformIndicatedAirspeed speed = (PlatformIndicatedAirspeed)v;
+        Assert.assertEquals(speed.getMetersPerSecond(), 0.0);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0m/s");
+
+        bytes = new byte[]{(byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformIndicatedAirspeed, bytes);
+        Assert.assertTrue(v instanceof PlatformIndicatedAirspeed);
+        speed = (PlatformIndicatedAirspeed)v;
+        Assert.assertEquals(speed.getMetersPerSecond(), 255);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff});
+        Assert.assertEquals(speed.getDisplayableValue(), "255m/s");
+
+        bytes = new byte[]{(byte)0x9f};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformIndicatedAirspeed, bytes);
+        Assert.assertTrue(v instanceof PlatformIndicatedAirspeed);
+        speed = (PlatformIndicatedAirspeed)v;
+        Assert.assertEquals(speed.getMetersPerSecond(), 159);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x9f});
+        Assert.assertEquals(speed.getDisplayableValue(), "159m/s");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new PlatformIndicatedAirspeed(-1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new PlatformIndicatedAirspeed(256);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new PlatformIndicatedAirspeed(new byte[]{0x00, 0x00});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformTrueAirspeedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformTrueAirspeedTest.java
@@ -1,0 +1,92 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PlatformTrueAirspeedTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // Min
+        PlatformTrueAirspeed speed = new PlatformTrueAirspeed(0);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+
+        // Max
+        speed = new PlatformTrueAirspeed(255);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff});
+
+        // From ST:
+        speed = new PlatformTrueAirspeed(147);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x93});
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // Min
+        PlatformTrueAirspeed speed = new PlatformTrueAirspeed(new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getMetersPerSecond(), 0.0);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals("0m/s", speed.getDisplayableValue());
+
+        // Max
+        speed = new PlatformTrueAirspeed(new byte[]{(byte)0xff});
+        Assert.assertEquals(speed.getMetersPerSecond(), 255);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff});
+        Assert.assertEquals("255m/s", speed.getDisplayableValue());
+
+        // From ST:
+        speed = new PlatformTrueAirspeed(new byte[]{(byte)0x93});
+        Assert.assertEquals(speed.getMetersPerSecond(), 147);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x93});
+        Assert.assertEquals("147m/s", speed.getDisplayableValue());
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformTrueAirspeed, bytes);
+        Assert.assertTrue(v instanceof PlatformTrueAirspeed);
+        PlatformTrueAirspeed speed = (PlatformTrueAirspeed)v;
+        Assert.assertEquals(speed.getMetersPerSecond(), 0.0);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals("0m/s", speed.getDisplayableValue());
+
+        bytes = new byte[]{(byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformTrueAirspeed, bytes);
+        Assert.assertTrue(v instanceof PlatformTrueAirspeed);
+        speed = (PlatformTrueAirspeed)v;
+        Assert.assertEquals(speed.getMetersPerSecond(), 255);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff});
+        Assert.assertEquals("255m/s", speed.getDisplayableValue());
+
+        bytes = new byte[]{(byte)0x93};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformTrueAirspeed, bytes);
+        Assert.assertTrue(v instanceof PlatformTrueAirspeed);
+        speed = (PlatformTrueAirspeed)v;
+        Assert.assertEquals(speed.getMetersPerSecond(), 147);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x93});
+        Assert.assertEquals("147m/s", speed.getDisplayableValue());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new PlatformTrueAirspeed(-1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new PlatformTrueAirspeed(256);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new PlatformTrueAirspeed(new byte[]{0x00, 0x00});
+    }
+}


### PR DESCRIPTION
## Motivation and Context
This implements support for Tag 8, 9 and 56. They are basically the same, although the semantics are different.

## Description
This is a very simple tag mapping, implemented in shared code.

## How Has This Been Tested?
Added unit tests, checked coverage changes.
Also ran this in the viewer application against some of the MISB test data (e.g. HD_MP2_06011_TS_ASYN_V1_001.mpg) which uses these tags.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

