### PR TITLE
Avoid throwing on unknown tags.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -31,11 +31,24 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j18-impl</artifactId>
+            <scope>test</scope>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>ffmpeg-platform</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.0</version>
+            <scope>test</scope>
+            <type>jar</type>
         </dependency>
     </dependencies>
 

--- a/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataMessage.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataMessage.java
@@ -1,5 +1,6 @@
 package org.jmisb.api.klv.st0102;
 
+import java.util.Collection;
 import org.jmisb.api.klv.IMisbMessage;
 
 import java.util.SortedMap;
@@ -31,5 +32,14 @@ public abstract class SecurityMetadataMessage implements IMisbMessage
     public ISecurityMetadataValue getField(SecurityMetadataKey key)
     {
         return map.get(key);
+    }
+
+    /**
+     * Get the available message keys
+     *
+     * @return Collection of the keys in the security metadata message.
+     */
+    public Collection<SecurityMetadataKey> getKeys() {
+        return map.keySet();
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSet.java
@@ -128,9 +128,6 @@ public class SecurityMetadataLocalSet extends SecurityMetadataMessage
         return "ST 0102 (local)";
     }
 
-    void getTags() {
-    }
-
     /**
      * Builder class for {@link SecurityMetadataLocalSet} objects
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSet.java
@@ -9,12 +9,15 @@ import java.util.*;
 
 import static org.jmisb.api.klv.KlvConstants.SecurityMetadataLocalSetUl;
 import static org.jmisb.core.klv.ArrayUtils.arrayFromChunks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Security Metadata Local Set message packet defined by ST 0102
  */
 public class SecurityMetadataLocalSet extends SecurityMetadataMessage
 {
+    private static Logger logger = LoggerFactory.getLogger(SecurityMetadataLocalSet.class);
     /**
      * Create the message from the given key/value pairs
      *
@@ -54,13 +57,12 @@ public class SecurityMetadataLocalSet extends SecurityMetadataMessage
         {
             SecurityMetadataKey key = SecurityMetadataKey.getKey(field.getTag());
 
-            if (key == SecurityMetadataKey.Undefined)
-            {
-                throw new KlvParseException("Invalid Security Metadata tag: " + field.getTag());
+            if (key == SecurityMetadataKey.Undefined) {
+                logger.info("Unknown Security Metadata tag: " + field.getTag());
+            } else {
+                ISecurityMetadataValue value = LocalSetFactory.createValue(key, field.getData());
+                setField(key, value);
             }
-
-            ISecurityMetadataValue value = LocalSetFactory.createValue(key, field.getData());
-            setField(key, value);
         }
     }
 
@@ -124,6 +126,9 @@ public class SecurityMetadataLocalSet extends SecurityMetadataMessage
     @Override
     public String displayHeader() {
         return "ST 0102 (local)";
+    }
+
+    void getTags() {
     }
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkMessage.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkMessage.java
@@ -7,6 +7,8 @@ import java.util.*;
 
 import static org.jmisb.api.klv.KlvConstants.UasDatalinkLocalUl;
 import static org.jmisb.core.klv.ArrayUtils.arrayFromChunks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * UAS Datalink Local Set message packet as defined by ST 0601
@@ -16,6 +18,8 @@ import static org.jmisb.core.klv.ArrayUtils.arrayFromChunks;
  */
 public class UasDatalinkMessage implements IMisbMessage
 {
+    private static Logger logger = LoggerFactory.getLogger(UasDatalinkMessage.class);
+
     // TODO: should we make this class immutable? May have benefits for stability in multi-threaded environments.
 
     /** Map containing all data elements in the message (except, normally, the checksum) */
@@ -54,7 +58,7 @@ public class UasDatalinkMessage implements IMisbMessage
             UasDatalinkTag tag = UasDatalinkTag.getTag(field.getTag());
             if (tag == UasDatalinkTag.Undefined)
             {
-                throw new KlvParseException("Invalid UAS Datalink tag: " + field.getTag());
+                logger.info("Unknown UAS Datalink tag: " + field.getTag());
             }
             else if (tag == UasDatalinkTag.Checksum)
             {

--- a/api/src/test/java/org/jmisb/api/klv/KlvParserTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/KlvParserTest.java
@@ -136,8 +136,8 @@ public class KlvParserTest
         byteBuffer.put((byte) 0x04);
         byteBuffer.put((byte) UasDatalinkTag.Checksum.getCode());
         byteBuffer.put(CHECKSUM_LEN);
-        byteBuffer.put((byte) 0x4a);
-        byteBuffer.put((byte) 0x53);
+        byteBuffer.put((byte) 0x4c);
+        byteBuffer.put((byte) 0x51);
         byte[] bytes = byteBuffer.array();
         try {
             List<IMisbMessage> messages = KlvParser.parseBytes(bytes);

--- a/api/src/test/java/org/jmisb/api/klv/KlvParserTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/KlvParserTest.java
@@ -7,12 +7,43 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
 
 public class KlvParserTest
 {
+    @Mock
+    AppenderSkeleton appender;
+    @Captor
+    ArgumentCaptor<LoggingEvent> logCaptor;
+
+    private final byte CHECKSUM_LEN = (byte)0x02;
+    private final byte[] UNKNOWN_TAG_KEY = new byte[]{(byte)0x90, (byte)0x00};
+    private final byte UNKNOWN_TAG_LEN = (byte)0x02;
+    private final byte[] UNKNOWN_TAG_VALUE = new byte[]{(byte)0x0a, (byte)0x0b};
+    private final byte SENSOR_LAT_LEN = (byte)0x04;
+    private final byte[] SENSOR_LAT_VALUE = new byte[]{(byte)0x3c, (byte)0x4e, (byte)0xad, (byte)0xfa};
+    private final byte SENSOR_LON_LEN = (byte)0x04;
+    private final byte[] SENSOR_LON_VALUE = new byte[]{(byte)0xcd, (byte)0x6b, (byte)0x78, (byte)0x4e};
+    private final byte SENSOR_ALT_LEN = (byte)0x02;
+    private final byte[] SENSOR_ALT_VALUE = new byte[]{(byte)0x1b, (byte)0xc4};
+
+    @BeforeMethod
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
+
     @Test
     public void testUasDatalink()
     {
@@ -33,6 +64,7 @@ public class KlvParserTest
             Assert.assertTrue(message instanceof UasDatalinkMessage);
 
             UasDatalinkMessage datalinkMessage = (UasDatalinkMessage) message;
+            Assert.assertEquals(datalinkMessage.getTags().size(), 3);
 
             SensorLatitude lat = (SensorLatitude) datalinkMessage.getField(UasDatalinkTag.SensorLatitude);
             SensorLongitude lon = (SensorLongitude) datalinkMessage.getField(UasDatalinkTag.SensorLongitude);
@@ -43,8 +75,11 @@ public class KlvParserTest
             Assert.assertNotNull(alt);
 
             Assert.assertEquals(lat.getDegrees(), 42.4036, SensorLatitude.DELTA);
+            Assert.assertEquals(lat.getBytes(), SENSOR_LAT_VALUE);
             Assert.assertEquals(lon.getDegrees(), -71.1284, SensorLongitude.DELTA);
+            Assert.assertEquals(lon.getBytes(), SENSOR_LON_VALUE);
             Assert.assertEquals(alt.getMeters(), 1258.3, SensorTrueAltitude.DELTA);
+            Assert.assertEquals(alt.getBytes(), SENSOR_ALT_VALUE);
 
         } catch (KlvParseException e)
         {
@@ -92,5 +127,115 @@ public class KlvParserTest
         UasDatalinkMessage message = new UasDatalinkMessage(values);
         byte[] bytes = message.frameMessage(false);
         System.out.println(ArrayUtils.toHexString(bytes, 8, true));
+    }
+
+    @Test
+    public void testChecksumOnlyParse() {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(21);
+        byteBuffer.put(KlvConstants.UasDatalinkLocalUl.getBytes());
+        byteBuffer.put((byte) 0x04);
+        byteBuffer.put((byte) UasDatalinkTag.Checksum.getCode());
+        byteBuffer.put(CHECKSUM_LEN);
+        byteBuffer.put((byte) 0x4a);
+        byteBuffer.put((byte) 0x53);
+        byte[] bytes = byteBuffer.array();
+        try {
+            List<IMisbMessage> messages = KlvParser.parseBytes(bytes);
+            Assert.assertEquals(messages.size(), 1);
+
+            IMisbMessage message = messages.get(0);
+            Assert.assertTrue(message instanceof UasDatalinkMessage);
+
+            UasDatalinkMessage datalinkMessage = (UasDatalinkMessage) message;
+            Collection<UasDatalinkTag> tags = datalinkMessage.getTags();
+            Assert.assertEquals(tags.size(), 0);
+        } catch (KlvParseException e) {
+            Assert.fail("Parse exception");
+        }
+    }
+
+    @Test
+    public void testUnknownTagParse() {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(26);
+        byteBuffer.put(KlvConstants.UasDatalinkLocalUl.getBytes());
+        byteBuffer.put((byte) 0x09);
+        byteBuffer.put(UNKNOWN_TAG_KEY);
+        byteBuffer.put(UNKNOWN_TAG_LEN);
+        byteBuffer.put(UNKNOWN_TAG_VALUE);
+        byteBuffer.put((byte) UasDatalinkTag.Checksum.getCode());
+        byteBuffer.put(CHECKSUM_LEN);
+        byteBuffer.put((byte) 0x5a);
+        byteBuffer.put((byte) 0xef);
+        byte[] bytes = byteBuffer.array();
+        Logger.getRootLogger().addAppender(appender);
+        try {
+            List<IMisbMessage> messages = KlvParser.parseBytes(bytes);
+            Assert.assertEquals(messages.size(), 1);
+
+            IMisbMessage message = messages.get(0);
+            Assert.assertTrue(message instanceof UasDatalinkMessage);
+
+            UasDatalinkMessage datalinkMessage = (UasDatalinkMessage) message;
+            Collection<UasDatalinkTag> tags = datalinkMessage.getTags();
+            Assert.assertEquals(tags.size(), 0);
+
+            Mockito.verify(appender).doAppend(logCaptor.capture());
+            Assert.assertEquals("Unknown UAS Datalink tag: 2048", logCaptor.getValue().getRenderedMessage());
+
+        } catch (KlvParseException e) {
+            Assert.fail("Parse exception");
+        }
+    }
+
+    @Test
+    public void testMixedKnownAndUnknownTagParse() {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(42);
+        byteBuffer.put(KlvConstants.UasDatalinkLocalUl.getBytes());
+        byteBuffer.put((byte) 0x19);
+        byteBuffer.put((byte) UasDatalinkTag.SensorLatitude.getCode());
+        byteBuffer.put(SENSOR_LAT_LEN);
+        byteBuffer.put(SENSOR_LAT_VALUE);
+        byteBuffer.put(UNKNOWN_TAG_KEY);
+        byteBuffer.put(UNKNOWN_TAG_LEN);
+        byteBuffer.put(UNKNOWN_TAG_VALUE);
+        byteBuffer.put((byte) UasDatalinkTag.SensorLongitude.getCode());
+        byteBuffer.put(SENSOR_LON_LEN);
+        byteBuffer.put(SENSOR_LON_VALUE);
+        byteBuffer.put((byte) UasDatalinkTag.SensorTrueAltitude.getCode());
+        byteBuffer.put(SENSOR_ALT_LEN);
+        byteBuffer.put(SENSOR_ALT_VALUE);
+        byteBuffer.put((byte) UasDatalinkTag.Checksum.getCode());
+        byteBuffer.put(CHECKSUM_LEN);
+        byteBuffer.put((byte) 0x36);
+        byteBuffer.put((byte) 0x68);
+        byte[] bytes = byteBuffer.array();
+        try {
+            List<IMisbMessage> messages = KlvParser.parseBytes(bytes);
+            Assert.assertEquals(messages.size(), 1);
+
+            IMisbMessage message = messages.get(0);
+            Assert.assertTrue(message instanceof UasDatalinkMessage);
+
+            UasDatalinkMessage datalinkMessage = (UasDatalinkMessage) message;
+            Collection<UasDatalinkTag> tags = datalinkMessage.getTags();
+            Assert.assertEquals(tags.size(), 3);
+
+            SensorLatitude lat = (SensorLatitude) datalinkMessage.getField(UasDatalinkTag.SensorLatitude);
+            SensorLongitude lon = (SensorLongitude) datalinkMessage.getField(UasDatalinkTag.SensorLongitude);
+            SensorTrueAltitude alt = (SensorTrueAltitude) datalinkMessage.getField(UasDatalinkTag.SensorTrueAltitude);
+
+            Assert.assertNotNull(lat);
+            Assert.assertNotNull(lon);
+            Assert.assertNotNull(alt);
+
+            Assert.assertEquals(lat.getDegrees(), 42.4036, SensorLatitude.DELTA);
+            Assert.assertEquals(lat.getBytes(), SENSOR_LAT_VALUE);
+            Assert.assertEquals(lon.getDegrees(), -71.1284, SensorLongitude.DELTA);
+            Assert.assertEquals(lon.getBytes(), SENSOR_LON_VALUE);
+            Assert.assertEquals(alt.getMeters(), 1258.3, SensorTrueAltitude.DELTA);
+            Assert.assertEquals(alt.getBytes(), SENSOR_ALT_VALUE);
+        } catch (KlvParseException e) {
+            Assert.fail("Parse exception");
+        }
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0102/localset/UnknownTagTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/localset/UnknownTagTest.java
@@ -1,0 +1,50 @@
+package org.jmisb.api.klv.st0102.localset;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.jmisb.api.common.KlvParseException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+
+public class UnknownTagTest {
+
+    @Mock
+    AppenderSkeleton appender;
+    @Captor
+    ArgumentCaptor<LoggingEvent> logCaptor;
+
+    @BeforeMethod
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+        Logger.getRootLogger().addAppender(appender);
+    }
+
+    @Test
+    public void testUnknownSecurityTag() throws KlvParseException {
+        byte[] bytes = new byte[]{88, 1, 1};
+        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false);
+        Assert.assertEquals(securityMetadataLocalSet.displayHeader(), "ST 0102 (local)");
+        Assert.assertEquals(0, securityMetadataLocalSet.getKeys().size());
+        Mockito.verify(appender).doAppend(logCaptor.capture());
+        Assert.assertEquals("Unknown Security Metadata tag: 88", logCaptor.getValue().getRenderedMessage());
+    }
+
+    @Test
+    public void testMixedKnownAndUnknownSecurityTags() throws KlvParseException {
+        byte[] bytes = new byte[]{1, 1, 1, 2, 1, 1, 88, 1, 1, 3, 4, 47, 47, 67, 65, 4, 0, 5, 0, 6, 2, 67, 65, 22, 2, 0, 5};
+        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false);
+        Assert.assertEquals(securityMetadataLocalSet.displayHeader(), "ST 0102 (local)");
+        Assert.assertEquals(7, securityMetadataLocalSet.getKeys().size());
+        Mockito.verify(appender).doAppend(logCaptor.capture());
+        Assert.assertEquals("Unknown Security Metadata tag: 88", logCaptor.getValue().getRenderedMessage());
+
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Resolves #17

## Description
The change is basically to replace the `throw` with logging, and tests that verify it works.

I did consider the suggestion in #17 to add as an `OpaqueValue` but that will require much larger changes, because it stretches the API contract about tags being known values. The MISB standards say to drop, so that seems reasonable.

## How Has This Been Tested?
Unit testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

(This is arguably a breaking change in that jmisb works differently in the presence of unknown tags, but since it only ignores single fields, I think that is reasonable to consider this a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

