### PR TITLE
Fix comment about resolution for Target Track Gate Height / Width

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetTrackGateSize.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetTrackGateSize.java
@@ -7,7 +7,7 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * <p>
  * Map 0..(2^8-1) to 0..510 pixels.
  * <p>
- * Resolution: 2 pixels (not 1 pixel as shown in ST).
+ * Resolution: 2 pixels.
  */
 abstract public class TargetTrackGateSize implements IUasDatalinkValue
 {


### PR DESCRIPTION
## Motivation and Context
We had a comment about 2px vs 1px in the Target Track Gate Size implementation. That is fixed in ST0601.16 and the comment is no longer valid.

## Description
Updated API docs.

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

