### PR TITLE
Implement ST0601 IMAPB tags

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformEllipsoidHeightExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformEllipsoidHeightExtended.java
@@ -1,0 +1,48 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Alternate Platform Ellipsoid Height Extended (ST 0601 tag 105)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Alternate platform ellipsoid height extended as measured from the reference
+ * WGS84 ellipsoid.
+ * <p>
+ * Resolution: 2 bytes = 2 meters, 3 bytes = 78.125 mm
+ * <p>
+ * Max Altitude: 40,000m for airborne systems
+ * <p>
+ * The purpose of Alternate Platform Ellipsoid Height Extended is to increase the
+ * range of altitude values currently defined in Tag 76 Alternate Platform
+ * Ellipsoid Height to support all CONOPs for airborne systems.
+ * </blockquote>
+ */
+public class AlternatePlatformEllipsoidHeightExtended extends UasDatalinkAltitudeExtended
+{
+    /**
+     * Create from value
+     *
+     * @param meters Ellipsoid height in meters. Valid range is [-900,40000]
+     */
+    public AlternatePlatformEllipsoidHeightExtended(double meters)
+    {
+        super(meters);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 8 bytes maximum
+     */
+    public AlternatePlatformEllipsoidHeightExtended(byte[] bytes)
+    {
+        super(bytes, 8);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Alternate Platform Ellipsoid Height";
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AltitudeAGL.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AltitudeAGL.java
@@ -1,0 +1,46 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Altitude AGL (ST 0601 tag 113).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Above Ground Level (AGL) height above the ground/water.
+ * <p>
+ * Max Altitude: 40,000m for airborne systems
+ * <p>
+ * Resolution: 2 bytes = 2.0 meters, 3 bytes = 0.7 cm
+ * <p>
+ * Altitude - AGL (Above Ground Level) is the distance measured from the ground
+ * (or terrain) to the aircraft.
+ * </blockquote>
+ */
+public class AltitudeAGL extends UasDatalinkAltitudeExtended
+{
+    /**
+     * Create from value
+     *
+     * @param meters Altitude in meters. Valid range is [-900,40000]
+     */
+    public AltitudeAGL(double meters)
+    {
+        super(meters);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 4 bytes maximum
+     */
+    public AltitudeAGL(byte[] bytes)
+    {
+        super(bytes, 4);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Altitude AGL";
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/DensityAltitudeExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/DensityAltitudeExtended.java
@@ -1,0 +1,45 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Density Altitude Extended (ST 0601 tag 103)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Density altitude above MSL at aircraft location.
+ * <p>
+ * Relative aircraft performance metric based on outside air temperature, static pressure, and humidity
+ * <p>
+ * Max Altitude: 40,000m for airborne systems
+ * <p>
+ * The purpose of Density Altitude Extended is to increase the range of altitude
+ * values currently defined in Tag 38 Density Altitude to support all CONOPs for
+ * airborne systems.
+ * </blockquote>
+ */
+public class DensityAltitudeExtended extends UasDatalinkAltitudeExtended
+{
+    /**
+     * Create from value
+     *
+     * @param meters Altitude in meters. Valid range is [-900,40000]
+     */
+    public DensityAltitudeExtended(double meters) {
+        super(meters);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 8 bytes maximum
+     */
+    public DensityAltitudeExtended(byte[] bytes) {
+        super(bytes, 8);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Density Altitude";
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/OnBoardMiStoragePercentFull.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/OnBoardMiStoragePercentFull.java
@@ -1,0 +1,82 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.klv.st1201.FpEncoder;
+
+/**
+ * On-board MI Storage Percent Full (Tag 120).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Amount of on-board Motion Imagery storage used as a percentage of the total storage
+ * <p>
+ * Used with "On-board MI Storage Capacity" (Tag 133), if available, to determine
+ * remaining recording storage space.
+ * <p>
+ * Resolution: 2 bytes = 0.004 percent,  3 bytes = 1.5E-5 percent
+ * </blockquote>
+ */
+public class OnBoardMiStoragePercentFull implements IUasDatalinkValue
+{
+    private static double MIN_VAL = 0.0;
+    private static double MAX_VAL = 100.0;
+    private static int RECOMMENDED_BYTES = 2;
+    private static int MAX_BYTES = 3;
+    private double percentage;
+
+    /**
+     * Create from value
+     *
+     * @param percentage MI storage level. Valid range is [0,100]
+     */
+    public OnBoardMiStoragePercentFull(double percentage)
+    {
+        if (percentage < MIN_VAL || percentage > MAX_VAL)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " must be in range [0,100]");
+        }
+        this.percentage = percentage;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, max length three bytes
+     */
+    public OnBoardMiStoragePercentFull(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " cannot be longer than " + MAX_BYTES + " bytes");
+        }
+        FpEncoder decoder = new FpEncoder(MIN_VAL, MAX_VAL, bytes.length);
+        this.percentage = decoder.decode(bytes);
+    }
+
+    /**
+     * Get percentage.
+     * @return the percentage of storage that has been used
+     */
+    public double getPercentage()
+    {
+        return this.percentage;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        FpEncoder encoder = new FpEncoder(MIN_VAL, MAX_VAL, RECOMMENDED_BYTES);
+        return encoder.encode(this.percentage);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+         return String.format("%.001f%%", this.percentage);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "On-board MI Storage Percent Full";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformCourseAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformCourseAngle.java
@@ -1,0 +1,89 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.klv.st1201.FpEncoder;
+
+/**
+ * Platform Course Angle (ST 0601 tag 112)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Direction the aircraft is moving relative to True North.
+ * <p>
+ * Resolution: 2 bytes = 16.625 milli-degrees
+ * <p>
+ * Length is variable based on users desired accuracy.
+ * <p>
+ * 0 (or 360) is true north, east is 90, south is 180, west is 270
+ * <p>
+ * The Platform Course is the direction the platform is moving (not necessarily
+ * the direction the platform is pointing).
+ * <p>
+ * Platform Course is directly measurable by on-board navigation or estimated
+ * computationally by comparing the last known position to current position.
+ * </blockquote>
+ */
+public class PlatformCourseAngle implements IUasDatalinkValue {
+
+    private static double MIN_VAL = 0.0;
+    private static double MAX_VAL = 360.0;
+    private static int RECOMMENDED_BYTES = 2;
+    private static int MAX_BYTES = 8;
+    private double angle;
+
+    /**
+     * Create from value
+     *
+     * @param angle the course angle in degrees. Valid range is [0, 360]
+     */
+    public PlatformCourseAngle(double angle)
+    {
+        if (angle < MIN_VAL || angle > MAX_VAL)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " must be in range [0,360]");
+        }
+        this.angle = angle;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array
+     */
+    public PlatformCourseAngle(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " cannot be longer than " + MAX_BYTES + " bytes");
+        }
+        FpEncoder decoder = new FpEncoder(MIN_VAL, MAX_VAL, bytes.length);
+        this.angle = decoder.decode(bytes);
+    }
+
+    /**
+     * Get the platform course angle
+     * @return The platform course angle in degrees
+     */
+    public double getAngle()
+    {
+        return this.angle;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        FpEncoder encoder = new FpEncoder(MIN_VAL, MAX_VAL, RECOMMENDED_BYTES);
+        return encoder.encode(this.angle);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return String.format("%.3f\u00B0", this.angle);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Platform Course Angle";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/RadarAltimeter.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/RadarAltimeter.java
@@ -1,0 +1,43 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Radar Altimeter (ST 0601 tag 114).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Height above the ground/water as reported by a RADAR altimeter.
+ * <p>
+ * Max Altitude: 40,000m for airborne systems
+ * <p>
+ * Resolution: 2 bytes = 2.0 meters, 3 bytes = 0.7 cm
+ * </blockquote>
+ */
+public class RadarAltimeter extends UasDatalinkAltitudeExtended
+{
+    /**
+     * Create from value
+     *
+     * @param meters Altitude in meters. Valid range is [-900,40000]
+     */
+    public RadarAltimeter(double meters)
+    {
+        super(meters);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 4 bytes maximum
+     */
+    public RadarAltimeter(byte[] bytes)
+    {
+        super(bytes, 4);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Radar Altimeter";
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/RangeToRecoveryLocation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/RangeToRecoveryLocation.java
@@ -1,0 +1,84 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.klv.st1201.FpEncoder;
+
+/**
+ * Range To Recovery Location (Tag 109).
+ * From ST:
+ * <blockquote>
+ * Distance from current position to airframe recovery position.
+ * <p>
+ * The Range To Recovery Location is the minimum distance from the current
+ * aircraft position to the aircraft recovery position. The distance is computed
+ * over the surface of the earth at the given altitude of the aircraft (i.e.,
+ * not a straight-line distance potentially through the earth). The furtherst
+ * distance is a point on the opposite side of the earth, at the given altitude.
+ * <p>
+ * Resolution: 2 bytes = 1 KM, 3 bytes = 3.9 meters, 4 bytes = 1.525 cm
+ * </blockquote>
+ */
+public class RangeToRecoveryLocation implements IUasDatalinkValue
+{
+    private static double MIN_VAL = 0.0;
+    private static double MAX_VAL = 21000.0;
+    private static int RECOMMENDED_BYTES = 3;
+    private static int MAX_BYTES = 4;
+    private double range;
+
+    /**
+     * Create from value
+     *
+     * @param range range to recovery location in km. Valid range is [0..21000]
+     */
+    public RangeToRecoveryLocation(double range)
+    {
+        if (range < MIN_VAL || range > MAX_VAL)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " must be in range [0,21000]");
+        }
+        this.range = range;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array
+     */
+    public RangeToRecoveryLocation(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " cannot be longer than " + MAX_BYTES + " bytes");
+        }
+        FpEncoder decoder = new FpEncoder(MIN_VAL, MAX_VAL, bytes.length);
+        this.range = decoder.decode(bytes);
+    }
+
+    /**
+     * Get range.
+     * @return the range in kilometres
+     */
+    public double getRange()
+    {
+        return this.range;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        FpEncoder encoder = new FpEncoder(MIN_VAL, MAX_VAL, RECOMMENDED_BYTES);
+        return encoder.encode(this.range);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+         return String.format("%.3fkm", this.range);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Range to Recovery Location";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorAngleRate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorAngleRate.java
@@ -1,0 +1,69 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.klv.st1201.FpEncoder;
+
+/**
+ * Shared implementation of Sensor Angle Rate.
+ * <p>
+ * This is used by Sensor Azimuth Rate, Sensor Elevation Rate, and Sensor Roll
+ * Rate (ST 0601 tag 117, 118 and 119).
+ */
+public abstract class SensorAngleRate implements IUasDatalinkValue
+{
+    private static double MIN_VAL = -1000.0;
+    private static double MAX_VAL = 1000.0;
+    private static int RECOMMENDED_BYTES = 3;
+    private static int MAX_BYTES = 4;
+    private double angleRate;
+
+    /**
+     * Create from value
+     *
+     * @param rate Sensor angle rate in degrees per second. Valid range is [-1000,1000]
+     */
+    public SensorAngleRate(double rate)
+    {
+        if (rate < MIN_VAL || rate > MAX_VAL)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " must be in range [-1000,1000]");
+        }
+        this.angleRate = rate;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 4 bytes maximum
+     */
+    public SensorAngleRate(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " cannot be longer than " + MAX_BYTES + " bytes");
+        }
+        FpEncoder decoder = new FpEncoder(MIN_VAL, MAX_VAL, bytes.length);
+        this.angleRate = decoder.decode(bytes);
+    }
+
+    /**
+     * Get the sensor angle rate
+     * @return The density altitude in meters
+     */
+    public double getAngleRate()
+    {
+        return this.angleRate;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        FpEncoder encoder = new FpEncoder(MIN_VAL, MAX_VAL, RECOMMENDED_BYTES);
+        return encoder.encode(this.angleRate);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return String.format("%.3f dps", this.angleRate);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorAzimuthRate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorAzimuthRate.java
@@ -1,0 +1,45 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Sensor Azimuth Rate (ST0601 Tag 117)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * The rate the sensors azimuth angle is changing.
+ * <p>
+ * Resolution: 2 bytes = 0.0625 degrees/second, 3 bytes = 0.000244 degrees/second
+ * <p>
+ * Uses the same orientation as Sensor Relative Azimuth Angle (Tag 18) Refer to
+ * Tag 18's diagram: From above the aircraft looking down, when the sensor is
+ * moving clockwise the rate is positive and negative when its moving
+ * counter-clockwise.
+ * </blockquote>
+ */
+public class SensorAzimuthRate extends SensorAngleRate
+{
+    /**
+     * Create from value
+     *
+     * @param rate Sensor angle rate in degrees per second. Valid range is [-1000,1000]
+     */
+    public SensorAzimuthRate(double rate)
+    {
+        super(rate);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 4 bytes maximum
+     */
+    public SensorAzimuthRate(byte[] bytes)
+    {
+        super(bytes);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Sensor Azimuth Rate";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorElevationRate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorElevationRate.java
@@ -1,0 +1,45 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Sensor Elevation Rate (ST0601 Tag 118)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * The rate the sensors elevation angle is changing.
+ * <p>
+ * Resolution: 2 bytes = 0.0625 degrees/second, 3 bytes = 0.000244 degrees/second
+ * <p>
+ * Uses the same orientation as Sensor Relative Elevation Angle (Tag 19). Refer
+ * to Tag 19's diagram: From the side view of the aircraft shown, when the
+ * sensor is moving clockwise the rate is positive and negative when its moving
+ * counter-clockwise.
+ * </blockquote>
+ */
+public class SensorElevationRate extends SensorAngleRate
+{
+    /**
+     * Create from value
+     *
+     * @param rate Sensor angle rate in degrees per second. Valid range is [-1000,1000]
+     */
+    public SensorElevationRate(double rate)
+    {
+        super(rate);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 4 bytes maximum
+     */
+    public SensorElevationRate(byte[] bytes)
+    {
+        super(bytes);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Sensor Elevation Rate";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorEllipsoidHeightExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorEllipsoidHeightExtended.java
@@ -1,0 +1,47 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Sensor Ellipsoid Height Extended (ST 0601 tag 104)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Sensor ellipsoid height extended as measured from the reference WGS84 ellipsoid.
+ * <p>
+ * Max Altitude: 40,000m for airborne systems
+ * <p>
+ * Resolution: 2 bytes = 2 meters, 3 bytes = 78.125 mm
+ * <p>
+ * The purpose of Sensor Ellipsoid Height Extended is to increase the range of
+ * altitude values currently defined in Tag 75 Sensor Ellipsoid Height to support
+ * all CONOPs for airborne systems.
+ * </blockquote>
+ */
+public class SensorEllipsoidHeightExtended extends UasDatalinkAltitudeExtended
+{
+    /**
+     * Create from value
+     *
+     * @param meters Ellipsoid height in meters. Valid range is [-900,40000]
+     */
+    public SensorEllipsoidHeightExtended(double meters)
+    {
+        super(meters);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 8 bytes maximum
+     */
+    public SensorEllipsoidHeightExtended(byte[] bytes)
+    {
+        super(bytes, 8);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor Ellipsoid Height";
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorRollRate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorRollRate.java
@@ -1,0 +1,46 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Sensor Roll Rate (ST0601 Tag 119)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * The rate the sensors roll angle is changing.
+ * <p>
+ * Resolution: 2 bytes = 0.0625 degrees/second, 3 bytes = 0.000244 degrees/second
+ * <p>
+ * Uses the same orientation as Sensor Relative Roll Angle (Tag 20). Refer to
+ * Tag 20's description: From behind the sensor, when the sensor is moving
+ * clockwise the rate is positive and negative when its moving
+ * counter-clockwise.
+ * </blockquote>
+ */
+public class SensorRollRate extends SensorAngleRate
+{
+    /**
+     * Create from value
+     *
+     * @param rate Sensor angle rate in degrees per second. Valid range is [-1000,1000]
+     */
+    public SensorRollRate(double rate)
+    {
+        super(rate);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 4 bytes maximum
+     */
+    public SensorRollRate(byte[] bytes)
+    {
+        super(bytes);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Sensor Roll Rate";
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetWidthExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetWidthExtended.java
@@ -1,0 +1,83 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.klv.st1201.FpEncoder;
+
+/**
+ * Target Width Extended (ST 0601 tag 96)
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Target width within sensor field of view.
+ * <p>
+ * Resolution: 2 bytes = 64 meters, 3 bytes = 0.25 meters
+ * <p>
+ * Range of 0 to 1,500,000 m established as maximum distance visible from an
+ * altitude of 40,000 m.
+ * </blockquote>
+ */
+public class TargetWidthExtended implements IUasDatalinkValue
+{
+    private double metres;
+    private static double MIN_VAL = 0.0;
+    private static double MAX_VAL = 1500000.0;
+    private static int RECOMMENDED_BYTES = 3;
+    private static int MAX_BYTES = 8;
+
+    /**
+     * Create from value
+     *
+     * @param meters Target width, in meters. Valid range is [0,1500000]
+     */
+    public TargetWidthExtended(double meters)
+    {
+        if (meters < MIN_VAL || meters > MAX_VAL) {
+            throw new IllegalArgumentException(this.getDisplayName() + " must be in range [0,1500000]");
+        }
+        this.metres = meters;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 8 bytes maximum
+     */
+    public TargetWidthExtended(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " cannot be longer than " + MAX_BYTES + " bytes");
+        }
+        FpEncoder decoder = new FpEncoder(MIN_VAL, MAX_VAL, bytes.length);
+        metres = decoder.decode(bytes);
+    }
+
+    /**
+     * Get the value in meters
+     *
+     * @return Target width in meters
+     */
+    public double getMeters()
+    {
+        return metres;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        FpEncoder encoder = new FpEncoder(MIN_VAL, MAX_VAL, RECOMMENDED_BYTES);
+        return encoder.encode(metres);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return String.format("%.1fm", metres);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Target Width Extended";
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TransmissionFrequency.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TransmissionFrequency.java
@@ -1,0 +1,82 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.klv.st1201.FpEncoder;
+
+/**
+ * Transmission Frequency (Tag 132).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Radio frequency used to transmit the Motion Imagery
+ * <p>
+ * Resolution: 2 bytes = 4 MHz, 3 bytes = 15.625 KHz
+ * <p>
+ * The Radio Frequency used to transmit the UAS Motion Imagery from the platform
+ * to the ground station or satellite uplink.
+ * </blockquote>
+ */
+public class TransmissionFrequency implements IUasDatalinkValue
+{
+    private static double MIN_VAL = 1.0;
+    private static double MAX_VAL = 99999.0;
+    private static int RECOMMENDED_BYTES = 3;
+    private static int MAX_BYTES = 4;
+    private double frequency;
+
+    /**
+     * Create from value
+     *
+     * @param frequency transmission frequency in MHz. Valid range is [1,99999]
+     */
+    public TransmissionFrequency(double frequency)
+    {
+        if (frequency < MIN_VAL || frequency > MAX_VAL)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " must be in range [1,99999]");
+        }
+        this.frequency = frequency;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array
+     */
+    public TransmissionFrequency(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " cannot be longer than " + MAX_BYTES + " bytes");
+        }
+        FpEncoder decoder = new FpEncoder(MIN_VAL, MAX_VAL, bytes.length);
+        this.frequency = decoder.decode(bytes);
+    }
+
+    /**
+     * Get frequency.
+     * @return the transmission frequency in MHz
+     */
+    public double getFrequency()
+    {
+        return this.frequency;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        FpEncoder encoder = new FpEncoder(MIN_VAL, MAX_VAL, RECOMMENDED_BYTES);
+        return encoder.encode(this.frequency);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+         return String.format("%.2fMHz", this.frequency);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Transmission Frequency";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitudeExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitudeExtended.java
@@ -1,0 +1,71 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.klv.st1201.FpEncoder;
+
+/**
+ * Shared implementation of IMAPB encoded altitude.
+ * <p>
+ * Used by Alternate Platform Ellipsoid Height Extended (ST 0601 tag 105),
+ * Altitude AGL (ST 0601 tag 113), Density Altitude Extended (ST 0601 tag 103),
+ * Radar Altimeter (ST 0601 tag 114) and Sensor Ellipsoid Height Extended (ST
+ * 0601 tag 104).
+ */
+public abstract class UasDatalinkAltitudeExtended implements IUasDatalinkValue
+{
+    protected static double MIN_VAL = -900.0;
+    protected static double MAX_VAL = 40000.0;
+    protected static int RECOMMENDED_BYTES = 3;
+    private double metres;
+
+    /**
+     * Create from value
+     *
+     * @param meters Altitude in meters. Valid range is [-900,40000]
+     */
+    public UasDatalinkAltitudeExtended(double meters)
+    {
+        if (meters < MIN_VAL || meters > MAX_VAL)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " must be in range [0,40000]");
+        }
+        this.metres = meters;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array
+     * @param maxBytes the maximum length of the array that is allowed (typically 8, sometimes 4)
+     */
+    public UasDatalinkAltitudeExtended(byte[] bytes, int maxBytes)
+    {
+        if (bytes.length > maxBytes)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " cannot be longer than " + maxBytes + " bytes");
+        }
+        FpEncoder decoder = new FpEncoder(MIN_VAL, MAX_VAL, bytes.length);
+        metres = decoder.decode(bytes);
+    }
+
+    /**
+     * Get the altitude
+     * @return The density altitude in meters
+     */
+    public double getMeters()
+    {
+        return this.metres;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        FpEncoder encoder = new FpEncoder(MIN_VAL, MAX_VAL, RECOMMENDED_BYTES);
+        return encoder.encode(metres);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return String.format("%.1fm", this.metres);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -225,8 +225,7 @@ public class UasDatalinkFactory
                 // TODO Implement ST 1206
                 return new OpaqueValue(bytes);
             case TargetWidthExtended:
-                // TODO IMAPB - does this mean ST1201?
-                return new OpaqueValue(bytes);
+                return new TargetWidthExtended(bytes);
             case RangeImage:
                 // TODO Implement ST 1002
                 return new OpaqueValue(bytes);
@@ -246,11 +245,11 @@ public class UasDatalinkFactory
                 // TODO Implement ST 1010
                 return new OpaqueValue(bytes);
             case DensityAltitudeExtended:
-                return new OpaqueValue(bytes);
+                return new DensityAltitudeExtended(bytes);
             case SensorEllipsoidHeightExtended:
-                return new OpaqueValue(bytes);
+                return new SensorEllipsoidHeightExtended(bytes);
             case AlternatePlatformEllipsoidHeightExtended:
-                return new OpaqueValue(bytes);
+                return new AlternatePlatformEllipsoidHeightExtended(bytes);
             case StreamDesignator:
                 return new UasDatalinkString(UasDatalinkString.STREAM_DESIGNATOR, bytes);
             case OperationalBase:
@@ -258,8 +257,7 @@ public class UasDatalinkFactory
             case BroadcastSource:
                 return new UasDatalinkString(UasDatalinkString.BROADCAST_SOURCE, bytes);
             case RangeToRecoveryLocation:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new RangeToRecoveryLocation(bytes);
             case TimeAirborne:
                 // TODO
                 return new OpaqueValue(bytes);
@@ -267,14 +265,11 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case PlatformCourseAngle:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new PlatformCourseAngle(bytes);
             case AltitudeAgl:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new AltitudeAGL(bytes);
             case RadarAltimeter:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new RadarAltimeter(bytes);
             case ControlCommand:
                 // TODO
                 return new OpaqueValue(bytes);
@@ -282,17 +277,13 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case SensorAzimuthRate:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new SensorAzimuthRate(bytes);
             case SensorElevationRate:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new SensorElevationRate(bytes);
             case SensorRollRate:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new SensorRollRate(bytes);
             case OnBoardMiStoragePercentFull:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new OnBoardMiStoragePercentFull(bytes);
             case ActiveWavelengthList:
                 // TODO
                 return new OpaqueValue(bytes);
@@ -322,13 +313,11 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case TransmissionFrequency:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new TransmissionFrequency(bytes);
             case OnBoardMiStorageCapacity:
                 return new OnBoardMiStorageCapacity(bytes);
             case ZoomPercentage:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new ZoomPercentage(bytes);
             case CommunicationsMethod:
                 return new UasDatalinkString(UasDatalinkString.COMMUNICATIONS_METHOD, bytes);
             case LeapSeconds:

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -199,7 +199,7 @@ public enum UasDatalinkTag
     MiisCoreIdentifier(94),
     /** Tag 95; MISB ST 1206 SAR Motion Imagery Metadata Local Set metadata items; Value is a {@link OpaqueValue} */
     SarMotionImageryMetadata(95),
-    /** Tag 96; Target width within sensor field of view; Value is a {@link OpaqueValue} */
+    /** Tag 96; Target width within sensor field of view; Value is a {@link TargetWidthExtended} */
     TargetWidthExtended(96),
     /** Tag 97; MISB ST 1002 Range Imaging Local Set metadata items; Value is a {@link OpaqueValue} */
     RangeImage(97),
@@ -213,11 +213,11 @@ public enum UasDatalinkTag
     Amend(101),
     /** Tag 102; MISB ST 1010 Floating Length Pack (FLP) metadata item, providing Standard Deviation and Cross Correlation (SDCC) metadata; Value is a {@link OpaqueValue} */
     SdccFlp(102),
-    /** Tag 103; Density altitude above MSL at aircraft location; Value is a {@link OpaqueValue} */
+    /** Tag 103; Density altitude above MSL at aircraft location; Value is a {@link DensityAltitudeExtended} */
     DensityAltitudeExtended(103),
-    /** Tag 104; Sensor ellipsoid height extended as measured from the reference WGS84 ellipsoid; Value is a {@link OpaqueValue} */
+    /** Tag 104; Sensor ellipsoid height extended as measured from the reference WGS84 ellipsoid; Value is a {@link SensorEllipsoidHeightExtended} */
     SensorEllipsoidHeightExtended(104),
-    /** Tag 105; Alternate platform ellipsoid height extended as measured from the reference WGS84 ellipsoid; Value is a {@link OpaqueValue} */
+    /** Tag 105; Alternate platform ellipsoid height extended as measured from the reference WGS84 ellipsoid; Value is a {@link AlternatePlatformEllipsoidHeightExtended} */
     AlternatePlatformEllipsoidHeightExtended(105),
     /** Tag 106; A second designation given to a sortie; Value is a {@link UasDatalinkString} */
     StreamDesignator(106),
@@ -225,29 +225,29 @@ public enum UasDatalinkTag
     OperationalBase(107),
     /** Tag 108; Name of the source, where the Motion Imagery is first broadcast; Value is a {@link UasDatalinkString} */
     BroadcastSource(108),
-    /** Tag 109; Distance from current position to airframe recovery position; Value is a {@link UasDatalinkString} */
+    /** Tag 109; Distance from current position to airframe recovery position; Value is a {@link RangeToRecoveryLocation} */
     RangeToRecoveryLocation(109),
     /** Tag 110; Number of seconds aircraft has been airborne; Value is a {@link OpaqueValue} */
     TimeAirborne(110),
     /** Tag 111; The speed the engine (or electric motor) is rotating at; Value is a {@link OpaqueValue} */
     PropulsionUnitSpeed(111),
-    /** Tag 112; Direction the aircraft is moving relative to True North; Value is a {@link OpaqueValue} */
+    /** Tag 112; Direction the aircraft is moving relative to True North; Value is a {@link PlatformCourseAngle} */
     PlatformCourseAngle(112),
-    /** Tag 113; Above Ground Level (AGL) height above the ground/water; Value is a {@link OpaqueValue} */
+    /** Tag 113; Above Ground Level (AGL) height above the ground/water; Value is a {@link AltitudeAGL} */
     AltitudeAgl(113),
-    /** Tag 114; Height above the ground/water as reported by a RADAR altimeter; Value is a {@link OpaqueValue} */
+    /** Tag 114; Height above the ground/water as reported by a RADAR altimeter; Value is a {@link RadarAltimeter} */
     RadarAltimeter(114),
     /** Tag 115; Record of command from GCS to Aircraft; Value is a {@link OpaqueValue} */
     ControlCommand(115),
     /** Tag 116; Acknowledgement of one or more control commands were received by the platform; Value is a {@link OpaqueValue} */
     ControlCommandVerification(116),
-    /** Tag 117; The rate the sensors azimuth angle is changing; Value is a {@link OpaqueValue} */
+    /** Tag 117; The rate the sensors azimuth angle is changing; Value is a {@link SensorAzimuthRate} */
     SensorAzimuthRate(117),
-    /** Tag 118; The rate the sensors elevation angle is changing; Value is a {@link OpaqueValue} */
+    /** Tag 118; The rate the sensors elevation angle is changing; Value is a {@link SensorElevationRate} */
     SensorElevationRate(118),
-    /** Tag 119; The rate the sensors roll angle is changing; Value is a {@link OpaqueValue} */
+    /** Tag 119; The rate the sensors roll angle is changing; Value is a {@link SensorRollRate} */
     SensorRollRate(119),
-    /** Tag 120; Amount of on-board Motion Imagery storage used as a percentage of the total storage; Value is a {@link OpaqueValue} */
+    /** Tag 120; Amount of on-board Motion Imagery storage used as a percentage of the total storage; Value is a {@link OnBoardMiStoragePercentFull} */
     OnBoardMiStoragePercentFull(120),
     /** Tag 121; List of wavelengths in Motion Imagery; Value is a {@link OpaqueValue} */
     ActiveWavelengthList(121),
@@ -271,11 +271,11 @@ public enum UasDatalinkTag
     AirbaseLocations(130),
     /** Tag 131; Time when aircraft became airborne; Value is a {@link OpaqueValue} */
     TakeOffTime(131),
-    /** Tag 132; Radio frequency used to transmit the Motion Imagery; Value is a {@link OpaqueValue} */
+    /** Tag 132; Radio frequency used to transmit the Motion Imagery; Value is a {@link TransmissionFrequency} */
     TransmissionFrequency(132),
     /** Tag 133; The total capacity of on-board Motion Imagery storage; Value is a {@link OnBoardMiStorageCapacity} */
     OnBoardMiStorageCapacity(133),
-    /** Tag 134; For a variable zoom system, the percentage of zoom; Value is a {@link OpaqueValue} */
+    /** Tag 134; For a variable zoom system, the percentage of zoom; Value is a {@link ZoomPercentage} */
     ZoomPercentage(134),
     /** Tag 135; Type of communications used with platform; Value is a {@link UasDatalinkString} */
     CommunicationsMethod(135),

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ZoomPercentage.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ZoomPercentage.java
@@ -1,0 +1,85 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.klv.st1201.FpEncoder;
+
+/**
+ * Zoom Percentage (Tag 134).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * For a variable zoom system, the percentage of zoom.
+ * <p>
+ * Resolution: 1 byte = 1%, 2 bytes = .0039%
+ * <p>
+ * Percentage of Zoom of the sensor system.
+ * <p>
+ * Includes both digital and optical zoom
+ * <p>
+ * 0% means no zoom, 100% means fully zoomed
+ * </blockquote>
+ */
+public class ZoomPercentage implements IUasDatalinkValue
+{
+    private static double MIN_VAL = 0.0;
+    private static double MAX_VAL = 100.0;
+    private static int RECOMMENDED_BYTES = 2;
+    private static int MAX_BYTES = 4;
+    private double percentage;
+
+    /**
+     * Create from value
+     *
+     * @param percentage Zoom percentage. Valid range is [0,100]
+     */
+    public ZoomPercentage(double percentage)
+    {
+        if (percentage < MIN_VAL || percentage > MAX_VAL)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " must be in range [0,100]");
+        }
+        this.percentage = percentage;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes IMAPB Encoded byte array, 4 bytes maximum
+     */
+    public ZoomPercentage(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " cannot be longer than " + MAX_BYTES + " bytes");
+        }
+        FpEncoder decoder = new FpEncoder(MIN_VAL, MAX_VAL, bytes.length);
+        this.percentage = decoder.decode(bytes);
+    }
+
+    /**
+     * Get percentage.
+     * @return the zoom percentage
+     */
+    public double getPercentage()
+    {
+        return this.percentage;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        FpEncoder encoder = new FpEncoder(MIN_VAL, MAX_VAL, RECOMMENDED_BYTES);
+        return encoder.encode(this.percentage);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+         return String.format("%.1f%%", this.percentage);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Zoom Percentage";
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/AlternatePlatformEllipsoidHeightExtendedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/AlternatePlatformEllipsoidHeightExtendedTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AlternatePlatformEllipsoidHeightExtendedTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        AlternatePlatformEllipsoidHeightExtended alt = new AlternatePlatformEllipsoidHeightExtended(23456.24);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getDisplayableValue(), "23456.2m");
+        Assert.assertEquals(alt.getDisplayName(), "Alternate Platform Ellipsoid Height");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        AlternatePlatformEllipsoidHeightExtended alt = new AlternatePlatformEllipsoidHeightExtended(new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getMeters(), 23456.24, 0.01);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getDisplayableValue(), "23456.2m");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.AlternatePlatformEllipsoidHeightExtended, bytes);
+        Assert.assertTrue(v instanceof AlternatePlatformEllipsoidHeightExtended);
+        AlternatePlatformEllipsoidHeightExtended alt = (AlternatePlatformEllipsoidHeightExtended)v;
+        Assert.assertEquals(alt.getMeters(), 23456.24, 0.01);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getDisplayableValue(), "23456.2m");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new AlternatePlatformEllipsoidHeightExtended(-900.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new AlternatePlatformEllipsoidHeightExtended(40000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new AlternatePlatformEllipsoidHeightExtended(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/AltitudeAGLTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/AltitudeAGLTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AltitudeAGLTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        AltitudeAGL alt = new AltitudeAGL(2150.0);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x05, (byte)0xF5, (byte)0x00});
+        Assert.assertEquals(alt.getDisplayableValue(), "2150.0m");
+        Assert.assertEquals(alt.getDisplayName(), "Altitude AGL");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        AltitudeAGL alt = new AltitudeAGL(new byte[]{(byte)0x05, (byte)0xF5, (byte)0x00});
+        Assert.assertEquals(alt.getMeters(), 2150.0, 0.01);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x05, (byte)0xF5, (byte)0x00});
+        Assert.assertEquals(alt.getDisplayableValue(), "2150.0m");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x05, (byte)0xF5, (byte)0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.AltitudeAgl, bytes);
+        Assert.assertTrue(v instanceof AltitudeAGL);
+        AltitudeAGL alt = (AltitudeAGL)v;
+        Assert.assertEquals(alt.getMeters(), 2150.0, 0.01);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x05, (byte)0xF5, (byte)0x00});
+        Assert.assertEquals(alt.getDisplayableValue(), "2150.0m");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new AltitudeAGL(-900.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new AltitudeAGL(40000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new AltitudeAGL(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/DensityAltitudeExtendedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/DensityAltitudeExtendedTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DensityAltitudeExtendedTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        DensityAltitudeExtended alt = new DensityAltitudeExtended(23456.24);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getDisplayableValue(), "23456.2m");
+        Assert.assertEquals(alt.getDisplayName(), "Density Altitude");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        DensityAltitudeExtended alt = new DensityAltitudeExtended(new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getMeters(), 23456.24, 0.01);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getDisplayableValue(), "23456.2m");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.DensityAltitudeExtended, bytes);
+        Assert.assertTrue(v instanceof DensityAltitudeExtended);
+        DensityAltitudeExtended alt = (DensityAltitudeExtended)v;
+        Assert.assertEquals(alt.getMeters(), 23456.24, 0.01);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getDisplayableValue(), "23456.2m");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new DensityAltitudeExtended(-900.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new DensityAltitudeExtended(40000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new DensityAltitudeExtended(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/OnBoardMiStoragePercentFullTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/OnBoardMiStoragePercentFullTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class OnBoardMiStoragePercentFullTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        OnBoardMiStoragePercentFull percent = new OnBoardMiStoragePercentFull(72.0);
+        Assert.assertEquals(percent.getBytes(), new byte[]{(byte)0x48, (byte)0x00});
+        Assert.assertEquals(percent.getDisplayableValue(), "72.0%");
+        Assert.assertEquals(percent.getDisplayName(), "On-board MI Storage Percent Full");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        OnBoardMiStoragePercentFull percent = new OnBoardMiStoragePercentFull(new byte[]{(byte)0x48, (byte)0x00});
+        Assert.assertEquals(percent.getPercentage(), 72.0, 0.01);
+        Assert.assertEquals(percent.getBytes(), new byte[]{(byte)0x48, (byte)0x00});
+        Assert.assertEquals(percent.getDisplayableValue(), "72.0%");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x48, (byte)0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.OnBoardMiStoragePercentFull, bytes);
+        Assert.assertTrue(v instanceof OnBoardMiStoragePercentFull);
+        OnBoardMiStoragePercentFull percent = (OnBoardMiStoragePercentFull)v;
+        Assert.assertEquals(percent.getPercentage(), 72.0, 0.01);
+        Assert.assertEquals(percent.getBytes(), new byte[]{(byte)0x48, (byte)0x00});
+        Assert.assertEquals(percent.getDisplayableValue(), "72.0%");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new OnBoardMiStoragePercentFull(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new OnBoardMiStoragePercentFull(100.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new OnBoardMiStoragePercentFull(new byte[]{0x01, 0x02, 0x03, 0x04});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PlatformCourseAngleTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PlatformCourseAngleTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PlatformCourseAngleTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        PlatformCourseAngle course = new PlatformCourseAngle(125.0);
+        Assert.assertEquals(course.getBytes(), new byte[]{(byte)0x1F, (byte)0x40});
+        Assert.assertEquals(course.getDisplayableValue(), "125.000\u00B0");
+        Assert.assertEquals(course.getDisplayName(), "Platform Course Angle");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        PlatformCourseAngle course = new PlatformCourseAngle(new byte[]{(byte)0x1F, (byte)0x40});
+        Assert.assertEquals(course.getAngle(), 125.0, 0.001);
+        Assert.assertEquals(course.getBytes(), new byte[]{(byte)0x1F, (byte)0x40});
+        Assert.assertEquals(course.getDisplayableValue(), "125.000\u00B0");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x1F, (byte)0x40};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.PlatformCourseAngle, bytes);
+        Assert.assertTrue(v instanceof PlatformCourseAngle);
+        PlatformCourseAngle course = (PlatformCourseAngle)v;
+        Assert.assertEquals(course.getAngle(), 125.0, 0.001);
+        Assert.assertEquals(course.getBytes(), new byte[]{(byte)0x1F, (byte)0x40});
+        Assert.assertEquals(course.getDisplayableValue(), "125.000\u00B0");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new PlatformCourseAngle(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new PlatformCourseAngle(360.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new PlatformCourseAngle(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/RadarAltimeterTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/RadarAltimeterTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class RadarAltimeterTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        RadarAltimeter alt = new RadarAltimeter(2154.50);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x05, (byte)0xF7, (byte)0x40});
+        Assert.assertEquals(alt.getDisplayableValue(), "2154.5m");
+        Assert.assertEquals(alt.getDisplayName(), "Radar Altimeter");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        RadarAltimeter alt = new RadarAltimeter(new byte[]{(byte)0x05, (byte)0xF7, (byte)0x40});
+        Assert.assertEquals(alt.getMeters(), 2154.50, 0.01);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x05, (byte)0xF7, (byte)0x40});
+        Assert.assertEquals(alt.getDisplayableValue(), "2154.5m");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x05, (byte)0xF7, (byte)0x40};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.RadarAltimeter, bytes);
+        Assert.assertTrue(v instanceof RadarAltimeter);
+        RadarAltimeter alt = (RadarAltimeter)v;
+        Assert.assertEquals(alt.getMeters(), 2154.50, 0.01);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x05, (byte)0xF7, (byte)0x40});
+        Assert.assertEquals(alt.getDisplayableValue(), "2154.5m");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new RadarAltimeter(-900.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new RadarAltimeter(40000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new RadarAltimeter(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/RangeToRecoveryLocationTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/RangeToRecoveryLocationTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class RangeToRecoveryLocationTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        RangeToRecoveryLocation range = new RangeToRecoveryLocation(1.625);
+        Assert.assertEquals(range.getBytes(), new byte[]{(byte)0x00, (byte)0x01, (byte)0xa0});
+        Assert.assertEquals(range.getDisplayableValue(), "1.625km");
+        Assert.assertEquals(range.getDisplayName(), "Range to Recovery Location");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        RangeToRecoveryLocation range = new RangeToRecoveryLocation(new byte[]{(byte)0x00, (byte)0x01, (byte)0xa0});
+        Assert.assertEquals(range.getRange(), 1.625, 0.01);
+        Assert.assertEquals(range.getBytes(), new byte[]{(byte)0x00, (byte)0x01, (byte)0xa0});
+        Assert.assertEquals(range.getDisplayableValue(), "1.625km");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x00, (byte)0x01, (byte)0xa0};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.RangeToRecoveryLocation, bytes);
+        Assert.assertTrue(v instanceof RangeToRecoveryLocation);
+        RangeToRecoveryLocation range = (RangeToRecoveryLocation)v;
+        Assert.assertEquals(range.getRange(), 1.625, 0.01);
+        Assert.assertEquals(range.getBytes(), new byte[]{(byte)0x00, (byte)0x01, (byte)0xa0});
+        Assert.assertEquals(range.getDisplayableValue(), "1.625km");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new RangeToRecoveryLocation(-0.001);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new RangeToRecoveryLocation(21000.1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new RangeToRecoveryLocation(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorAngleRateTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorAngleRateTest.java
@@ -1,0 +1,122 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SensorAngleRateTest
+{
+    @Test
+    public void testConstructFromValueTag117()
+    {
+        // From ST
+        SensorAngleRate rate = new SensorAzimuthRate(1);
+        Assert.assertEquals(rate.getBytes(), new byte[]{(byte)0x3E, (byte)0x90, (byte)0x00});
+        Assert.assertEquals(rate.getDisplayableValue(), "1.000 dps");
+        Assert.assertEquals(rate.getDisplayName(), "Sensor Azimuth Rate");
+    }
+
+    @Test
+    public void testConstructFromEncodedTag117()
+    {
+        // From ST
+        SensorAngleRate rate = new SensorAzimuthRate(new byte[]{(byte)0x3E, (byte)0x90});
+        Assert.assertEquals(rate.getAngleRate(), 1.0, 0.01);
+        Assert.assertEquals(rate.getBytes(), new byte[]{(byte)0x3E, (byte)0x90, (byte)0x00});
+        Assert.assertEquals(rate.getDisplayableValue(), "1.000 dps");
+    }
+
+    @Test
+    public void testFactoryTag117() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x3E, (byte)0x90};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorAzimuthRate, bytes);
+        Assert.assertTrue(v instanceof SensorAzimuthRate);
+        SensorAzimuthRate rate = (SensorAzimuthRate)v;
+        Assert.assertEquals(rate.getAngleRate(), 1.0, 0.001);
+        Assert.assertEquals(rate.getBytes(), new byte[]{(byte)0x3E, (byte)0x90, (byte)0x00});
+        Assert.assertEquals(rate.getDisplayableValue(), "1.000 dps");
+    }
+
+    @Test
+    public void testConstructFromValueTag118()
+    {
+        // From ST
+        SensorAngleRate rate = new SensorElevationRate(0.004176);
+        Assert.assertEquals(rate.getBytes(), new byte[]{(byte)0x3E, (byte)0x80, (byte)0x11});
+        Assert.assertEquals(rate.getDisplayableValue(), "0.004 dps");
+        Assert.assertEquals(rate.getDisplayName(), "Sensor Elevation Rate");
+    }
+
+    @Test
+    public void testConstructFromEncodedTag118()
+    {
+        // From ST:
+        SensorAngleRate rate = new SensorElevationRate(new byte[]{(byte)0x3E, (byte)0x80, (byte)0x11});
+        Assert.assertEquals(rate.getAngleRate(), 0.004176, 0.001);
+        Assert.assertEquals(rate.getBytes(), new byte[]{(byte)0x3E, (byte)0x80, (byte)0x11});
+        Assert.assertEquals(rate.getDisplayableValue(), "0.004 dps");
+    }
+
+    @Test
+    public void testFactoryTag118() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x3E, (byte)0x80, (byte)0x11};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorElevationRate, bytes);
+        Assert.assertTrue(v instanceof SensorElevationRate);
+        SensorElevationRate rate = (SensorElevationRate)v;
+        Assert.assertEquals(rate.getAngleRate(), 0.004176, 0.001);
+        Assert.assertEquals(rate.getBytes(), new byte[]{(byte)0x3E, (byte)0x80, (byte)0x11});
+        Assert.assertEquals(rate.getDisplayableValue(), "0.004 dps");
+    }
+
+    @Test
+    public void testConstructFromValueTag119()
+    {
+        // From ST
+        SensorAngleRate rate = new SensorRollRate(-50);
+        Assert.assertEquals(rate.getBytes(), new byte[]{(byte)0x3B, (byte)0x60, (byte)0x00});
+        Assert.assertEquals(rate.getDisplayableValue(), "-50.000 dps");
+        Assert.assertEquals(rate.getDisplayName(), "Sensor Roll Rate");
+    }
+
+    @Test
+    public void testConstructFromEncodedTag119()
+    {
+        // From ST:
+        SensorAngleRate rate = new SensorRollRate(new byte[]{(byte)0x3B, (byte)0x60});
+        Assert.assertEquals(rate.getAngleRate(), -50.0, 0.001);
+        Assert.assertEquals(rate.getBytes(), new byte[]{(byte)0x3B, (byte)0x60, (byte)0x00});
+        Assert.assertEquals(rate.getDisplayableValue(), "-50.000 dps");
+    }
+
+    @Test
+    public void testFactoryTag119() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x3B, (byte)0x60};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorRollRate, bytes);
+        Assert.assertTrue(v instanceof SensorRollRate);
+        SensorRollRate rate = (SensorRollRate)v;
+        Assert.assertEquals(rate.getAngleRate(), -50.0, 0.001);
+        Assert.assertEquals(rate.getBytes(), new byte[]{(byte)0x3B, (byte)0x60, (byte)0x00});
+        Assert.assertEquals(rate.getDisplayableValue(), "-50.000 dps");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new SensorAzimuthRate(-1000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new SensorElevationRate(1000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new SensorRollRate(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorEllipsoidHeightExtendedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorEllipsoidHeightExtendedTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SensorEllipsoidHeightExtendedTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        SensorEllipsoidHeightExtended alt = new SensorEllipsoidHeightExtended(23456.24);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getDisplayableValue(), "23456.2m");
+        Assert.assertEquals(alt.getDisplayName(), "Sensor Ellipsoid Height");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        SensorEllipsoidHeightExtended alt = new SensorEllipsoidHeightExtended(new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getMeters(), 23456.24, 0.01);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getDisplayableValue(), "23456.2m");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorEllipsoidHeightExtended, bytes);
+        Assert.assertTrue(v instanceof SensorEllipsoidHeightExtended);
+        SensorEllipsoidHeightExtended alt = (SensorEllipsoidHeightExtended)v;
+        Assert.assertEquals(alt.getMeters(), 23456.24, 0.01);
+        Assert.assertEquals(alt.getBytes(), new byte[]{(byte)0x2F, (byte)0x92, (byte)0x1E});
+        Assert.assertEquals(alt.getDisplayableValue(), "23456.2m");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new SensorEllipsoidHeightExtended(-900.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new SensorEllipsoidHeightExtended(40000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new SensorEllipsoidHeightExtended(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/TargetWidthExtendedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/TargetWidthExtendedTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TargetWidthExtendedTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        TargetWidthExtended width = new TargetWidthExtended(13898.5463);
+        Assert.assertEquals(width.getBytes(), new byte[]{(byte)0x00, (byte)0xD9, (byte)0x2A});
+        Assert.assertEquals(width.getDisplayableValue(), "13898.5m");
+        Assert.assertEquals(width.getDisplayName(), "Target Width Extended");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        TargetWidthExtended width = new TargetWidthExtended(new byte[]{(byte)0x00, (byte)0xD9, (byte)0x2A});
+        Assert.assertEquals(width.getMeters(), 13898.5463, 0.25);
+        Assert.assertEquals(width.getBytes(), new byte[]{(byte)0x00, (byte)0xD9, (byte)0x2A});
+        Assert.assertEquals(width.getDisplayableValue(), "13898.5m");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x00, (byte)0xD9, (byte)0x2A};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.TargetWidthExtended, bytes);
+        Assert.assertTrue(v instanceof TargetWidthExtended);
+        TargetWidthExtended width = (TargetWidthExtended)v;
+        Assert.assertEquals(width.getMeters(), 13898.5463, 0.25);
+        Assert.assertEquals(width.getBytes(), new byte[]{(byte)0x00, (byte)0xD9, (byte)0x2A});
+        Assert.assertEquals(width.getDisplayableValue(), "13898.5m");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new TargetWidthExtended(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new TargetWidthExtended(1500000.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new TargetWidthExtended(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/TransmissionFrequencyTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/TransmissionFrequencyTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TransmissionFrequencyTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        TransmissionFrequency freq = new TransmissionFrequency(2400.0);
+        Assert.assertEquals(freq.getBytes(), new byte[]{(byte)0x02, (byte)0x57, (byte)0xc0});
+        Assert.assertEquals(freq.getDisplayableValue(), "2400.00MHz");
+        Assert.assertEquals(freq.getDisplayName(), "Transmission Frequency");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        TransmissionFrequency freq = new TransmissionFrequency(new byte[]{(byte)0x02, (byte)0x57, (byte)0xc0});
+        Assert.assertEquals(freq.getFrequency(), 2400.0, 0.01);
+        Assert.assertEquals(freq.getBytes(), new byte[]{(byte)0x02, (byte)0x57, (byte)0xc0});
+        Assert.assertEquals(freq.getDisplayableValue(), "2400.00MHz");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x02, (byte)0x57, (byte)0xc0};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.TransmissionFrequency, bytes);
+        Assert.assertTrue(v instanceof TransmissionFrequency);
+        TransmissionFrequency freq = (TransmissionFrequency)v;
+        Assert.assertEquals(freq.getFrequency(), 2400.0, 0.01);
+        Assert.assertEquals(freq.getBytes(), new byte[]{(byte)0x02, (byte)0x57, (byte)0xC0});
+        Assert.assertEquals(freq.getDisplayableValue(), "2400.00MHz");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new TransmissionFrequency(0.999);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new TransmissionFrequency(100000.0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new TransmissionFrequency(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/ZoomPercentageTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/ZoomPercentageTest.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ZoomPercentageTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        ZoomPercentage percent = new ZoomPercentage(55.0);
+        Assert.assertEquals(percent.getBytes(), new byte[]{(byte)0x37, (byte)0x00});
+        Assert.assertEquals(percent.getDisplayableValue(), "55.0%");
+        Assert.assertEquals(percent.getDisplayName(), "Zoom Percentage");
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        // From ST:
+        ZoomPercentage percent = new ZoomPercentage(new byte[]{(byte)0x37, (byte)0x00});
+        Assert.assertEquals(percent.getPercentage(), 55.0, 0.01);
+        Assert.assertEquals(percent.getBytes(), new byte[]{(byte)0x37, (byte)0x00});
+        Assert.assertEquals(percent.getDisplayableValue(), "55.0%");
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x37, (byte)0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.ZoomPercentage, bytes);
+        Assert.assertTrue(v instanceof ZoomPercentage);
+        ZoomPercentage percent = (ZoomPercentage)v;
+        Assert.assertEquals(percent.getPercentage(), 55.0, 0.01);
+        Assert.assertEquals(percent.getBytes(), new byte[]{(byte)0x37, (byte)0x00});
+        Assert.assertEquals(percent.getDisplayableValue(), "55.0%");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new ZoomPercentage(-0.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        new ZoomPercentage(100.01);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooLong()
+    {
+        new ZoomPercentage(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st1201/FpEncoderThreeByteTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1201/FpEncoderThreeByteTest.java
@@ -1,0 +1,115 @@
+package org.jmisb.api.klv.st1201;
+
+import org.testng.Assert;
+import org.testng.annotations.*;
+
+public class FpEncoderThreeByteTest
+{
+    @Test
+    public void testDecode3byte_0()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = {(byte)0x00, (byte)0x00, (byte)0x00};
+        double val = fpEncoder.decode(encoded);
+        Assert.assertEquals(val, -900.0, 1e-8);
+    }
+
+    @Test
+    public void testEncode3byte_0()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = fpEncoder.encode(-900.0);
+        byte[] expected = {(byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(encoded, expected);
+    }
+
+    @Test
+    public void testDecode3byte_0_1()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = {(byte)0x00, (byte)0x00, (byte)0x01};
+        double val = fpEncoder.decode(encoded);
+        Assert.assertEquals(val, -899.998046875, 1e-8);
+    }
+
+    @Test
+    public void testEncode3byte_0_1()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = fpEncoder.encode(-899.998046875);
+        byte[] expected = {(byte)0x00, (byte)0x00, (byte)0x01};
+        Assert.assertEquals(encoded, expected);
+    }
+
+    @Test
+    public void testDecode3byte_1()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = {(byte)0x08, (byte)0x98, (byte)0x00};
+        double val = fpEncoder.decode(encoded);
+        Assert.assertEquals(val, 200, 1e-8);
+    }
+
+    @Test
+    public void testEncode3byte_1()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = fpEncoder.encode(200.0);
+        byte[] expected = {(byte)0x08, (byte)0x98, (byte)0x00};
+        Assert.assertEquals(encoded, expected);
+    }
+
+    @Test
+    public void testDecode3byte_1_1()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = {(byte)0x08, (byte)0x98, (byte)0x01};
+        double val = fpEncoder.decode(encoded);
+        Assert.assertEquals(val, 200.001953125, 1e-8);
+    }
+
+    @Test
+    public void testEncode3byte_1_1()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = fpEncoder.encode(200.001953125);
+        byte[] expected = {(byte)0x08, (byte)0x98, (byte)0x01};
+        Assert.assertEquals(encoded, expected);
+    }
+
+    @Test
+    public void testDecode3byte_1_7F()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = {(byte)0x08, (byte)0x98, (byte)0x7F};
+        double val = fpEncoder.decode(encoded);
+        Assert.assertEquals(val, 200.248046875, 1e-8);
+    }
+
+    @Test
+    public void testDecode3byte_2()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = {(byte)0x08, (byte)0xFC, (byte)0x00};
+        double val = fpEncoder.decode(encoded);
+        Assert.assertEquals(val, 250, 1e-8);
+    }
+
+    @Test
+    public void testDecode3byte_3()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = {(byte)0x07, (byte)0xD0, (byte)0x00};
+        double val = fpEncoder.decode(encoded);
+        Assert.assertEquals(val, 100, 1e-8);
+    }
+
+    @Test
+    public void testDecode3byte_4()
+    {
+        FpEncoder fpEncoder = new FpEncoder(-900, 9000, 3);
+        byte[] encoded = {(byte)0x09, (byte)0x60, (byte)0x00};
+        double val = fpEncoder.decode(encoded);
+        Assert.assertEquals(val, 300, 1e-8);
+    }
+}

--- a/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
+++ b/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
@@ -67,6 +67,23 @@ public class PrimitiveConverter
     }
 
     /**
+     * Convert part of a byte array to an signed 16-bit integer
+     *
+     * @param bytes The array
+     * @param offset the offset into the array where the conversion should start
+     * @return The signed 16-bit integer
+     */
+    public static short toInt16(byte[] bytes, int offset)
+    {
+        if (offset + Short.BYTES <= bytes.length)
+        {
+            return ByteBuffer.wrap(bytes, offset, Short.BYTES).getShort();
+        }
+
+        throw new IllegalArgumentException("Invalid buffer length");
+    }
+
+    /**
      * Convert a signed 16-bit integer to a byte array
      *
      * @param val The short value (16-byte signed integer)


### PR DESCRIPTION
## Motivation and Context
This implements several IMAPB-related tags for ST0601. I have a Tag 141 change coming, which relies on this functionality.

## Description
The IMAPB tags are often three bytes, so the FpEncoder implementation changes to handle that.
Otherwise its pretty much standard IUasDatalinkValue implementation, with factory changes and tests.

## How Has This Been Tested?
Unit tests only.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

