### PR TITLE
Implement LE90 and CE90 target error estimate (Tag 45/46)

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetErrorEstimateCe90.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetErrorEstimateCe90.java
@@ -1,0 +1,44 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Target Error Estimate - CE90 (ST 0601 tag 45)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Circular error 90 (CE90) is the estimated error distance in the horizontal direction.
+ * <p>
+ * Specifies the radius of 90% probability on a plane tangent to the earth’s surface.
+ * <p>
+ * Map 0..(2^16-1) to 0..4095 metres
+ * <p>
+ * Resolution: ~0.0625 metres
+ * </blockquote>
+ */
+public class TargetErrorEstimateCe90 extends UasDatalinkTargetErrorEstimate
+{
+    /**
+     * Create from value
+     *
+     * @param metres The value in metres, in the range [0..4095]
+     */
+    public TargetErrorEstimateCe90(double metres)
+    {
+        super(metres);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes The byte array of length 2
+     */
+    public TargetErrorEstimateCe90(byte[] bytes)
+    {
+        super(bytes);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Target Error CE90";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetErrorEstimateLe90.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetErrorEstimateLe90.java
@@ -1,0 +1,44 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Target Error Estimate - LE90 (ST 0601 tag 46)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Lateral error 90 (LE90) is the estimated error distance in the vertical (or lateral) direction.
+ * <p>
+ * Specifies the interval of 90% probability in the local vertical direction.
+ * <p>
+ * Map 0..(2^16-1) to 0..4095 metres
+ * <p>
+ * Resolution: ~0.0625 metres
+ * </blockquote>
+ */
+public class TargetErrorEstimateLe90 extends UasDatalinkTargetErrorEstimate
+{
+    /**
+     * Create from value
+     *
+     * @param metres The value in metres, in the range [0..4095]
+     */
+    public TargetErrorEstimateLe90(double metres)
+    {
+        super(metres);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes The byte array of length 2
+     */
+    public TargetErrorEstimateLe90(byte[] bytes)
+    {
+        super(bytes);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Target Error LE90";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -117,11 +117,9 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case TargetErrorCe90:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new TargetErrorEstimateCe90(bytes);
             case TargetErrorLe90:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new TargetErrorEstimateLe90(bytes);
             case GenericFlagData01:
                 // TODO
                 return new OpaqueValue(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -97,9 +97,9 @@ public enum UasDatalinkTag
     TargetTrackGateWidth(43),
     /** Tag 44; Tracking gate height (y value) of tracked target within field of view; Value is a {@link OpaqueValue} */
     TargetTrackGateHeight(44),
-    /** Tag 45; Circular error 90 (CE90) is the estimated error distance in the horizontal direction; Value is a {@link OpaqueValue} */
+    /** Tag 45; Circular error 90 (CE90) is the estimated error distance in the horizontal direction; Value is a {@link TargetErrorEstimateCe90} */
     TargetErrorCe90(45),
-    /** Tag 46; Lateral error 90 (LE90) is the estimated error distance in the vertical (or lateral) direction; Value is a {@link OpaqueValue} */
+    /** Tag 46; Lateral error 90 (LE90) is the estimated error distance in the vertical (or lateral) direction; Value is a {@link TargetErrorEstimateLe90} */
     TargetErrorLe90(46),
     /** Tag 47; Generic metadata flags; Value is a {@link OpaqueValue} */
     GenericFlagData01(47),

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTargetErrorEstimate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTargetErrorEstimate.java
@@ -1,0 +1,74 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * Target Error Estimate (used by ST 0601 tag 45 and 46)
+ * <blockquote>
+ * From ST:
+ * <p>
+ * Map 0..(2^16-1) to 0..4095 metres
+ * <p>
+ * Resolution: ~0.0625 metres
+ * </blockquote>
+ */
+public abstract class UasDatalinkTargetErrorEstimate implements IUasDatalinkValue
+{
+    protected static double FLOAT_RANGE = 4095;
+    protected static double INT_RANGE = 65535.0; // (2^16) - 1
+    protected double metres;
+
+    /**
+     * Create from value
+     *
+     * @param metres The value in metres
+     */
+    public UasDatalinkTargetErrorEstimate(double metres)
+    {
+        if ((metres < 0) || (metres > 4095.0))
+        {
+            throw new IllegalArgumentException(getDisplayName() + " must be in range [0,4095]");
+        }
+
+        this.metres = metres;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes The byte array of length 2
+     */
+    public UasDatalinkTargetErrorEstimate(byte[] bytes)
+    {
+        if (bytes.length != 2)
+        {
+            throw new IllegalArgumentException(getDisplayName() + " encoding is a 2-byte unsigned int");
+        }
+
+        int intVal = PrimitiveConverter.toUint16(bytes);
+        this.metres = (intVal / INT_RANGE) * FLOAT_RANGE;
+    }
+
+    /**
+     * Get the value in metres
+     *
+     * @return The error value in metres
+     */
+    public double getMetres()
+    {
+        return metres;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        int val = (int)Math.round((metres / FLOAT_RANGE) * INT_RANGE);
+        return PrimitiveConverter.uint16ToBytes(val);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return String.format("%.4fm", metres);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/TargetErrorEstimateCe90Test.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/TargetErrorEstimateCe90Test.java
@@ -1,0 +1,81 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TargetErrorEstimateCe90Test {
+
+    @Test
+    public void testMinMax()
+    {
+        TargetErrorEstimateCe90 errorEstimate = new TargetErrorEstimateCe90(0.0);
+        byte[] bytes = errorEstimate.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte) 0x00, (byte) 0x00});
+        Assert.assertEquals(errorEstimate.getMetres(), 0.0);
+        Assert.assertEquals("0.0000m", errorEstimate.getDisplayableValue());
+
+        errorEstimate = new TargetErrorEstimateCe90(4095.0);
+        bytes = errorEstimate.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte) 0xff, (byte) 0xff});
+        Assert.assertEquals(errorEstimate.getMetres(), 4095.0);
+        Assert.assertEquals("4095.0000m", errorEstimate.getDisplayableValue());
+
+        bytes = new byte[]{(byte) 0x00, (byte) 0x00};
+        errorEstimate = new TargetErrorEstimateCe90(bytes);
+        Assert.assertEquals(errorEstimate.getMetres(), 0.0);
+        Assert.assertEquals(errorEstimate.getBytes(), bytes);
+
+        bytes = new byte[]{(byte) 0xff, (byte) 0xff};
+        errorEstimate = new TargetErrorEstimateCe90(bytes);
+        Assert.assertEquals(errorEstimate.getMetres(), 4095.0);
+        Assert.assertEquals(errorEstimate.getBytes(), bytes);
+
+        Assert.assertEquals(errorEstimate.getDisplayName(), "Target Error CE90");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte) 0x00, (byte) 0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.TargetErrorCe90, bytes);
+        Assert.assertTrue(v instanceof TargetErrorEstimateCe90);
+        Assert.assertEquals(v.getDisplayName(), "Target Error CE90");
+        TargetErrorEstimateCe90 errorEstimate = (TargetErrorEstimateCe90) v;
+        Assert.assertEquals(errorEstimate.getMetres(), 0.0);
+        Assert.assertEquals(errorEstimate.getBytes(), bytes);
+
+        bytes = new byte[]{(byte) 0xff, (byte) 0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TargetErrorCe90, bytes);
+        Assert.assertTrue(v instanceof TargetErrorEstimateCe90);
+        errorEstimate = (TargetErrorEstimateCe90) v;
+        Assert.assertEquals(errorEstimate.getMetres(), 4095.0);
+        Assert.assertEquals(errorEstimate.getBytes(), bytes);
+
+        bytes = new byte[]{(byte) 0x1A, (byte) 0x95};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TargetErrorCe90, bytes);
+        Assert.assertTrue(v instanceof TargetErrorEstimateCe90);
+        errorEstimate = (TargetErrorEstimateCe90) v;
+        Assert.assertEquals(errorEstimate.getMetres(), 425.215152, 0.00001);
+        Assert.assertEquals(errorEstimate.getBytes(), bytes);
+        Assert.assertEquals(errorEstimate.getDisplayableValue(), "425.2152m");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new TargetErrorEstimateCe90(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new TargetErrorEstimateCe90(4095.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new TargetErrorEstimateCe90(new byte[]{0x00, 0x00, 0x00});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/TargetErrorEstimateLe90Test.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/TargetErrorEstimateLe90Test.java
@@ -1,0 +1,81 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TargetErrorEstimateLe90Test {
+
+    @Test
+    public void testMinMax()
+    {
+        TargetErrorEstimateLe90 errorEstimate = new TargetErrorEstimateLe90(0.0);
+        byte[] bytes = errorEstimate.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte) 0x00, (byte) 0x00});
+        Assert.assertEquals(errorEstimate.getMetres(), 0.0);
+        Assert.assertEquals("0.0000m", errorEstimate.getDisplayableValue());
+
+        errorEstimate = new TargetErrorEstimateLe90(4095.0);
+        bytes = errorEstimate.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte) 0xff, (byte) 0xff});
+        Assert.assertEquals(errorEstimate.getMetres(), 4095.0);
+        Assert.assertEquals("4095.0000m", errorEstimate.getDisplayableValue());
+
+        bytes = new byte[]{(byte) 0x00, (byte) 0x00};
+        errorEstimate = new TargetErrorEstimateLe90(bytes);
+        Assert.assertEquals(errorEstimate.getMetres(), 0.0);
+        Assert.assertEquals(errorEstimate.getBytes(), bytes);
+
+        bytes = new byte[]{(byte) 0xff, (byte) 0xff};
+        errorEstimate = new TargetErrorEstimateLe90(bytes);
+        Assert.assertEquals(errorEstimate.getMetres(), 4095.0);
+        Assert.assertEquals(errorEstimate.getBytes(), bytes);
+
+        Assert.assertEquals(errorEstimate.getDisplayName(), "Target Error LE90");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte) 0x00, (byte) 0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.TargetErrorLe90, bytes);
+        Assert.assertTrue(v instanceof TargetErrorEstimateLe90);
+        Assert.assertEquals(v.getDisplayName(), "Target Error LE90");
+        TargetErrorEstimateLe90 errorEstimate = (TargetErrorEstimateLe90) v;
+        Assert.assertEquals(errorEstimate.getMetres(), 0.0);
+        Assert.assertEquals(errorEstimate.getBytes(), bytes);
+
+        bytes = new byte[]{(byte) 0xff, (byte) 0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TargetErrorLe90, bytes);
+        Assert.assertTrue(v instanceof TargetErrorEstimateLe90);
+        errorEstimate = (TargetErrorEstimateLe90) v;
+        Assert.assertEquals(errorEstimate.getMetres(), 4095.0);
+        Assert.assertEquals(errorEstimate.getBytes(), bytes);
+
+        bytes = new byte[]{(byte) 0x26, (byte) 0x11};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TargetErrorLe90, bytes);
+        Assert.assertTrue(v instanceof TargetErrorEstimateLe90);
+        errorEstimate = (TargetErrorEstimateLe90) v;
+        Assert.assertEquals(errorEstimate.getMetres(), 608.9231, 0.0001);
+        Assert.assertEquals(errorEstimate.getBytes(), bytes);
+        Assert.assertEquals(errorEstimate.getDisplayableValue(), "608.9231m");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new TargetErrorEstimateLe90(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new TargetErrorEstimateLe90(4095.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new TargetErrorEstimateLe90(new byte[]{0x00, 0x00, 0x00});
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Implements missing KLV tags for target error estimates.

## Description
Implementation uses shared superclass - the semantics between these values are quite different, although the value mapping is the same.

Includes changes to factory method and unit tests.

## How Has This Been Tested?
Unit tests.
Used viewer application on one of the MISB First Level Integration tests to check display.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

