### PR TITLE
Add getDisplayName() to IUasDatalinkValue.

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/AirfieldBarometricPressure.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AirfieldBarometricPressure.java
@@ -23,4 +23,10 @@ public class AirfieldBarometricPressure extends UasPressureMillibars
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Airfield Barometric Pressure";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformAltitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformAltitude.java
@@ -23,4 +23,10 @@ public class AlternatePlatformAltitude extends UasDatalinkAltitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Alternate Platform Altitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformLatitude.java
@@ -23,4 +23,10 @@ public class AlternatePlatformLatitude extends UasDatalinkLatitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Alternate Platform Latitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformLongitude.java
@@ -23,4 +23,10 @@ public class AlternatePlatformLongitude extends UasDatalinkLongitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+       return "Alternate Platform Longitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/CornerOffset.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/CornerOffset.java
@@ -88,4 +88,10 @@ public class CornerOffset implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Corner Offset";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/DensityAltitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/DensityAltitude.java
@@ -24,4 +24,10 @@ public class DensityAltitude extends UasDatalinkAltitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Density Altitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/DifferentialPressure.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/DifferentialPressure.java
@@ -24,4 +24,10 @@ public class DifferentialPressure extends UasPressureMillibars
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Differential Pressure";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterElevation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterElevation.java
@@ -30,4 +30,10 @@ public class FrameCenterElevation extends UasDatalinkAltitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Frame Center Elevation";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterHae.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterHae.java
@@ -31,4 +31,10 @@ public class FrameCenterHae extends UasDatalinkAltitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Frame Center Height Above Ellipsoid";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterLatitude.java
@@ -24,4 +24,10 @@ public class FrameCenterLatitude extends UasDatalinkLatitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Frame Center Latitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterLongitude.java
@@ -24,4 +24,10 @@ public class FrameCenterLongitude extends UasDatalinkLongitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Frame Center Longitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FullCornerLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FullCornerLatitude.java
@@ -24,4 +24,10 @@ public class FullCornerLatitude extends UasDatalinkLatitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Corner Latitude Point";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FullCornerLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FullCornerLongitude.java
@@ -24,4 +24,10 @@ public class FullCornerLongitude extends UasDatalinkLongitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Corner Longitude Point";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/HorizontalFov.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/HorizontalFov.java
@@ -72,4 +72,10 @@ public class HorizontalFov implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor Horizontal Field of View";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/IUasDatalinkValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/IUasDatalinkValue.java
@@ -16,4 +16,10 @@ public interface IUasDatalinkValue
      * @return String representing the value
      */
     String getDisplayableValue();
+
+    /**
+     * Get the human-readable name for the value
+     * @return The name of the type
+     */
+    String getDisplayName();
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/NestedSecurityMetadata.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/NestedSecurityMetadata.java
@@ -8,10 +8,10 @@ import org.jmisb.api.klv.st0102.localset.SecurityMetadataLocalSet;
  * <p>
  * From ST:
  * <blockquote>
- * Local set tag to include the ST 0102 Local Set Security Metadata items within ST 0601. Use the ST 0102 Local Set Tags
- * within the ST 0601 tag 0d48.
+ * Local set tag to include the ST 0102 Local Set Security Metadata items within ST 0601.
+ * Use the MISB ST 0102 Local Set tags within the MISB ST 0601 item 48.
  * <p>
- * The length field is the size of all ST 0102 metadata items to be packaged within tag 0d48.
+ * The length field is the size of all MISB ST 0102 metadata items to be packaged within item 48.
  * </blockquote>
  */
 public class NestedSecurityMetadata implements IUasDatalinkValue
@@ -57,5 +57,11 @@ public class NestedSecurityMetadata implements IUasDatalinkValue
     public String getDisplayableValue()
     {
         return "[Security metadata]";
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Security";
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/OnBoardMiStorageCapacity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/OnBoardMiStorageCapacity.java
@@ -90,4 +90,10 @@ public class OnBoardMiStorageCapacity implements IUasDatalinkValue
     {
         return gigabytes + "GB";
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "On-Board MI Storage Capacity";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/OpaqueValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/OpaqueValue.java
@@ -28,4 +28,10 @@ public class OpaqueValue implements IUasDatalinkValue
         return "N/A";
     }
 
+    @Override
+    public String getDisplayName()
+    {
+        return "Opaque Value";
+    }
+
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttack.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttack.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Platform Angle of Angle (ST 0601 tag 50)
+ * Platform Angle of Attack (ST 0601 tag 50)
  * <p>
  * From ST:
  * <blockquote>
@@ -33,6 +33,12 @@ public class PlatformAngleOfAttack extends UasDatalinkAngle {
      */
     public PlatformAngleOfAttack(byte[] bytes) {
         super(bytes);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform Angle of Attack";
     }
 
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttackFull.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttackFull.java
@@ -85,4 +85,10 @@ public class PlatformAngleOfAttackFull implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform Angle of Attack (Full)";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformGroundSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformGroundSpeed.java
@@ -33,4 +33,10 @@ public class PlatformGroundSpeed extends UasDatalinkSpeed implements IUasDatalin
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform Ground Speed";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformHeadingAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformHeadingAngle.java
@@ -2,8 +2,6 @@ package org.jmisb.api.klv.st0601;
 
 import org.jmisb.core.klv.PrimitiveConverter;
 
-import java.text.DecimalFormat;
-
 /**
  * Platform Heading Angle (ST 0601 tag 5)
  * <p>
@@ -71,5 +69,10 @@ public class PlatformHeadingAngle implements IUasDatalinkValue
     public String getDisplayableValue()
     {
         return String.format("%.4f\u00B0", degrees);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Platform Heading Angle";
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformIndicatedAirspeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformIndicatedAirspeed.java
@@ -33,4 +33,10 @@ public class PlatformIndicatedAirspeed extends UasDatalinkSpeed implements IUasD
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform Indicated Airspeed";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformPitchAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformPitchAngle.java
@@ -35,4 +35,10 @@ public class PlatformPitchAngle extends UasDatalinkAngle {
         super(bytes);
     }
 
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform Pitch Angle";
+    }
+
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformPitchAngleFull.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformPitchAngleFull.java
@@ -85,4 +85,10 @@ public class PlatformPitchAngleFull implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform Pitch Angle (Full)";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformRollAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformRollAngle.java
@@ -86,4 +86,10 @@ public class PlatformRollAngle implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform Roll Angle";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformRollAngleFull.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformRollAngleFull.java
@@ -85,4 +85,10 @@ public class PlatformRollAngleFull implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform Roll Angle (Full)";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformSideslipAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformSideslipAngle.java
@@ -36,4 +36,10 @@ public class PlatformSideslipAngle extends UasDatalinkAngle
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform Sideslip Angle";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformSideslipAngleFull.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformSideslipAngleFull.java
@@ -85,4 +85,10 @@ public class PlatformSideslipAngleFull implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform Sideslip Angle (Full)";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformTrueAirspeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformTrueAirspeed.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Platform True Speed (ST 0601 tag 8)
+ * Platform True Airspeed (ST 0601 tag 8)
  * <p>
  * From ST:
  * <blockquote>
@@ -32,5 +32,11 @@ public class PlatformTrueAirspeed extends UasDatalinkSpeed implements IUasDatali
     public PlatformTrueAirspeed(byte[] bytes)
     {
         super(bytes);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Platform True Airspeed";
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PrecisionTimeStamp.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PrecisionTimeStamp.java
@@ -96,4 +96,10 @@ public class PrecisionTimeStamp implements IUasDatalinkValue
     {
         return "" + microseconds;
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Precision Time Stamp";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ST0601Version.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ST0601Version.java
@@ -55,4 +55,10 @@ public class ST0601Version implements IUasDatalinkValue
     {
         return "" + (int)version;
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Version Number";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorEastVelocity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorEastVelocity.java
@@ -25,4 +25,10 @@ public class SensorEastVelocity extends UasDatalinkSensorVelocity
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor East Velocity";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorLatitude.java
@@ -24,4 +24,10 @@ public class SensorLatitude extends UasDatalinkLatitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor Latitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorLongitude.java
@@ -28,4 +28,10 @@ public class SensorLongitude extends UasDatalinkLongitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor Longitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorNorthVelocity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorNorthVelocity.java
@@ -25,4 +25,10 @@ public class SensorNorthVelocity extends UasDatalinkSensorVelocity
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor North Velocity";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeAzimuth.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeAzimuth.java
@@ -69,4 +69,10 @@ public class SensorRelativeAzimuth implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor Relative Azimuth";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeElevation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeElevation.java
@@ -87,4 +87,10 @@ public class SensorRelativeElevation implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor Relative Elevation";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeRoll.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeRoll.java
@@ -70,4 +70,10 @@ public class SensorRelativeRoll implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor Relative Roll";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorTrueAltitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorTrueAltitude.java
@@ -23,4 +23,10 @@ public class SensorTrueAltitude extends UasDatalinkAltitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor True Altitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SlantRange.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SlantRange.java
@@ -71,4 +71,10 @@ public class SlantRange implements IUasDatalinkValue
     {
         return String.format("%.2fm", meters);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Slant Range";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/StaticPressure.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/StaticPressure.java
@@ -27,4 +27,10 @@ public class StaticPressure extends UasPressureMillibars
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Static Pressure";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationElevation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationElevation.java
@@ -23,4 +23,10 @@ public class TargetLocationElevation extends UasDatalinkAltitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Target Location Elevation";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationLatitude.java
@@ -25,4 +25,10 @@ public class TargetLocationLatitude extends UasDatalinkLatitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Target Location Latitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationLongitude.java
@@ -25,4 +25,10 @@ public class TargetLocationLongitude extends UasDatalinkLongitude
     {
         super(bytes);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Target Location Longitude";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetWidth.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetWidth.java
@@ -72,4 +72,10 @@ public class TargetWidth implements IUasDatalinkValue
     {
         return String.format("%.2fm", meters);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Target Width";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitude.java
@@ -29,7 +29,7 @@ public abstract class UasDatalinkAltitude implements IUasDatalinkValue
     {
         if (meters > MAX_VALUE || meters < MIN_VALUE)
         {
-            throw new IllegalArgumentException("Altitude must be in range [-900,19000]");
+            throw new IllegalArgumentException(getDisplayName() + " must be in range [-900,19000]");
         }
         this.meters = meters;
     }
@@ -42,7 +42,7 @@ public abstract class UasDatalinkAltitude implements IUasDatalinkValue
     {
         if (bytes.length != 2)
         {
-            throw new IllegalArgumentException("Altitude encoding is a 2-byte unsigned int");
+            throw new IllegalArgumentException(getDisplayName() + " encoding is a 2-byte unsigned int");
         }
 
         int intVal = PrimitiveConverter.toUint16(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAngle.java
@@ -32,7 +32,7 @@ public abstract class UasDatalinkAngle implements IUasDatalinkValue
     {
         if (degrees != Double.POSITIVE_INFINITY && (degrees < -20 || degrees > 20))
         {
-            throw new IllegalArgumentException("Angle must be in range [-20,20]");
+            throw new IllegalArgumentException(getDisplayName() + " must be in range [-20,20]");
         }
 
         this.degrees = degrees;
@@ -47,7 +47,7 @@ public abstract class UasDatalinkAngle implements IUasDatalinkValue
     {
         if (bytes.length != 2)
         {
-            throw new IllegalArgumentException("Angle encoding is a 2-byte signed int");
+            throw new IllegalArgumentException(getDisplayName() + " encoding is a 2-byte signed int");
         }
 
         if (Arrays.equals(bytes, invalidBytes))

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -30,8 +30,9 @@ public class UasDatalinkFactory
             case PrecisionTimeStamp:
                 return new PrecisionTimeStamp(bytes);
             case MissionId:
+                return new UasDatalinkString(UasDatalinkString.MISSION_ID, bytes);
             case PlatformTailNumber:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.PLATFORM_TAIL_NUMBER, bytes);
             case PlatformHeadingAngle:
                 return new PlatformHeadingAngle(bytes);
             case PlatformPitchAngle:
@@ -43,11 +44,11 @@ public class UasDatalinkFactory
             case PlatformIndicatedAirspeed:
                 return new PlatformIndicatedAirspeed(bytes);
             case PlatformDesignation:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.PLATFORM_DESIGNATION, bytes);
             case ImageSourceSensor:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.IMAGE_SOURCE_SENSOR, bytes);
             case ImageCoordinateSystem:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.IMAGE_COORDINATE_SYSTEM, bytes);
             case SensorLatitude:
                 return new SensorLatitude(bytes);
             case SensorLongitude:
@@ -152,7 +153,7 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case PlatformCallSign:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.PLATFORM_CALL_SIGN, bytes);
             case WeaponLoad:
                 // TODO
                 return new OpaqueValue(bytes);
@@ -180,7 +181,7 @@ public class UasDatalinkFactory
             case AlternatePlatformAltitude:
                 return new AlternatePlatformAltitude(bytes);
             case AlternatePlatformName:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.ALTERNATE_PLATFORM_NAME, bytes);
             case AlternatePlatformHeading:
                 // TODO
                 return new OpaqueValue(bytes);
@@ -268,11 +269,11 @@ public class UasDatalinkFactory
             case AlternatePlatformEllipsoidHeightExtended:
                 return new OpaqueValue(bytes);
             case StreamDesignator:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.STREAM_DESIGNATOR, bytes);
             case OperationalBase:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.OPERATIONAL_BASE, bytes);
             case BroadcastSource:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.BROADCAST_SOURCE, bytes);
             case RangeToRecoveryLocation:
                 // TODO
                 return new OpaqueValue(bytes);
@@ -333,7 +334,7 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case TargetId:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.TARGET_ID, bytes);
             case AirbaseLocations:
                 // TODO
                 return new OpaqueValue(bytes);
@@ -349,7 +350,7 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case CommunicationsMethod:
-                return new UasDatalinkString(bytes);
+                return new UasDatalinkString(UasDatalinkString.COMMUNICATIONS_METHOD, bytes);
             case LeapSeconds:
                 // TODO
                 return new OpaqueValue(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLatitude.java
@@ -32,7 +32,7 @@ public abstract class UasDatalinkLatitude implements IUasDatalinkValue
     {
         if (degrees != Double.POSITIVE_INFINITY && (degrees < -90 || degrees > 90))
         {
-            throw new IllegalArgumentException("Latitude must be in range [-90,90]");
+            throw new IllegalArgumentException(getDisplayName() + " must be in range [-90,90]");
         }
         this.degrees = degrees;
     }
@@ -45,7 +45,7 @@ public abstract class UasDatalinkLatitude implements IUasDatalinkValue
     {
         if (bytes.length != 4)
         {
-            throw new IllegalArgumentException("Latitude encoding is a 4-byte int");
+            throw new IllegalArgumentException(getDisplayName() + " encoding is a 4-byte int");
         }
 
         if (Arrays.equals(bytes, invalidBytes))

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLongitude.java
@@ -33,7 +33,7 @@ public abstract class UasDatalinkLongitude implements IUasDatalinkValue
     {
         if (degrees != Double.POSITIVE_INFINITY && (degrees < -180 || degrees > 180))
         {
-            throw new IllegalArgumentException("Longitude must be in range [-180,180]");
+            throw new IllegalArgumentException(getDisplayName() + " must be in range [-180,180]");
         }
         this.degrees = degrees;
     }
@@ -47,7 +47,7 @@ public abstract class UasDatalinkLongitude implements IUasDatalinkValue
     {
         if (bytes.length != 4)
         {
-            throw new IllegalArgumentException("Longitude encoding is a 4-byte int");
+            throw new IllegalArgumentException(getDisplayName() + " encoding is a 4-byte int");
         }
 
         if (Arrays.equals(bytes, invalidBytes))

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkSensorVelocity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkSensorVelocity.java
@@ -31,7 +31,7 @@ abstract public class UasDatalinkSensorVelocity implements IUasDatalinkValue
     {
         if (velocity != Double.POSITIVE_INFINITY && (velocity < -327.0 || velocity > 327.0))
         {
-            throw new IllegalArgumentException("Sensor velocity must be in range [-327,327]");
+            throw new IllegalArgumentException(getDisplayName() + " must be in range [-327,327]");
         }
 
         this.velocity = velocity;
@@ -45,7 +45,7 @@ abstract public class UasDatalinkSensorVelocity implements IUasDatalinkValue
     {
         if (bytes.length != 2)
         {
-            throw new IllegalArgumentException("Sensor velocity encoding is a 2-byte signed int");
+            throw new IllegalArgumentException(getDisplayName() + " encoding is a 2-byte signed int");
         }
 
         if (Arrays.equals(bytes, invalidBytes))

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkSpeed.java
@@ -9,7 +9,7 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * <p>
  * Resolution: 1 metre/second.
  */
-public class UasDatalinkSpeed implements IUasDatalinkValue
+abstract public class UasDatalinkSpeed implements IUasDatalinkValue
 {
     private int speed;
     private static double MIN_VALUE = 0;
@@ -24,7 +24,7 @@ public class UasDatalinkSpeed implements IUasDatalinkValue
     {
         if (speed > MAX_VALUE || speed < MIN_VALUE)
         {
-            throw new IllegalArgumentException("Speed must be in range [0, 255]");
+            throw new IllegalArgumentException(getDisplayName() + " must be in range [0, 255]");
         }
         this.speed = speed;
     }
@@ -38,7 +38,7 @@ public class UasDatalinkSpeed implements IUasDatalinkValue
     {
         if (bytes.length != 1)
         {
-            throw new IllegalArgumentException("Speed encoding is a 1-byte unsigned int");
+            throw new IllegalArgumentException(getDisplayName() + " encoding is a 1-byte unsigned int");
         }
 
         int intVal = PrimitiveConverter.toUint8(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkString.java
@@ -7,23 +7,41 @@ import java.nio.charset.StandardCharsets;
  */
 public class UasDatalinkString implements IUasDatalinkValue
 {
+    public final static String ALTERNATE_PLATFORM_NAME = "Alternate Platform Name";
+    public final static String BROADCAST_SOURCE = "Broadcast Source";
+    public final static String COMMUNICATIONS_METHOD = "Communications Method";
+    public final static String IMAGE_COORDINATE_SYSTEM = "Image Coordinate System";
+    public final static String IMAGE_SOURCE_SENSOR = "Image Source Sensor";
+    public final static String MISSION_ID = "Mission ID";
+    public final static String OPERATIONAL_BASE = "Operational Base";
+    public final static String PLATFORM_CALL_SIGN = "Platform Call Sign";
+    public final static String PLATFORM_DESIGNATION = "Platform Designation";
+    public final static String PLATFORM_TAIL_NUMBER = "Platform Tail Number";
+    public final static String STREAM_DESIGNATOR = "Stream Designator";
+    public final static String TARGET_ID = "Target ID";
+
+    private final String displayName;
     private String stringValue;
 
     /**
      * Create from value
+     * @param name The display name for the datalink string
      * @param value The string value
      */
-    public UasDatalinkString(String value)
+    public UasDatalinkString(String name, String value)
     {
+        this.displayName = name;
         this.stringValue = value;
     }
 
     /**
      * Create from encoded bytes
+     * @param name The display name for the datalink string
      * @param bytes Encoded byte array
      */
-    public UasDatalinkString(byte[] bytes)
+    public UasDatalinkString(String name, byte[] bytes)
     {
+        this.displayName = name;
         this.stringValue = new String(bytes);
     }
 
@@ -46,5 +64,10 @@ public class UasDatalinkString implements IUasDatalinkValue
     public String getDisplayableValue()
     {
         return stringValue;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasEnumeration.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasEnumeration.java
@@ -17,12 +17,6 @@ public abstract class UasEnumeration implements IUasDatalinkValue
     abstract Map<Integer, String> getDisplayValues();
 
     /**
-     * Get the human-readable name for the enumeration
-     * @return The name of the enumerated type
-     */
-    abstract String getDisplayName();
-
-    /**
      * Create from value
      *
      * @param enumeratedValue The value of the enumeration

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasPressureMillibars.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasPressureMillibars.java
@@ -26,7 +26,7 @@ abstract public class UasPressureMillibars implements IUasDatalinkValue
     {
         if (pressureMillibars < 0 || pressureMillibars > RANGE)
         {
-            throw new IllegalArgumentException("Pressure must be in range [0,5000]");
+            throw new IllegalArgumentException(getDisplayName() + " must be in range [0,5000]");
         }
         pressure = pressureMillibars;
     }
@@ -39,7 +39,7 @@ abstract public class UasPressureMillibars implements IUasDatalinkValue
     {
         if (bytes.length != 2)
         {
-            throw new IllegalArgumentException("Pressure encoding is a 2-byte unsigned int");
+            throw new IllegalArgumentException(getDisplayName() + " encoding is a 2-byte unsigned int");
         }
 
         int intVal = PrimitiveConverter.toUint16(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/VerticalFov.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/VerticalFov.java
@@ -72,4 +72,10 @@ public class VerticalFov implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor Vertical Field of View";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WindDirectionAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WindDirectionAngle.java
@@ -69,4 +69,10 @@ public class WindDirectionAngle implements IUasDatalinkValue
     {
         return String.format("%.4f\u00B0", degrees);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Wind Direction";
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WindSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WindSpeed.java
@@ -74,4 +74,10 @@ public class WindSpeed implements IUasDatalinkValue
     {
         return String.format("%.1fm/s", windspeed);
     }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Wind Speed";
+    }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/AirfieldBarometricPressureTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/AirfieldBarometricPressureTest.java
@@ -13,11 +13,13 @@ public class AirfieldBarometricPressureTest
         byte[] bytes = pressure.getBytes();
         Assert.assertEquals(bytes, new byte[]{0x00, 0x00});
         Assert.assertEquals(pressure.getMillibars(), 0.0);
+        Assert.assertEquals(pressure.getDisplayName(), "Airfield Barometric Pressure");
 
         pressure = new AirfieldBarometricPressure(5000.0);
         bytes = pressure.getBytes();
         Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff});
         Assert.assertEquals(pressure.getMillibars(), 5000.0);
+        Assert.assertEquals(pressure.getDisplayName(), "Airfield Barometric Pressure");
 
         // Example from standard
         pressure = new AirfieldBarometricPressure(2088.96010);
@@ -25,6 +27,7 @@ public class AirfieldBarometricPressureTest
         Assert.assertEquals(bytes, new byte[]{(byte)0x6A, (byte)0xF4});
         Assert.assertEquals(pressure.getMillibars(), 2088.96010);
         Assert.assertEquals("2088.96mB", pressure.getDisplayableValue());
+        Assert.assertEquals(pressure.getDisplayName(), "Airfield Barometric Pressure");
     }
 
     @Test
@@ -34,20 +37,24 @@ public class AirfieldBarometricPressureTest
         AirfieldBarometricPressure pressure = new AirfieldBarometricPressure(bytes);
         Assert.assertEquals(pressure.getMillibars(), 0.0);
         Assert.assertEquals(pressure.getBytes(), bytes);
+        Assert.assertEquals(pressure.getDisplayName(), "Airfield Barometric Pressure");
 
         bytes = new byte[]{(byte)0xff, (byte)0xff};
         pressure = new AirfieldBarometricPressure(bytes);
         Assert.assertEquals(pressure.getMillibars(), 5000.0);
         Assert.assertEquals(pressure.getBytes(), bytes);
+        Assert.assertEquals(pressure.getDisplayName(), "Airfield Barometric Pressure");
 
         // Some random byte arrays
         bytes = new byte[]{(byte)0xa8, (byte)0x73};
         pressure = new AirfieldBarometricPressure(bytes);
         Assert.assertEquals(pressure.getBytes(), bytes);
+        Assert.assertEquals(pressure.getDisplayName(), "Airfield Barometric Pressure");
 
         bytes = new byte[]{(byte)0x34, (byte)0x9d};
         pressure = new AirfieldBarometricPressure(bytes);
         Assert.assertEquals(pressure.getBytes(), bytes);
+        Assert.assertEquals(pressure.getDisplayName(), "Airfield Barometric Pressure");
     }
 
     @Test
@@ -59,6 +66,7 @@ public class AirfieldBarometricPressureTest
         AirfieldBarometricPressure pressure = (AirfieldBarometricPressure)v;
         Assert.assertEquals(pressure.getMillibars(), 0.0);
         Assert.assertEquals(pressure.getBytes(), bytes);
+        Assert.assertEquals(pressure.getDisplayName(), "Airfield Barometric Pressure");
 
         bytes = new byte[]{(byte)0xff, (byte)0xff};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.AirfieldBarometricPressure, bytes);
@@ -66,6 +74,7 @@ public class AirfieldBarometricPressureTest
         pressure = (AirfieldBarometricPressure)v;
         Assert.assertEquals(pressure.getMillibars(), 5000.0);
         Assert.assertEquals(pressure.getBytes(), bytes);
+        Assert.assertEquals(pressure.getDisplayName(), "Airfield Barometric Pressure");
 
         bytes = new byte[]{(byte)0x6A, (byte)0xF4};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.AirfieldBarometricPressure, bytes);
@@ -73,6 +82,7 @@ public class AirfieldBarometricPressureTest
         pressure = (AirfieldBarometricPressure)v;
         Assert.assertEquals(pressure.getMillibars(), 2088.96010, 0.00001);
         Assert.assertEquals("2088.96mB", pressure.getDisplayableValue());
+        Assert.assertEquals(pressure.getDisplayName(), "Airfield Barometric Pressure");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/api/src/test/java/org/jmisb/api/klv/st0601/CornerOffsetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/CornerOffsetTest.java
@@ -14,18 +14,21 @@ public class CornerOffsetTest
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x80, (byte)0x01});
         Assert.assertEquals(offset.getDegrees(), -0.075);
         Assert.assertEquals(offset.getDisplayableValue(), "-0.0750\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // Max
         offset = new CornerOffset(0.075);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x7f, (byte)0xff});
         Assert.assertEquals(offset.getDegrees(), 0.075);
         Assert.assertEquals(offset.getDisplayableValue(), "0.0750\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // Zero
         offset = new CornerOffset(0);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x00, (byte)0x00});
         Assert.assertEquals(offset.getDegrees(), 0.0);
         Assert.assertEquals(offset.getDisplayableValue(), "0.0000\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // ST example from tag 26
         // frame center lat = -10.5423886331461 (from tag 23)
@@ -35,12 +38,14 @@ public class CornerOffsetTest
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0xc0, (byte)0x6e});
         Assert.assertEquals(offset.getDegrees(), -0.037249367);
         Assert.assertEquals(offset.getDisplayableValue(), "-0.0372\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // Error condition
         offset = new CornerOffset(Double.POSITIVE_INFINITY);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x80, (byte)0x00});
         Assert.assertEquals(offset.getDegrees(), Double.POSITIVE_INFINITY);
         Assert.assertEquals(offset.getDisplayableValue(), "Infinity\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
     }
 
     @Test
@@ -51,18 +56,21 @@ public class CornerOffsetTest
         Assert.assertEquals(offset.getDegrees(), -0.075);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x80, (byte)0x01});
         Assert.assertEquals(offset.getDisplayableValue(), "-0.0750\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // Max
         offset = new CornerOffset(new byte[]{(byte)0x7f, (byte)0xff});
         Assert.assertEquals(offset.getDegrees(), 0.075);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x7f, (byte)0xff});
         Assert.assertEquals(offset.getDisplayableValue(), "0.0750\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // Zero
         offset = new CornerOffset(new byte[]{(byte)0x00, (byte)0x00});
         Assert.assertEquals(offset.getDegrees(), 0.0);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x00, (byte)0x00});
         Assert.assertEquals(offset.getDisplayableValue(), "0.0000\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // ST example
         // Resolution is 1.2 micro degrees, so error is +/- 0.6 micro degrees
@@ -71,12 +79,14 @@ public class CornerOffsetTest
         Assert.assertEquals(offset.getDegrees(), -0.037249367, delta);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0xc0, (byte)0x6e});
         Assert.assertEquals(offset.getDisplayableValue(), "-0.0372\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // Error condition
         offset = new CornerOffset(new byte[]{(byte)0x80, (byte)0x00});
         Assert.assertEquals(offset.getDegrees(), Double.POSITIVE_INFINITY);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x80, (byte)0x00});
         Assert.assertEquals(offset.getDisplayableValue(), "Infinity\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
     }
 
     @Test
@@ -89,6 +99,7 @@ public class CornerOffsetTest
         Assert.assertEquals(offset.getDegrees(), -0.075);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x80, (byte)0x01});
         Assert.assertEquals(offset.getDisplayableValue(), "-0.0750\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // Max
         bytes = new byte[]{(byte)0x7f, (byte)0xff};
@@ -98,6 +109,7 @@ public class CornerOffsetTest
         Assert.assertEquals(offset.getDegrees(), 0.075);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x7f, (byte)0xff});
         Assert.assertEquals(offset.getDisplayableValue(), "0.0750\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // Zero
         bytes = new byte[]{(byte)0x00, (byte)0x00};
@@ -107,11 +119,13 @@ public class CornerOffsetTest
         Assert.assertEquals(offset.getDegrees(), 0.0);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0x00, (byte)0x00});
         Assert.assertEquals(offset.getDisplayableValue(), "0.0000\u00B0");
+        Assert.assertEquals(offset.getDisplayName(), "Corner Offset");
 
         // ST example
         bytes = new byte[]{(byte)0xc0, (byte)0x6e};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLongitudePoint2, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
+        Assert.assertEquals(v.getDisplayName(), "Corner Offset");
         offset = (CornerOffset)v;
         Assert.assertEquals(offset.getDegrees(), -0.037249367, 0.000001);
         Assert.assertEquals(offset.getBytes(), new byte[]{(byte)0xc0, (byte)0x6e});
@@ -119,15 +133,19 @@ public class CornerOffsetTest
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLatitudePoint3, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
+        Assert.assertEquals(v.getDisplayName(), "Corner Offset");
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLongitudePoint3, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
+        Assert.assertEquals(v.getDisplayName(), "Corner Offset");
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLatitudePoint4, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
+        Assert.assertEquals(v.getDisplayName(), "Corner Offset");
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLongitudePoint4, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
+        Assert.assertEquals(v.getDisplayName(), "Corner Offset");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/api/src/test/java/org/jmisb/api/klv/st0601/DifferentialPressureTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/DifferentialPressureTest.java
@@ -25,6 +25,7 @@ public class DifferentialPressureTest
         Assert.assertEquals(bytes, new byte[]{(byte)0x3D, (byte)0x07});
         Assert.assertEquals(pressure.getMillibars(), 1191.95850);
         Assert.assertEquals("1191.96mB", pressure.getDisplayableValue());
+        Assert.assertEquals(pressure.getDisplayName(), "Differential Pressure");
     }
 
     @Test
@@ -48,6 +49,7 @@ public class DifferentialPressureTest
         bytes = new byte[]{(byte)0x34, (byte)0x9d};
         pressure = new DifferentialPressure(bytes);
         Assert.assertEquals(pressure.getBytes(), bytes);
+        Assert.assertEquals(pressure.getDisplayName(), "Differential Pressure");
     }
 
     @Test
@@ -55,6 +57,7 @@ public class DifferentialPressureTest
     {
         byte[] bytes = new byte[]{0x00, 0x00};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.DifferentialPressure, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Differential Pressure");
         Assert.assertTrue(v instanceof DifferentialPressure);
         DifferentialPressure pressure = (DifferentialPressure)v;
         Assert.assertEquals(pressure.getMillibars(), 0.0);
@@ -62,6 +65,7 @@ public class DifferentialPressureTest
 
         bytes = new byte[]{(byte)0xff, (byte)0xff};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.DifferentialPressure, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Differential Pressure");
         Assert.assertTrue(v instanceof DifferentialPressure);
         pressure = (DifferentialPressure)v;
         Assert.assertEquals(pressure.getMillibars(), 5000.0);

--- a/api/src/test/java/org/jmisb/api/klv/st0601/HorizontalFovTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/HorizontalFovTest.java
@@ -26,6 +26,8 @@ public class HorizontalFovTest
         Assert.assertEquals(fov.getBytes(), new byte[]{(byte)0xcd, (byte)0x9c});
         Assert.assertEquals(fov.getDegrees(), 144.5713);
         Assert.assertEquals(fov.getDisplayableValue(), "144.5713\u00B0");
+
+        Assert.assertEquals(fov.getDisplayName(), "Sensor Horizontal Field of View");
     }
 
     @Test
@@ -47,6 +49,7 @@ public class HorizontalFovTest
         fov = new HorizontalFov(new byte[]{(byte)0xcd, (byte)0x9c});
         Assert.assertEquals(fov.getDegrees(), 144.5713, delta);
         Assert.assertEquals(fov.getBytes(), new byte[]{(byte)0xcd, (byte)0x9c});
+        Assert.assertEquals(fov.getDisplayName(), "Sensor Horizontal Field of View");
     }
 
     @Test
@@ -54,6 +57,7 @@ public class HorizontalFovTest
     {
         byte[] bytes = new byte[]{0x00, 0x00};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorHorizontalFov, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Sensor Horizontal Field of View");
         Assert.assertTrue(v instanceof HorizontalFov);
         HorizontalFov fov = (HorizontalFov)v;
         Assert.assertEquals(fov.getDegrees(), 0.0);
@@ -61,6 +65,7 @@ public class HorizontalFovTest
 
         bytes = new byte[]{(byte)0xff, (byte)0xff};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorHorizontalFov, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Sensor Horizontal Field of View");
         Assert.assertTrue(v instanceof HorizontalFov);
         fov = (HorizontalFov)v;
         Assert.assertEquals(fov.getDegrees(), 180.0);
@@ -68,6 +73,7 @@ public class HorizontalFovTest
 
         bytes = new byte[]{(byte)0xcd, (byte)0x9c};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorHorizontalFov, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Sensor Horizontal Field of View");
         Assert.assertTrue(v instanceof HorizontalFov);
         fov = (HorizontalFov)v;
         Assert.assertEquals(fov.getDegrees(), 144.5713, 0.0001);

--- a/api/src/test/java/org/jmisb/api/klv/st0601/IcingDetectedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/IcingDetectedTest.java
@@ -12,16 +12,19 @@ public class IcingDetectedTest {
         IcingDetected icingDetected = new IcingDetected((byte) 0);
         Assert.assertEquals(icingDetected.getBytes(), new byte[]{(byte) 0});
         Assert.assertEquals(icingDetected.getDisplayableValue(), "Detector off");
+        Assert.assertEquals(icingDetected.getDisplayName(), "Icing Detected");
 
         // Max
         icingDetected = new IcingDetected((byte) 2);
         Assert.assertEquals(icingDetected.getBytes(), new byte[]{(byte) 2});
         Assert.assertEquals(icingDetected.getDisplayableValue(), "Icing detected");
+        Assert.assertEquals(icingDetected.getDisplayName(), "Icing Detected");
 
         // Other value...
         icingDetected = new IcingDetected((byte) 1);
         Assert.assertEquals(icingDetected.getBytes(), new byte[]{(byte) 1});
         Assert.assertEquals(icingDetected.getDisplayableValue(), "No icing detected");
+        Assert.assertEquals(icingDetected.getDisplayName(), "Icing Detected");
     }
 
     @Test
@@ -31,24 +34,28 @@ public class IcingDetectedTest {
         Assert.assertEquals(icingDetected.getIcingDetected(), (byte) 0);
         Assert.assertEquals(icingDetected.getBytes(), new byte[]{(byte) 0x00});
         Assert.assertEquals(icingDetected.getDisplayableValue(), "Detector off");
+        Assert.assertEquals(icingDetected.getDisplayName(), "Icing Detected");
 
         // Max
         icingDetected = new IcingDetected(new byte[]{(byte) 2});
         Assert.assertEquals(icingDetected.getIcingDetected(), (byte) 2);
         Assert.assertEquals(icingDetected.getBytes(), new byte[]{(byte) 0x02});
         Assert.assertEquals(icingDetected.getDisplayableValue(), "Icing detected");
+        Assert.assertEquals(icingDetected.getDisplayName(), "Icing Detected");
 
         // Other value...
         icingDetected = new IcingDetected(new byte[]{(byte) 1});
         Assert.assertEquals(icingDetected.getIcingDetected(), (byte) 1);
         Assert.assertEquals(icingDetected.getBytes(), new byte[]{(byte) 0x01});
         Assert.assertEquals(icingDetected.getDisplayableValue(), "No icing detected");
+        Assert.assertEquals(icingDetected.getDisplayName(), "Icing Detected");
     }
 
     @Test
     public void testFactory() throws KlvParseException {
         byte[] bytes = new byte[]{(byte) 0x00};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.IcingDetected, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Icing Detected");
         Assert.assertTrue(v instanceof IcingDetected);
         IcingDetected icingDetected = (IcingDetected) v;
         Assert.assertEquals(icingDetected.getIcingDetected(), (byte) 0);
@@ -57,6 +64,7 @@ public class IcingDetectedTest {
 
         bytes = new byte[]{(byte) 0x01};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.IcingDetected, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Icing Detected");
         Assert.assertTrue(v instanceof IcingDetected);
         icingDetected = (IcingDetected) v;
         Assert.assertEquals(icingDetected.getIcingDetected(), (byte) 1);
@@ -66,6 +74,7 @@ public class IcingDetectedTest {
         bytes = new byte[]{(byte) 0x02};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.IcingDetected, bytes);
         Assert.assertTrue(v instanceof IcingDetected);
+        Assert.assertEquals(v.getDisplayName(), "Icing Detected");
         icingDetected = (IcingDetected) v;
         Assert.assertEquals(icingDetected.getIcingDetected(), (byte) 2);
         Assert.assertEquals(icingDetected.getBytes(), new byte[]{(byte) 0x02});

--- a/api/src/test/java/org/jmisb/api/klv/st0601/NestedSecurityMetadataTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/NestedSecurityMetadataTest.java
@@ -1,0 +1,46 @@
+package org.jmisb.api.klv.st0601;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0102.ISecurityMetadataValue;
+import org.jmisb.api.klv.st0102.SecurityMetadataKey;
+import org.jmisb.api.klv.st0102.SecurityMetadataString;
+import org.jmisb.api.klv.st0102.localset.SecurityMetadataLocalSet;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class NestedSecurityMetadataTest
+{
+    @Test
+    public void testConstructFromLocalSet()
+    {
+        NestedSecurityMetadata nestedSecurityMetadata = new NestedSecurityMetadata(makeLocalSet());
+        Assert.assertNotNull(nestedSecurityMetadata);
+        Assert.assertEquals(nestedSecurityMetadata.getDisplayName(), "Security");
+        Assert.assertEquals(nestedSecurityMetadata.getDisplayableValue(), "[Security metadata]");
+        Assert.assertEquals(nestedSecurityMetadata.getLocalSet().getField(SecurityMetadataKey.Caveats).getDisplayableValue(), "TesT1");
+    }
+
+    @Test
+    public void testConstructFromBytes() throws KlvParseException
+    {
+        SecurityMetadataLocalSet localSet = makeLocalSet();
+        byte[] localSetAsByteArray = localSet.frameMessage(true);
+        NestedSecurityMetadata nestedSecurityMetadata = new NestedSecurityMetadata(localSetAsByteArray);
+        Assert.assertNotNull(nestedSecurityMetadata);
+
+        Assert.assertEquals(nestedSecurityMetadata.getDisplayName(), "Security");
+        Assert.assertEquals(nestedSecurityMetadata.getDisplayableValue(), "[Security metadata]");
+        Assert.assertEquals(nestedSecurityMetadata.getLocalSet().getField(SecurityMetadataKey.Caveats).getDisplayableValue(), "TesT1");
+        byte[] bytes = nestedSecurityMetadata.getBytes();
+        Assert.assertEquals(bytes, localSetAsByteArray);
+    }
+
+    private SecurityMetadataLocalSet makeLocalSet() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> securityKeyValuePairs = new TreeMap<>();
+        securityKeyValuePairs.put(SecurityMetadataKey.Caveats, new SecurityMetadataString("TesT1"));
+        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(securityKeyValuePairs);
+        return securityMetadataLocalSet;
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/OnBoardMiStorageCapacityTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/OnBoardMiStorageCapacityTest.java
@@ -10,12 +10,14 @@ public class OnBoardMiStorageCapacityTest
     public void testMinMax()
     {
         OnBoardMiStorageCapacity capacity = new OnBoardMiStorageCapacity(0);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
         byte[] bytes = capacity.getBytes();
         Assert.assertEquals(bytes, new byte[]{(byte)0x00});
         Assert.assertEquals(capacity.getGigabytes(), 0);
         Assert.assertEquals(capacity.getDisplayableValue(), "0GB");
 
         capacity = new OnBoardMiStorageCapacity(4294967295L);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
         bytes = capacity.getBytes();
         Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
         Assert.assertEquals(capacity.getGigabytes(), 4294967295L);
@@ -23,36 +25,42 @@ public class OnBoardMiStorageCapacityTest
 
         bytes = new byte[]{(byte)0x00};
         capacity = new OnBoardMiStorageCapacity(bytes);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
         Assert.assertEquals(capacity.getGigabytes(), 0L);
         Assert.assertEquals(capacity.getBytes(), new byte[]{(byte)0x00});
         Assert.assertEquals(capacity.getDisplayableValue(), "0GB");
 
         bytes = new byte[]{(byte)0xff};
         capacity = new OnBoardMiStorageCapacity(bytes);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
         Assert.assertEquals(capacity.getGigabytes(), 255);
         Assert.assertEquals(capacity.getBytes(), bytes);
         Assert.assertEquals(capacity.getDisplayableValue(), "255GB");
 
         bytes = new byte[]{(byte)0x00, (byte)0x00};
         capacity = new OnBoardMiStorageCapacity(bytes);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
         Assert.assertEquals(capacity.getGigabytes(), 0L);
         Assert.assertEquals(capacity.getBytes(), new byte[]{(byte)0x00});
         Assert.assertEquals(capacity.getDisplayableValue(), "0GB");
 
         bytes = new byte[]{(byte)0xff, (byte)0xff};
         capacity = new OnBoardMiStorageCapacity(bytes);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
         Assert.assertEquals(capacity.getGigabytes(), 65535);
         Assert.assertEquals(capacity.getBytes(), bytes);
         Assert.assertEquals(capacity.getDisplayableValue(), "65535GB");
 
         bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
         capacity = new OnBoardMiStorageCapacity(bytes);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
         Assert.assertEquals(capacity.getGigabytes(), 0L);
         Assert.assertEquals(capacity.getBytes(), new byte[]{(byte)0x00});
         Assert.assertEquals(capacity.getDisplayableValue(), "0GB");
 
         bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
         capacity = new OnBoardMiStorageCapacity(bytes);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
         Assert.assertEquals(capacity.getGigabytes(), 4294967295L);
         Assert.assertEquals(capacity.getBytes(), bytes);
         Assert.assertEquals(capacity.getDisplayableValue(), "4294967295GB");
@@ -84,11 +92,13 @@ public class OnBoardMiStorageCapacityTest
         byte[] origBytes = new byte[]{(byte)0x27, (byte)0x10};
 
         OnBoardMiStorageCapacity capacity = new OnBoardMiStorageCapacity(origBytes);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
         Assert.assertEquals(capacity.getGigabytes(), value);
         Assert.assertEquals(capacity.getBytes(), origBytes);
         Assert.assertEquals(capacity.getDisplayableValue(), "10000GB");
 
         capacity = new OnBoardMiStorageCapacity(value);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
         Assert.assertEquals(capacity.getGigabytes(), value);
         Assert.assertEquals(capacity.getBytes(), origBytes);
     }
@@ -98,6 +108,7 @@ public class OnBoardMiStorageCapacityTest
         byte[] bytes = new byte[]{(byte)0x00};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.OnBoardMiStorageCapacity, bytes);
         Assert.assertTrue(v instanceof OnBoardMiStorageCapacity);
+        Assert.assertEquals(v.getDisplayName(), "On-Board MI Storage Capacity");
         OnBoardMiStorageCapacity capacity = (OnBoardMiStorageCapacity)v;
         Assert.assertEquals(capacity.getGigabytes(), 0L);
         Assert.assertEquals(capacity.getBytes(), new byte[]{(byte)0x00});
@@ -106,6 +117,7 @@ public class OnBoardMiStorageCapacityTest
         bytes = new byte[]{(byte)0xff};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OnBoardMiStorageCapacity, bytes);
         Assert.assertTrue(v instanceof OnBoardMiStorageCapacity);
+        Assert.assertEquals(v.getDisplayName(), "On-Board MI Storage Capacity");
         capacity = (OnBoardMiStorageCapacity)v;
         Assert.assertEquals(capacity.getGigabytes(), 255);
         Assert.assertEquals(capacity.getBytes(), bytes);
@@ -114,6 +126,7 @@ public class OnBoardMiStorageCapacityTest
         bytes = new byte[]{(byte)0x00, (byte)0x00};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OnBoardMiStorageCapacity, bytes);
         Assert.assertTrue(v instanceof OnBoardMiStorageCapacity);
+        Assert.assertEquals(v.getDisplayName(), "On-Board MI Storage Capacity");
         capacity = (OnBoardMiStorageCapacity)v;
         Assert.assertEquals(capacity.getGigabytes(), 0L);
         Assert.assertEquals(capacity.getBytes(), new byte[]{(byte)0x00});
@@ -122,6 +135,7 @@ public class OnBoardMiStorageCapacityTest
         bytes = new byte[]{(byte)0xff, (byte)0xff};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OnBoardMiStorageCapacity, bytes);
         Assert.assertTrue(v instanceof OnBoardMiStorageCapacity);
+        Assert.assertEquals(v.getDisplayName(), "On-Board MI Storage Capacity");
         capacity = (OnBoardMiStorageCapacity)v;
         Assert.assertEquals(capacity.getGigabytes(), 65535);
         Assert.assertEquals(capacity.getBytes(), bytes);
@@ -130,6 +144,7 @@ public class OnBoardMiStorageCapacityTest
         bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OnBoardMiStorageCapacity, bytes);
         Assert.assertTrue(v instanceof OnBoardMiStorageCapacity);
+        Assert.assertEquals(v.getDisplayName(), "On-Board MI Storage Capacity");
         capacity = (OnBoardMiStorageCapacity)v;
         Assert.assertEquals(capacity.getGigabytes(), 0L);
         Assert.assertEquals(capacity.getBytes(), new byte[]{(byte)0x00});
@@ -138,6 +153,7 @@ public class OnBoardMiStorageCapacityTest
         bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OnBoardMiStorageCapacity, bytes);
         Assert.assertTrue(v instanceof OnBoardMiStorageCapacity);
+        Assert.assertEquals(v.getDisplayName(), "On-Board MI Storage Capacity");
         capacity = (OnBoardMiStorageCapacity)v;
         Assert.assertEquals(capacity.getGigabytes(), 4294967295L);
         Assert.assertEquals(capacity.getBytes(), bytes);

--- a/api/src/test/java/org/jmisb/api/klv/st0601/OperationalModeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/OperationalModeTest.java
@@ -31,6 +31,8 @@ public class OperationalModeTest {
         operationalMode = new OperationalMode((byte) 4);
         Assert.assertEquals(operationalMode.getBytes(), new byte[]{(byte) 4});
         Assert.assertEquals(operationalMode.getDisplayableValue(), "Maintenance");
+
+        Assert.assertEquals(operationalMode.getDisplayName(), "Operational Mode");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttackFullTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttackFullTest.java
@@ -30,6 +30,8 @@ public class PlatformAngleOfAttackFullTest
         platformAngleOfAttackFull = new PlatformAngleOfAttackFull(bytes);
         Assert.assertEquals(platformAngleOfAttackFull.getDegrees(), 90.0);
         Assert.assertEquals(platformAngleOfAttackFull.getBytes(), bytes);
+
+        Assert.assertEquals(platformAngleOfAttackFull.getDisplayName(), "Platform Angle of Attack (Full)");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttackTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttackTest.java
@@ -29,6 +29,8 @@ public class PlatformAngleOfAttackTest {
         angle = new PlatformAngleOfAttack(bytes);
         Assert.assertEquals(angle.getDegrees(), 20.0);
         Assert.assertEquals(angle.getBytes(), bytes);
+
+        Assert.assertEquals(angle.getDisplayName(), "Platform Angle of Attack");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformGroundSpeedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformGroundSpeedTest.java
@@ -20,6 +20,8 @@ public class PlatformGroundSpeedTest
         // From ST:
         speed = new PlatformGroundSpeed(140);
         Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x8c});
+
+        Assert.assertEquals(speed.getDisplayName(), "Platform Ground Speed");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformHeadingAngleTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformHeadingAngleTest.java
@@ -27,6 +27,8 @@ public class PlatformHeadingAngleTest
         Assert.assertEquals(bytes, new byte[]{(byte)0x71, (byte)0xc2});
         Assert.assertEquals(platformHeadingAngle.getDegrees(), 159.9744);
         Assert.assertEquals(platformHeadingAngle.getDisplayableValue(), "159.9744\u00B0");
+
+        Assert.assertEquals(platformHeadingAngle.getDisplayName(), "Platform Heading Angle");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformIndicatedAirspeedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformIndicatedAirspeedTest.java
@@ -20,6 +20,8 @@ public class PlatformIndicatedAirspeedTest
         // From ST:
         speed = new PlatformIndicatedAirspeed(159);
         Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x9f});
+
+        Assert.assertEquals(speed.getDisplayName(), "Platform Indicated Airspeed");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformPitchAngleFullTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformPitchAngleFullTest.java
@@ -30,6 +30,8 @@ public class PlatformPitchAngleFullTest
         platformPitchAngleFull = new PlatformPitchAngleFull(bytes);
         Assert.assertEquals(platformPitchAngleFull.getDegrees(), 90.0);
         Assert.assertEquals(platformPitchAngleFull.getBytes(), bytes);
+
+        Assert.assertEquals(platformPitchAngleFull.getDisplayName(), "Platform Pitch Angle (Full)");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformPitchAngleTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformPitchAngleTest.java
@@ -30,6 +30,8 @@ public class PlatformPitchAngleTest
         platformPitchAngle = new PlatformPitchAngle(bytes);
         Assert.assertEquals(platformPitchAngle.getDegrees(), 20.0);
         Assert.assertEquals(platformPitchAngle.getBytes(), bytes);
+
+        Assert.assertEquals(platformPitchAngle.getDisplayName(), "Platform Pitch Angle");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformRollAngleFullTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformRollAngleFullTest.java
@@ -30,6 +30,8 @@ public class PlatformRollAngleFullTest
         platformRollAngleFull = new PlatformRollAngleFull(bytes);
         Assert.assertEquals(platformRollAngleFull.getDegrees(), 90.0);
         Assert.assertEquals(platformRollAngleFull.getBytes(), bytes);
+
+        Assert.assertEquals(platformRollAngleFull.getDisplayName(), "Platform Roll Angle (Full)");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformRollAngleTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformRollAngleTest.java
@@ -30,6 +30,8 @@ public class PlatformRollAngleTest
         platformRollAngle = new PlatformRollAngle(bytes);
         Assert.assertEquals(platformRollAngle.getDegrees(), 50.0);
         Assert.assertEquals(platformRollAngle.getBytes(), bytes);
+
+        Assert.assertEquals(platformRollAngle.getDisplayName(), "Platform Roll Angle");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformSideslipAngleFullTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformSideslipAngleFullTest.java
@@ -30,6 +30,8 @@ public class PlatformSideslipAngleFullTest
         platformSideslipAngleFull = new PlatformSideslipAngleFull(bytes);
         Assert.assertEquals(platformSideslipAngleFull.getDegrees(), 90.0);
         Assert.assertEquals(platformSideslipAngleFull.getBytes(), bytes);
+
+        Assert.assertEquals(platformSideslipAngleFull.getDisplayName(), "Platform Sideslip Angle (Full)");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformSideslipAngleTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformSideslipAngleTest.java
@@ -29,6 +29,7 @@ public class PlatformSideslipAngleTest {
         angle = new PlatformSideslipAngle(bytes);
         Assert.assertEquals(angle.getDegrees(), 20.0);
         Assert.assertEquals(angle.getBytes(), bytes);
+        Assert.assertEquals(angle.getDisplayName(), "Platform Sideslip Angle");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformStatusTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformStatusTest.java
@@ -55,6 +55,8 @@ public class PlatformStatusTest {
         operationalMode = new PlatformStatus((byte) 12);
         Assert.assertEquals(operationalMode.getBytes(), new byte[]{(byte) 0x0C});
         Assert.assertEquals(operationalMode.getDisplayableValue(), "Landed-Parked");
+
+        Assert.assertEquals(operationalMode.getDisplayName(), "Platform Status");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformTrueAirspeedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformTrueAirspeedTest.java
@@ -20,6 +20,8 @@ public class PlatformTrueAirspeedTest
         // From ST:
         speed = new PlatformTrueAirspeed(147);
         Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x93});
+
+        Assert.assertEquals(speed.getDisplayName(), "Platform True Airspeed");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PrecisionTimeStampTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PrecisionTimeStampTest.java
@@ -20,6 +20,7 @@ public class PrecisionTimeStampTest
         byte[] bytes = new byte[]{(byte)0x00, (byte)0x04, (byte)0x59, (byte)0xf4,
                 (byte)0xA6, (byte)0xaa, (byte)0x4a, (byte)0xa8};
         PrecisionTimeStamp pts = new PrecisionTimeStamp(bytes);
+        Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
         Assert.assertEquals(pts.getDisplayableValue(), "1224807209913000");
         LocalDateTime dateTime = pts.getLocalDateTime();
 
@@ -34,6 +35,7 @@ public class PrecisionTimeStampTest
         // Convert value -> byte[]
         long microseconds = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli() * 1000;
         PrecisionTimeStamp pts2 = new PrecisionTimeStamp(microseconds);
+        Assert.assertEquals(pts2.getDisplayName(), "Precision Time Stamp");
         Assert.assertEquals(pts2.getBytes(), new byte[]{(byte)0x00, (byte)0x04, (byte)0x59, (byte)0xf4,
                 (byte)0xA6, (byte)0xaa, (byte)0x4a, (byte)0xa8});
 
@@ -48,6 +50,7 @@ public class PrecisionTimeStampTest
                 (byte)0xA6, (byte)0xaa, (byte)0x4a, (byte)0xa8};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.PrecisionTimeStamp, bytes);
         Assert.assertTrue(v instanceof PrecisionTimeStamp);
+        Assert.assertEquals(v.getDisplayName(), "Precision Time Stamp");
         PrecisionTimeStamp pts = (PrecisionTimeStamp)v;
         Assert.assertEquals(pts.getDisplayableValue(), "1224807209913000");
         LocalDateTime dateTime = pts.getLocalDateTime();
@@ -66,6 +69,7 @@ public class PrecisionTimeStampTest
     {
         LocalDateTime now = LocalDateTime.now();
         PrecisionTimeStamp pts = new PrecisionTimeStamp(now);
+        Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
         Assert.assertEquals(pts.getLocalDateTime().getDayOfMonth(), now.getDayOfMonth());
         Assert.assertEquals(pts.getLocalDateTime().getHour(), now.getHour());
         long ptsMicroseconds = pts.getMicroseconds();
@@ -77,13 +81,15 @@ public class PrecisionTimeStampTest
     public void testMinAndMax()
     {
         PrecisionTimeStamp pts = new PrecisionTimeStamp(0L);
+        Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
         Assert.assertEquals(pts.getLocalDateTime().getYear(), 1970);
         Assert.assertEquals(pts.getLocalDateTime().getMonth(), Month.JANUARY);
         Assert.assertEquals(pts.getLocalDateTime().getDayOfMonth(), 1);
         Assert.assertEquals(pts.getDisplayableValue(), "0");
 
         // Create max value and ensure no exception is thrown
-        new PrecisionTimeStamp(Long.MAX_VALUE);
+        pts = new PrecisionTimeStamp(Long.MAX_VALUE);
+        Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/api/src/test/java/org/jmisb/api/klv/st0601/ST0601VersionTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/ST0601VersionTest.java
@@ -55,6 +55,8 @@ public class ST0601VersionTest {
         Assert.assertEquals(version.getBytes(), new byte[]{(byte) 0x0d});
         Assert.assertEquals(version.getVersion(), 13);
         Assert.assertEquals(version.getDisplayableValue(), "13");
+
+        Assert.assertEquals(version.getDisplayName(), "Version Number");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorEastVelocityTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorEastVelocityTest.java
@@ -30,6 +30,8 @@ public class SensorEastVelocityTest
         velocity = new SensorEastVelocity(bytes);
         Assert.assertEquals(velocity.getVelocity(), 327.0);
         Assert.assertEquals(velocity.getBytes(), bytes);
+
+        Assert.assertEquals(velocity.getDisplayName(), "Sensor East Velocity");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorLatitudeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorLatitudeTest.java
@@ -33,6 +33,8 @@ public class SensorLatitudeTest
         latitude = new SensorLatitude(Double.POSITIVE_INFINITY);
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00});
         Assert.assertEquals(latitude.getDegrees(), Double.POSITIVE_INFINITY);
+
+        Assert.assertEquals(latitude.getDisplayName(), "Sensor Latitude");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorLongitudeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorLongitudeTest.java
@@ -33,6 +33,8 @@ public class SensorLongitudeTest
         longitude = new SensorLongitude(Double.POSITIVE_INFINITY);
         Assert.assertEquals(longitude.getBytes(), new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00});
         Assert.assertEquals(longitude.getDegrees(), Double.POSITIVE_INFINITY);
+
+        Assert.assertEquals(longitude.getDisplayName(), "Sensor Longitude");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorNorthVelocityTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorNorthVelocityTest.java
@@ -30,6 +30,8 @@ public class SensorNorthVelocityTest
         velocity = new SensorNorthVelocity(bytes);
         Assert.assertEquals(velocity.getVelocity(), 327.0);
         Assert.assertEquals(velocity.getBytes(), bytes);
+
+        Assert.assertEquals(velocity.getDisplayName(), "Sensor North Velocity");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorRelativeAzimuthTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorRelativeAzimuthTest.java
@@ -28,6 +28,8 @@ public class SensorRelativeAzimuthTest
         Assert.assertEquals(ex, new byte[]{(byte)0x72, (byte)0x4a, (byte)0x0a, (byte)0x20});
         Assert.assertEquals(az.getDegrees(), val);
         Assert.assertEquals("160.7192\u00B0", az.getDisplayableValue());
+
+        Assert.assertEquals(az.getDisplayName(), "Sensor Relative Azimuth");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorRelativeElevationTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorRelativeElevationTest.java
@@ -42,6 +42,8 @@ public class SensorRelativeElevationTest
         elevation = new SensorRelativeElevation(Double.POSITIVE_INFINITY);
         Assert.assertEquals(elevation.getDegrees(), Double.POSITIVE_INFINITY);
         Assert.assertEquals(elevation.getBytes(), error);
+
+        Assert.assertEquals(elevation.getDisplayName(), "Sensor Relative Elevation");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorRelativeRollTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorRelativeRollTest.java
@@ -58,7 +58,8 @@ public class SensorRelativeRollTest
 
         bytes = new byte[]{(byte)0xd7, (byte)0x03, (byte)0x9d, (byte)0xc8};
         roll = new SensorRelativeRoll(bytes);
-        Assert.assertEquals(roll.getBytes(), bytes);
+
+        Assert.assertEquals(roll.getDisplayName(), "Sensor Relative Roll");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorTrueAltitudeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorTrueAltitudeTest.java
@@ -27,6 +27,8 @@ public class SensorTrueAltitudeTest
         altitude = new SensorTrueAltitude(14190.72);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0xc2, (byte)0x21});
         Assert.assertEquals(altitude.getMeters(), 14190.72);
+
+        Assert.assertEquals(altitude.getDisplayName(), "Sensor True Altitude");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SlantRangeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SlantRangeTest.java
@@ -24,6 +24,8 @@ public class SlantRangeTest
         range = new SlantRange(68590.98);
         Assert.assertEquals(range.getBytes(), new byte[]{(byte)0x03, (byte)0x83, (byte)0x09, (byte)0x23});
         Assert.assertEquals(range.getDisplayableValue(), "68590.98m");
+
+        Assert.assertEquals(range.getDisplayName(), "Slant Range");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/StaticPressureTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/StaticPressureTest.java
@@ -25,6 +25,8 @@ public class StaticPressureTest
         Assert.assertEquals(bytes, new byte[]{(byte)0xBE, (byte)0xBA});
         Assert.assertEquals(pressure.getMillibars(),3725.18502);
         Assert.assertEquals("3725.19mB", pressure.getDisplayableValue());
+
+        Assert.assertEquals(pressure.getDisplayName(), "Static Pressure");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/TargetWidthTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/TargetWidthTest.java
@@ -23,6 +23,8 @@ public class TargetWidthTest
         width = new TargetWidth(722.8199);
         Assert.assertEquals(width.getBytes(), new byte[]{(byte)0x12, (byte)0x81});
         Assert.assertEquals(width.getDisplayableValue(), "722.82m");
+
+        Assert.assertEquals(width.getDisplayName(), "Target Width");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkAltitudeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkAltitudeTest.java
@@ -17,55 +17,65 @@ public class UasDatalinkAltitudeTest
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x34, (byte)0xf3});
         Assert.assertEquals(altitude.getMeters(), 3216.037);
         Assert.assertEquals(altitude.getDisplayableValue(), "3216.0m");
+        Assert.assertEquals(altitude.getDisplayName(), "Frame Center Elevation");
 
         altitude = new FrameCenterElevation(new byte[]{(byte)0x34, (byte)0xf3});
         Assert.assertEquals(altitude.getMeters(), 3216.037, delta);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x34, (byte)0xf3});
         Assert.assertEquals(altitude.getDisplayableValue(), "3216.0m");
+        Assert.assertEquals(altitude.getDisplayName(), "Frame Center Elevation");
 
         // Density Altitude
         altitude = new DensityAltitude(14818.68);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0xca, (byte)0x35});
         Assert.assertEquals(altitude.getMeters(), 14818.68);
         Assert.assertEquals(altitude.getDisplayableValue(), "14818.7m");
+        Assert.assertEquals(altitude.getDisplayName(), "Density Altitude");
 
         altitude = new DensityAltitude(new byte[]{(byte)0xca, (byte)0x35});
         Assert.assertEquals(altitude.getMeters(), 14818.68, delta);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0xca, (byte)0x35});
         Assert.assertEquals(altitude.getDisplayableValue(), "14818.7m");
+        Assert.assertEquals(altitude.getDisplayName(), "Density Altitude");
 
         // Alternate Platform Altitude
         altitude = new AlternatePlatformAltitude(9.445334);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x0b, (byte)0xb3});
         Assert.assertEquals(altitude.getMeters(), 9.445334);
         Assert.assertEquals(altitude.getDisplayableValue(), "9.4m");
+        Assert.assertEquals(altitude.getDisplayName(), "Alternate Platform Altitude");
 
         altitude = new AlternatePlatformAltitude(new byte[]{(byte)0x0b, (byte)0xb3});
         Assert.assertEquals(altitude.getMeters(), 9.445334, delta);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x0b, (byte)0xb3});
         Assert.assertEquals(altitude.getDisplayableValue(), "9.4m");
+        Assert.assertEquals(altitude.getDisplayName(), "Alternate Platform Altitude");
 
         // Frame Center Height Above Ellipsoid
         altitude = new FrameCenterHae(9.445334);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x0b, (byte)0xb3});
         Assert.assertEquals(altitude.getMeters(), 9.445334);
         Assert.assertEquals(altitude.getDisplayableValue(), "9.4m");
+        Assert.assertEquals(altitude.getDisplayName(), "Frame Center Height Above Ellipsoid");
 
         altitude = new FrameCenterHae(new byte[]{(byte)0x0b, (byte)0xb3});
         Assert.assertEquals(altitude.getMeters(), 9.445334, delta);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x0b, (byte)0xb3});
         Assert.assertEquals(altitude.getDisplayableValue(), "9.4m");
+        Assert.assertEquals(altitude.getDisplayName(), "Frame Center Height Above Ellipsoid");
 
         // Target Location Elevation
         altitude = new TargetLocationElevation(9.445334);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x0b, (byte)0xb3});
         Assert.assertEquals(altitude.getMeters(), 9.445334);
         Assert.assertEquals(altitude.getDisplayableValue(), "9.4m");
+        Assert.assertEquals(altitude.getDisplayName(), "Target Location Elevation");
 
         altitude = new TargetLocationElevation(new byte[]{(byte)0xF8, (byte)0x23});
         Assert.assertEquals(altitude.getMeters(), 18389.0471, delta);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0xf8, (byte)0x23});
         Assert.assertEquals(altitude.getDisplayableValue(), "18389.0m");
+        Assert.assertEquals(altitude.getDisplayName(), "Target Location Elevation");
     }
 
     @Test
@@ -77,6 +87,7 @@ public class UasDatalinkAltitudeTest
         Assert.assertEquals(altitude.getMeters(), 3216.037, delta);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x34, (byte)0xf3});
         Assert.assertEquals(altitude.getDisplayableValue(), "3216.0m");
+        Assert.assertEquals(altitude.getDisplayName(), "Frame Center Elevation");
     }
 
     @Test
@@ -88,6 +99,7 @@ public class UasDatalinkAltitudeTest
         Assert.assertEquals(altitude.getMeters(), 14818.68, delta);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0xca, (byte)0x35});
         Assert.assertEquals(altitude.getDisplayableValue(), "14818.7m");
+        Assert.assertEquals(altitude.getDisplayName(), "Density Altitude");
     }
 
     @Test
@@ -99,6 +111,7 @@ public class UasDatalinkAltitudeTest
         Assert.assertEquals(altitude.getMeters(), 9.445334, delta);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x0b, (byte)0xb3});
         Assert.assertEquals(altitude.getDisplayableValue(), "9.4m");
+        Assert.assertEquals(altitude.getDisplayName(), "Alternate Platform Altitude");
     }
 
     @Test
@@ -110,6 +123,7 @@ public class UasDatalinkAltitudeTest
         Assert.assertEquals(altitude.getMeters(), 9.445334, delta);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x0b, (byte)0xb3});
         Assert.assertEquals(altitude.getDisplayableValue(), "9.4m");
+        Assert.assertEquals(altitude.getDisplayName(), "Frame Center Height Above Ellipsoid");
     }
 
     @Test
@@ -121,5 +135,6 @@ public class UasDatalinkAltitudeTest
         Assert.assertEquals(altitude.getMeters(), 18389.0471, delta);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0xf8, (byte)0x23});
         Assert.assertEquals(altitude.getDisplayableValue(), "18389.0m");
+        Assert.assertEquals(altitude.getDisplayName(), "Target Location Elevation");
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkLatitudeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkLatitudeTest.java
@@ -17,40 +17,48 @@ public class UasDatalinkLatitudeTest
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0x85, (byte)0xa1, (byte)0x5a, (byte)0x39});
         Assert.assertEquals(latitude.getDegrees(), -86.041207348947);
         Assert.assertEquals(latitude.getDisplayableValue(), "-86.0412\u00B0");
+        Assert.assertEquals(latitude.getDisplayName(), "Alternate Platform Latitude");
 
         latitude = new AlternatePlatformLatitude(new byte[]{(byte)0x85, (byte)0xa1, (byte)0x5a, (byte)0x39});
         Assert.assertEquals(latitude.getDegrees(), -86.041207348947, delta);
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0x85, (byte)0xa1, (byte)0x5a, (byte)0x39});
+        Assert.assertEquals(latitude.getDisplayName(), "Alternate Platform Latitude");
 
         // Frame Center Latitude
         latitude = new FrameCenterLatitude(-10.5423886331461);
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0xf1, (byte)0x01, (byte)0xa2, (byte)0x29});
         Assert.assertEquals(latitude.getDegrees(), -10.5423886331461);
         Assert.assertEquals(latitude.getDisplayableValue(), "-10.5424\u00B0");
+        Assert.assertEquals(latitude.getDisplayName(), "Frame Center Latitude");
 
         latitude = new FrameCenterLatitude(new byte[]{(byte)0xf1, (byte)0x01, (byte)0xa2, (byte)0x29});
         Assert.assertEquals(latitude.getDegrees(), -10.5423886331461, delta);
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0xf1, (byte)0x01, (byte)0xa2, (byte)0x29});
+        Assert.assertEquals(latitude.getDisplayName(), "Frame Center Latitude");
 
         // Target Location Latitude
         latitude = new TargetLocationLatitude(-79.1638500518929);
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0x8f, (byte)0x69, (byte)0x52, (byte)0x62});
         Assert.assertEquals(latitude.getDegrees(), -79.1638500518929);
         Assert.assertEquals(latitude.getDisplayableValue(), "-79.1639\u00B0");
+        Assert.assertEquals(latitude.getDisplayName(), "Target Location Latitude");
 
         latitude = new TargetLocationLatitude(new byte[]{(byte)0x8f, (byte)0x69, (byte)0x52, (byte)0x62});
         Assert.assertEquals(latitude.getDegrees(), -79.1638500518929, delta);
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0x8f, (byte)0x69, (byte)0x52, (byte)0x62});
+        Assert.assertEquals(latitude.getDisplayName(), "Target Location Latitude");
 
         // Corner Latitude Point 1
         latitude = new FullCornerLatitude(-10.579637999887);
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0xf0, (byte)0xf4, (byte)0x12, (byte)0x44});
         Assert.assertEquals(latitude.getDegrees(), -10.579637999887);
         Assert.assertEquals(latitude.getDisplayableValue(), "-10.5796\u00B0");
+        Assert.assertEquals(latitude.getDisplayName(), "Corner Latitude Point");
 
         latitude = new FullCornerLatitude(new byte[]{(byte)0xf0, (byte)0xf4, (byte)0x12, (byte)0x44});
         Assert.assertEquals(latitude.getDegrees(), -10.579637999887, delta);
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0xf0, (byte)0xf4, (byte)0x12, (byte)0x44});
+        Assert.assertEquals(latitude.getDisplayName(), "Corner Latitude Point");
     }
 
     @Test
@@ -62,6 +70,7 @@ public class UasDatalinkLatitudeTest
         Assert.assertEquals(latitude.getDegrees(), -86.041207348947, delta);
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0x85, (byte)0xa1, (byte)0x5a, (byte)0x39});
         Assert.assertEquals(latitude.getDisplayableValue(), "-86.0412\u00B0");
+        Assert.assertEquals(latitude.getDisplayName(), "Alternate Platform Latitude");
     }
 
     @Test
@@ -72,6 +81,7 @@ public class UasDatalinkLatitudeTest
         FrameCenterLatitude latitude = (FrameCenterLatitude)v;
         Assert.assertEquals(latitude.getDegrees(), -10.5423886331461, delta);
         Assert.assertEquals(latitude.getDisplayableValue(), "-10.5424\u00B0");
+        Assert.assertEquals(latitude.getDisplayName(), "Frame Center Latitude");
     }
 
     @Test
@@ -83,24 +93,29 @@ public class UasDatalinkLatitudeTest
         Assert.assertEquals(latitude.getDegrees(), -79.1638500518929, delta);
         Assert.assertEquals(latitude.getDisplayableValue(), "-79.1639\u00B0");
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0x8f, (byte)0x69, (byte)0x52, (byte)0x62});
+        Assert.assertEquals(latitude.getDisplayName(), "Target Location Latitude");
     }
 
     @Test
     public void testFactoryFullCornerLatitude() throws KlvParseException {
         byte[] bytes = new byte[]{(byte)0xf0, (byte)0xf4, (byte)0x12, (byte)0x44};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLatPt1, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Corner Latitude Point");
         Assert.assertTrue(v instanceof FullCornerLatitude);
         FullCornerLatitude latitude = (FullCornerLatitude)v;
         Assert.assertEquals(latitude.getDegrees(), -10.579637999887, delta);
         Assert.assertEquals(latitude.getBytes(), new byte[]{(byte)0xf0, (byte)0xf4, (byte)0x12, (byte)0x44});
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLatPt2, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Corner Latitude Point");
         Assert.assertTrue(v instanceof FullCornerLatitude);
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLatPt3, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Corner Latitude Point");
         Assert.assertTrue(v instanceof FullCornerLatitude);
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLatPt4, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Corner Latitude Point");
         Assert.assertTrue(v instanceof FullCornerLatitude);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkLongitudeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkLongitudeTest.java
@@ -17,40 +17,48 @@ public class UasDatalinkLongitudeTest
         Assert.assertEquals(longitude.getBytes(), new byte[]{(byte)0x00, (byte)0x1c, (byte)0x50, (byte)0x1c});
         Assert.assertEquals(longitude.getDegrees(), 0.155527554524842);
         Assert.assertEquals(longitude.getDisplayableValue(), "0.1555\u00B0");
+        Assert.assertEquals(longitude.getDisplayName(), "Alternate Platform Longitude");
 
         longitude = new AlternatePlatformLongitude(new byte[]{(byte)0x00, (byte)0x1c, (byte)0x50, (byte)0x1c});
         Assert.assertEquals(longitude.getDegrees(), 0.155527554524842, delta);
         Assert.assertEquals(longitude.getBytes(), new byte[]{(byte)0x00, (byte)0x1c, (byte)0x50, (byte)0x1c});
+        Assert.assertEquals(longitude.getDisplayName(), "Alternate Platform Longitude");
 
         // Frame Center Longitude
         longitude = new FrameCenterLongitude(29.157890122923);
         Assert.assertEquals(longitude.getBytes(), new byte[]{(byte)0x14, (byte)0xbc, (byte)0x08, (byte)0x2b});
         Assert.assertEquals(longitude.getDegrees(), 29.157890122923);
         Assert.assertEquals(longitude.getDisplayableValue(), "29.1579\u00B0");
+        Assert.assertEquals(longitude.getDisplayName(), "Frame Center Longitude");
 
         longitude = new FrameCenterLongitude(new byte[]{(byte)0x14, (byte)0xbc, (byte)0x08, (byte)0x2b});
         Assert.assertEquals(longitude.getDegrees(), 29.157890122923, delta);
         Assert.assertEquals(longitude.getBytes(), new byte[]{(byte)0x14, (byte)0xbc, (byte)0x08, (byte)0x2b});
+        Assert.assertEquals(longitude.getDisplayName(), "Frame Center Longitude");
 
         // Target Location Longitude
         longitude = new TargetLocationLongitude(166.400812960416);
         Assert.assertEquals(longitude.getBytes(), new byte[]{(byte)0x76, (byte)0x54, (byte)0x57, (byte)0xf2});
         Assert.assertEquals(longitude.getDegrees(), 166.400812960416);
         Assert.assertEquals(longitude.getDisplayableValue(), "166.4008\u00B0");
+        Assert.assertEquals(longitude.getDisplayName(), "Target Location Longitude");
 
         longitude = new TargetLocationLongitude(new byte[]{(byte)0x76, (byte)0x54, (byte)0x57, (byte)0xf2});
         Assert.assertEquals(longitude.getDegrees(), 166.400812960416, delta);
         Assert.assertEquals(longitude.getBytes(), new byte[]{(byte)0x76, (byte)0x54, (byte)0x57, (byte)0xf2});
+        Assert.assertEquals(longitude.getDisplayName(), "Target Location Longitude");
 
         // Corner Longitude Point 1
         longitude = new FullCornerLongitude(29.1273677986333);
         Assert.assertEquals(longitude.getBytes(), new byte[]{(byte)0x14, (byte)0xb6, (byte)0x79, (byte)0xb9});
         Assert.assertEquals(longitude.getDegrees(), 29.1273677986333);
         Assert.assertEquals(longitude.getDisplayableValue(), "29.1274\u00B0");
+        Assert.assertEquals(longitude.getDisplayName(), "Corner Longitude Point");
 
         longitude = new FullCornerLongitude(new byte[]{(byte)0x14, (byte)0xb6, (byte)0x79, (byte)0xb9});
         Assert.assertEquals(longitude.getDegrees(), 29.1273677986333, delta);
         Assert.assertEquals(longitude.getBytes(), new byte[]{(byte)0x14, (byte)0xb6, (byte)0x79, (byte)0xb9});
+        Assert.assertEquals(longitude.getDisplayName(), "Corner Longitude Point");
     }
 
     @Test
@@ -62,6 +70,7 @@ public class UasDatalinkLongitudeTest
         Assert.assertEquals(longitude.getBytes(),bytes);
         Assert.assertEquals(longitude.getDegrees(), 0.155527554524842, delta);
         Assert.assertEquals(longitude.getDisplayableValue(), "0.1555\u00B0");
+        Assert.assertEquals(longitude.getDisplayName(), "Alternate Platform Longitude");
     }
 
     @Test
@@ -72,6 +81,7 @@ public class UasDatalinkLongitudeTest
         FrameCenterLongitude longitude = (FrameCenterLongitude)v;
         Assert.assertEquals(longitude.getDegrees(), 29.157890122923, delta);
         Assert.assertEquals(longitude.getDisplayableValue(), "29.1579\u00B0");
+        Assert.assertEquals(longitude.getDisplayName(), "Frame Center Longitude");
     }
 
     @Test
@@ -82,12 +92,14 @@ public class UasDatalinkLongitudeTest
         TargetLocationLongitude longitude = (TargetLocationLongitude)v;
         Assert.assertEquals(longitude.getDegrees(), 166.400812960416, delta);
         Assert.assertEquals(longitude.getDisplayableValue(), "166.4008\u00B0");
+        Assert.assertEquals(longitude.getDisplayName(), "Target Location Longitude");
     }
 
     @Test
-    public void testFactoryFullCornerLatitude() throws KlvParseException {
+    public void testFactoryFullCornerLongitude() throws KlvParseException {
         byte[] bytes = new byte[]{(byte)0x14, (byte)0xb6, (byte)0x79, (byte)0xb9};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLonPt1, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Corner Longitude Point");
         Assert.assertTrue(v instanceof FullCornerLongitude);
         FullCornerLongitude longitude = (FullCornerLongitude)v;
         Assert.assertEquals(longitude.getDegrees(), 29.1273677986333, delta);
@@ -95,11 +107,14 @@ public class UasDatalinkLongitudeTest
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLonPt2, bytes);
         Assert.assertTrue(v instanceof FullCornerLongitude);
+        Assert.assertEquals(v.getDisplayName(), "Corner Longitude Point");
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLonPt3, bytes);
         Assert.assertTrue(v instanceof FullCornerLongitude);
+        Assert.assertEquals(v.getDisplayName(), "Corner Longitude Point");
 
         v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLonPt4, bytes);
         Assert.assertTrue(v instanceof FullCornerLongitude);
+        Assert.assertEquals(v.getDisplayName(), "Corner Longitude Point");
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkStringTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkStringTest.java
@@ -13,8 +13,10 @@ public class UasDatalinkStringTest
         final String stringVal = "MISSION01";
         final byte[] bytes = new byte[]{0x4d, 0x49, 0x53, 0x53, 0x49, 0x4f, 0x4e, 0x30, 0x31};
 
-        UasDatalinkString idFromString = new UasDatalinkString(stringVal);
-        UasDatalinkString idFromBytes = new UasDatalinkString(bytes);
+        UasDatalinkString idFromString = new UasDatalinkString(UasDatalinkString.MISSION_ID, stringVal);
+        Assert.assertEquals(idFromString.getDisplayName(), UasDatalinkString.MISSION_ID);
+        UasDatalinkString idFromBytes = new UasDatalinkString(UasDatalinkString.MISSION_ID, bytes);
+        Assert.assertEquals(idFromBytes.getDisplayName(), UasDatalinkString.MISSION_ID);
 
         Assert.assertEquals(idFromString.getBytes(), bytes);
         Assert.assertEquals(idFromString.getDisplayableValue(), "MISSION01");
@@ -29,6 +31,7 @@ public class UasDatalinkStringTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.MissionId, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString id = (UasDatalinkString)v;
+        Assert.assertEquals(id.getDisplayName(), UasDatalinkString.MISSION_ID);
         Assert.assertEquals(id.getBytes(), bytes);
         Assert.assertEquals(id.getDisplayableValue(), "MISSION01");
     }
@@ -40,6 +43,7 @@ public class UasDatalinkStringTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.AlternatePlatformName, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString str = (UasDatalinkString)v;
+        Assert.assertEquals(str.getDisplayName(), UasDatalinkString.ALTERNATE_PLATFORM_NAME);
         Assert.assertEquals(str.getBytes(), bytes);
         Assert.assertEquals(str.getDisplayableValue(), "APACHE");
     }
@@ -51,6 +55,7 @@ public class UasDatalinkStringTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.StreamDesignator, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString str = (UasDatalinkString)v;
+        Assert.assertEquals(str.getDisplayName(), UasDatalinkString.STREAM_DESIGNATOR);
         Assert.assertEquals(str.getBytes(), bytes);
         Assert.assertEquals(str.getDisplayableValue(), "BLUE");
     }
@@ -62,6 +67,7 @@ public class UasDatalinkStringTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.OperationalBase, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString str = (UasDatalinkString)v;
+        Assert.assertEquals(str.getDisplayName(), UasDatalinkString.OPERATIONAL_BASE);
         Assert.assertEquals(str.getBytes(), bytes);
         Assert.assertEquals(str.getDisplayableValue(), "BASE01");
     }
@@ -70,9 +76,10 @@ public class UasDatalinkStringTest
     public void testFactoryBroadcastSource() throws KlvParseException
     {
         byte[] bytes = new byte[]{0x48, 0x4F, 0x4D, 0x45};
-        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.OperationalBase, bytes);
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.BroadcastSource, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString str = (UasDatalinkString)v;
+        Assert.assertEquals(str.getDisplayName(), UasDatalinkString.BROADCAST_SOURCE);
         Assert.assertEquals(str.getBytes(), bytes);
         Assert.assertEquals(str.getDisplayableValue(), "HOME");
     }
@@ -84,6 +91,7 @@ public class UasDatalinkStringTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformDesignation, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString str = (UasDatalinkString)v;
+        Assert.assertEquals(str.getDisplayName(), UasDatalinkString.PLATFORM_DESIGNATION);
         Assert.assertEquals(str.getBytes(), bytes);
         Assert.assertEquals(str.getDisplayableValue(), "MQ1-B");
     }
@@ -95,6 +103,7 @@ public class UasDatalinkStringTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.ImageSourceSensor, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString str = (UasDatalinkString)v;
+        Assert.assertEquals(str.getDisplayName(), UasDatalinkString.IMAGE_SOURCE_SENSOR);
         Assert.assertEquals(str.getBytes(), bytes);
         Assert.assertEquals(str.getDisplayableValue(), "EO");
     }
@@ -106,6 +115,7 @@ public class UasDatalinkStringTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.ImageCoordinateSystem, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString str = (UasDatalinkString)v;
+        Assert.assertEquals(str.getDisplayName(), UasDatalinkString.IMAGE_COORDINATE_SYSTEM);
         Assert.assertEquals(str.getBytes(), bytes);
         Assert.assertEquals(str.getDisplayableValue(), "WGS-84");
     }
@@ -117,6 +127,7 @@ public class UasDatalinkStringTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformCallSign, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString str = (UasDatalinkString)v;
+        Assert.assertEquals(str.getDisplayName(), UasDatalinkString.PLATFORM_CALL_SIGN);
         Assert.assertEquals(str.getBytes(), bytes);
         Assert.assertEquals(str.getDisplayableValue(), "TOP GUN");
     }
@@ -129,6 +140,7 @@ public class UasDatalinkStringTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.TargetId, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString str = (UasDatalinkString)v;
+        Assert.assertEquals(str.getDisplayName(), UasDatalinkString.TARGET_ID);
         Assert.assertEquals(str.getBytes(), bytes);
         Assert.assertEquals(str.getDisplayableValue(), "123456");
     }
@@ -140,6 +152,7 @@ public class UasDatalinkStringTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.CommunicationsMethod, bytes);
         Assert.assertTrue(v instanceof UasDatalinkString);
         UasDatalinkString str = (UasDatalinkString)v;
+        Assert.assertEquals(str.getDisplayName(), UasDatalinkString.COMMUNICATIONS_METHOD);
         Assert.assertEquals(str.getBytes(), bytes);
         Assert.assertEquals(str.getDisplayableValue(), "Frequency Modulation");
     }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/VerticalFovTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/VerticalFovTest.java
@@ -26,6 +26,8 @@ public class VerticalFovTest
         Assert.assertEquals(fov.getBytes(), new byte[]{(byte)0xd9, (byte)0x17});
         Assert.assertEquals(fov.getDegrees(), 152.6436);
         Assert.assertEquals(fov.getDisplayableValue(), "152.6436\u00B0");
+
+        Assert.assertEquals(fov.getDisplayName(), "Sensor Vertical Field of View");
     }
 
     @Test
@@ -47,6 +49,8 @@ public class VerticalFovTest
         fov = new VerticalFov(new byte[]{(byte)0xd9, (byte)0x17});
         Assert.assertEquals(fov.getDegrees(), 152.6436, delta);
         Assert.assertEquals(fov.getBytes(), new byte[]{(byte)0xd9, (byte)0x17});
+
+        Assert.assertEquals(fov.getDisplayName(), "Sensor Vertical Field of View");
     }
 
     @Test
@@ -56,6 +60,7 @@ public class VerticalFovTest
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorVerticalFov, bytes);
         Assert.assertTrue(v instanceof VerticalFov);
         VerticalFov fov = (VerticalFov)v;
+        Assert.assertEquals(fov.getDisplayName(), "Sensor Vertical Field of View");
         Assert.assertEquals(fov.getDegrees(), 0.0);
         Assert.assertEquals(fov.getBytes(), new byte[]{(byte)0x00, (byte)0x00});
 
@@ -63,11 +68,13 @@ public class VerticalFovTest
         v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorVerticalFov, bytes);
         Assert.assertTrue(v instanceof VerticalFov);
         fov = (VerticalFov)v;
+        Assert.assertEquals(fov.getDisplayName(), "Sensor Vertical Field of View");
         Assert.assertEquals(fov.getDegrees(), 180.0);
         Assert.assertEquals(fov.getBytes(), new byte[]{(byte)0xff, (byte)0xff});
 
         bytes = new byte[]{(byte)0xd9, (byte)0x17};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorVerticalFov, bytes);
+        Assert.assertEquals(v.getDisplayName(), "Sensor Vertical Field of View");
         Assert.assertTrue(v instanceof VerticalFov);
         fov = (VerticalFov)v;
         Assert.assertEquals(fov.getDegrees(), 152.6436, 0.0001);

--- a/api/src/test/java/org/jmisb/api/klv/st0601/WindDirectionAngleTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/WindDirectionAngleTest.java
@@ -25,6 +25,8 @@ public class WindDirectionAngleTest
         Assert.assertEquals(bytes, new byte[]{(byte)0xA7, (byte)0xC4});
         Assert.assertEquals(angle.getDegrees(), 235.924010);
         Assert.assertEquals("235.9240\u00B0", angle.getDisplayableValue());
+
+        Assert.assertEquals(angle.getDisplayName(), "Wind Direction");
     }
 
     @Test
@@ -48,6 +50,8 @@ public class WindDirectionAngleTest
         bytes = new byte[]{(byte)0x34, (byte)0x9d};
         angle = new WindDirectionAngle(bytes);
         Assert.assertEquals(angle.getBytes(), bytes);
+
+        Assert.assertEquals(angle.getDisplayName(), "Wind Direction");
     }
 
     @Test
@@ -59,6 +63,7 @@ public class WindDirectionAngleTest
         WindDirectionAngle angle = (WindDirectionAngle)v;
         Assert.assertEquals(angle.getDegrees(), 0.0);
         Assert.assertEquals(angle.getBytes(), bytes);
+        Assert.assertEquals(angle.getDisplayName(), "Wind Direction");
 
         bytes = new byte[]{(byte)0xff, (byte)0xff};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.WindDirection, bytes);
@@ -66,6 +71,7 @@ public class WindDirectionAngleTest
         angle = (WindDirectionAngle)v;
         Assert.assertEquals(angle.getDegrees(), 360.0);
         Assert.assertEquals(angle.getBytes(), bytes);
+        Assert.assertEquals(angle.getDisplayName(), "Wind Direction");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/api/src/test/java/org/jmisb/api/klv/st0601/WindSpeedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/WindSpeedTest.java
@@ -20,6 +20,8 @@ public class WindSpeedTest
         // From ST:
         range = new WindSpeed(69.8039216);
         Assert.assertEquals(range.getBytes(), new byte[]{(byte)0xB2});
+
+        Assert.assertEquals(range.getDisplayName(), "Wind Speed");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/video/StreamerUtil.java
+++ b/api/src/test/java/org/jmisb/api/video/StreamerUtil.java
@@ -49,15 +49,15 @@ public class StreamerUtil
         // Sample metadata
         SortedMap<UasDatalinkTag, IUasDatalinkValue> values = new TreeMap<>();
         values.put(UasDatalinkTag.PrecisionTimeStamp, new PrecisionTimeStamp(LocalDateTime.now()));
-        values.put(UasDatalinkTag.MissionId, new UasDatalinkString("Unit Testing"));
-        values.put(UasDatalinkTag.PlatformDesignation, new UasDatalinkString("Thunderbolt"));
-        values.put(UasDatalinkTag.ImageSourceSensor, new UasDatalinkString("DTV"));
-        values.put(UasDatalinkTag.ImageCoordinateSystem, new UasDatalinkString("Geodetic WGS84"));
+        values.put(UasDatalinkTag.MissionId, new UasDatalinkString(UasDatalinkString.MISSION_ID, "Unit Testing"));
+        values.put(UasDatalinkTag.PlatformDesignation, new UasDatalinkString(UasDatalinkString.PLATFORM_DESIGNATION, "Thunderbolt"));
+        values.put(UasDatalinkTag.ImageSourceSensor, new UasDatalinkString(UasDatalinkString.IMAGE_SOURCE_SENSOR, "DTV"));
+        values.put(UasDatalinkTag.ImageCoordinateSystem, new UasDatalinkString(UasDatalinkString.IMAGE_COORDINATE_SYSTEM, "Geodetic WGS84"));
         values.put(UasDatalinkTag.SensorLatitude, new SensorLatitude(42.4036));
         values.put(UasDatalinkTag.SensorLongitude, new SensorLongitude(-71.1284));
         values.put(UasDatalinkTag.SensorTrueAltitude, new SensorTrueAltitude(1258.3));
         values.put(UasDatalinkTag.UasLdsVersionNumber, new ST0601Version((byte)11));
-        values.put(UasDatalinkTag.TargetId, new UasDatalinkString("tango"));
+        values.put(UasDatalinkTag.TargetId, new UasDatalinkString(UasDatalinkString.TARGET_ID, "tango"));
 
         IMisbMessage message;
 

--- a/api/src/test/java/org/jmisb/api/video/VideoFileInputOutputIT.java
+++ b/api/src/test/java/org/jmisb/api/video/VideoFileInputOutputIT.java
@@ -182,10 +182,10 @@ public class VideoFileInputOutputIT
 
                 values.put(UasDatalinkTag.PrecisionTimeStamp, new PrecisionTimeStamp(LocalDateTime.now()));
 
-                values.put(UasDatalinkTag.MissionId, new UasDatalinkString(missionId));
-                values.put(UasDatalinkTag.PlatformDesignation, new UasDatalinkString("Thunderbolt"));
-                values.put(UasDatalinkTag.ImageSourceSensor, new UasDatalinkString("DTV"));
-                values.put(UasDatalinkTag.ImageCoordinateSystem, new UasDatalinkString("Geodetic WGS84"));
+                values.put(UasDatalinkTag.MissionId, new UasDatalinkString(UasDatalinkString.MISSION_ID, missionId));
+                values.put(UasDatalinkTag.PlatformDesignation, new UasDatalinkString(UasDatalinkString.PLATFORM_DESIGNATION, "Thunderbolt"));
+                values.put(UasDatalinkTag.ImageSourceSensor, new UasDatalinkString(UasDatalinkString.IMAGE_SOURCE_SENSOR, "DTV"));
+                values.put(UasDatalinkTag.ImageCoordinateSystem, new UasDatalinkString(UasDatalinkString.IMAGE_SOURCE_SENSOR, "Geodetic WGS84"));
 
                 values.put(UasDatalinkTag.SensorLatitude, new SensorLatitude(sensorLatitude));
                 values.put(UasDatalinkTag.SensorLongitude, new SensorLongitude(sensorLongitude));

--- a/api/src/test/java/org/jmisb/api/video/VideoStreamInputOutputIT.java
+++ b/api/src/test/java/org/jmisb/api/video/VideoStreamInputOutputIT.java
@@ -48,10 +48,10 @@ public class VideoStreamInputOutputIT
         // Sample metadata
         SortedMap<UasDatalinkTag, IUasDatalinkValue> values = new TreeMap<>();
         values.put(UasDatalinkTag.PrecisionTimeStamp, new PrecisionTimeStamp(LocalDateTime.now()));
-        values.put(UasDatalinkTag.MissionId, new UasDatalinkString("Unit Testing"));
-        values.put(UasDatalinkTag.PlatformDesignation, new UasDatalinkString("Thunderbolt"));
-        values.put(UasDatalinkTag.ImageSourceSensor, new UasDatalinkString("DTV"));
-        values.put(UasDatalinkTag.ImageCoordinateSystem, new UasDatalinkString("Geodetic WGS84"));
+        values.put(UasDatalinkTag.MissionId, new UasDatalinkString(UasDatalinkString.MISSION_ID, "Unit Testing"));
+        values.put(UasDatalinkTag.PlatformDesignation, new UasDatalinkString(UasDatalinkString.PLATFORM_DESIGNATION, "Thunderbolt"));
+        values.put(UasDatalinkTag.ImageSourceSensor, new UasDatalinkString(UasDatalinkString.IMAGE_SOURCE_SENSOR, "DTV"));
+        values.put(UasDatalinkTag.ImageCoordinateSystem, new UasDatalinkString(UasDatalinkString.IMAGE_COORDINATE_SYSTEM, "Geodetic WGS84"));
         values.put(UasDatalinkTag.SensorLatitude, new SensorLatitude(42.4036));
         values.put(UasDatalinkTag.SensorLongitude, new SensorLongitude(-71.1284));
         values.put(UasDatalinkTag.SensorTrueAltitude, new SensorTrueAltitude(1258.3));


### PR DESCRIPTION
## Motivation and Context
Allows a tag-specific display name for all tags.
Resolves #42 

Overall, the change is extensive, but simple.

## Description
Implement method on all implementations. Update callers. Update unit tests to verify.

This is a breaking change for the constructor of UasDatalinkString. Now, instead of providing
just the value, you have to say what kind of String it is:

`new UasDatalinkString(UasDatalinkString.MISSION_ID, missionId));`

Constants for all valid String tags have been added to UasDatalinkString.

## How Has This Been Tested?
Unit testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.

