### PR TITLE
Minor test tweaks for ST1201 (IMAPB)

### DIFF
--- a/api/src/test/java/org/jmisb/api/klv/st1201/FpEncoderTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1201/FpEncoderTest.java
@@ -1,6 +1,5 @@
-package org.jmisb.api.klv;
+package org.jmisb.api.klv.st1201;
 
-import org.jmisb.api.klv.st1201.FpEncoder;
 import org.testng.Assert;
 import org.testng.annotations.*;
 

--- a/api/src/test/java/org/jmisb/api/klv/st1201/ST1201AnnexATest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1201/ST1201AnnexATest.java
@@ -1,0 +1,29 @@
+package org.jmisb.api.klv.st1201;
+
+import org.testng.Assert;
+import org.testng.annotations.*;
+
+public class ST1201AnnexATest
+{
+    @Test
+    public void testSmallRange()
+    {
+        // IMAPB(0.1, 0.9, 2)
+        FpEncoder fpEncoder = new FpEncoder(0.1, 0.9, 2);
+        byte[] encoded = fpEncoder.encode(0.1);
+        Assert.assertEquals(encoded.length, 2);
+        Assert.assertEquals(encoded, new byte[]{(byte)0x00, (byte)0x00});
+
+        encoded = fpEncoder.encode(0.5);
+        Assert.assertEquals(encoded.length, 2);
+        Assert.assertEquals(encoded, new byte[]{(byte)0x33, (byte)0x33});
+
+        encoded = fpEncoder.encode(0.9);
+        Assert.assertEquals(encoded.length, 2);
+        Assert.assertEquals(encoded, new byte[]{(byte)0x66, (byte)0x66});
+
+        encoded = fpEncoder.encode(Double.NEGATIVE_INFINITY);
+        Assert.assertEquals(encoded.length, 2);
+        Assert.assertEquals(encoded, new byte[]{(byte)0xe8, (byte)0x00});
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Minot test improvements for ST1201 (FpEncoder). No functional changes.

## Description
This moves the test to match the implementing class, and adds one more test from Annex A to ST1201.

## How Has This Been Tested?
Added new unit test, ran existing tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

