### PR TITLE
Add support for Airfield Elevation (Tag 54).

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/AirfieldElevation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AirfieldElevation.java
@@ -1,0 +1,43 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Airfield Elevation (ST 0601 tag 69)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Elevation of airfield corresponding to Airfield Barometric Pressure.
+ * <p>
+ * Airfield Elevation is measured at the airfield location. This relates to the
+ * Airfield Barometric Pressure metadata item.
+ * <p>
+ * Map 0..(2^16-1) to -900..19000 meters.
+ * <p>
+ * Resolution: ~0.3 meters.
+ * </blockquote>
+ */
+public class AirfieldElevation extends UasDatalinkAltitude
+{
+    /**
+     * Create from value
+     * @param meters Altitude in meters. Legal values are in [-900,19000].
+     */
+    public AirfieldElevation(double meters)
+    {
+        super(meters);
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes The byte array of length 2
+     */
+    public AirfieldElevation(byte[] bytes)
+    {
+        super(bytes);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Airfield Elevation";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -134,8 +134,7 @@ public class UasDatalinkFactory
             case AirfieldBarometricPressure:
                 return new AirfieldBarometricPressure(bytes);
             case AirfieldElevation:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new AirfieldElevation(bytes);
             case RelativeHumidity:
                 return new RelativeHumidity(bytes);
             case PlatformGroundSpeed:

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -115,7 +115,7 @@ public enum UasDatalinkTag
     PlatformSideslipAngle(52),
     /** Tag 53; Local pressure at airfield of known height; Value is a {@link AirfieldBarometricPressure} */
     AirfieldBarometricPressure(53),
-    /** Tag 54; Elevation of airfield corresponding to Airfield Barometric Pressure; Value is a {@link OpaqueValue} */
+    /** Tag 54; Elevation of airfield corresponding to Airfield Barometric Pressure; Value is a {@link AirfieldElevation} */
     AirfieldElevation(54),
     /** Tag 55; Relative humidity at aircraft location; Value is a {@link RelativeHumidity} */
     RelativeHumidity(55),

--- a/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkAltitudeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkAltitudeTest.java
@@ -38,6 +38,19 @@ public class UasDatalinkAltitudeTest
         Assert.assertEquals(altitude.getDisplayableValue(), "14818.7m");
         Assert.assertEquals(altitude.getDisplayName(), "Density Altitude");
 
+        // Airfield Elevation
+        altitude = new AirfieldElevation(8306.80552);
+        Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x76, (byte)0x70});
+        Assert.assertEquals(altitude.getMeters(), 8306.80552);
+        Assert.assertEquals(altitude.getDisplayableValue(), "8306.8m");
+        Assert.assertEquals(altitude.getDisplayName(), "Airfield Elevation");
+
+        altitude = new AirfieldElevation(new byte[]{(byte)0x76, (byte)0x70});
+        Assert.assertEquals(altitude.getMeters(), 8306.80552, delta);
+        Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x76, (byte)0x70});
+        Assert.assertEquals(altitude.getDisplayableValue(), "8306.8m");
+        Assert.assertEquals(altitude.getDisplayName(), "Airfield Elevation");
+
         // Alternate Platform Altitude
         altitude = new AlternatePlatformAltitude(9.445334);
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x0b, (byte)0xb3});
@@ -100,6 +113,18 @@ public class UasDatalinkAltitudeTest
         Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0xca, (byte)0x35});
         Assert.assertEquals(altitude.getDisplayableValue(), "14818.7m");
         Assert.assertEquals(altitude.getDisplayName(), "Density Altitude");
+    }
+
+    @Test
+    public void testFactoryAirfieldElevation() throws KlvParseException {
+        byte[] bytes = new byte[]{(byte)0x76, (byte)0x70};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.AirfieldElevation, bytes);
+        Assert.assertTrue(v instanceof AirfieldElevation);
+        AirfieldElevation altitude = (AirfieldElevation)v;
+        Assert.assertEquals(altitude.getMeters(), 8306.80552, delta);
+        Assert.assertEquals(altitude.getBytes(), new byte[]{(byte)0x76, (byte)0x70});
+        Assert.assertEquals(altitude.getDisplayableValue(), "8306.8m");
+        Assert.assertEquals(altitude.getDisplayName(), "Airfield Elevation");
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
Adds support for a missing ST0601 tag.

## Description
This is really just another example of UasDatalinkAltitude, so just implements that superclass, and adds corresponding tests and factory method implementation.

## How Has This Been Tested?
Unit tests, plus the viewer application on MISB test data that uses this tag.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

