### PR TITLE
Update Onboard MI Storage Capacity to support three byte input.

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/OnBoardMiStorageCapacity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/OnBoardMiStorageCapacity.java
@@ -21,6 +21,7 @@ public class OnBoardMiStorageCapacity implements IUasDatalinkValue
     private long gigabytes;
     private static long MIN_VAL = 0;
     private static long MAX_VAL = 4294967295L; // 2^32-1
+    private static int MAX_BYTES = 4;
 
     /**
      * Create from value
@@ -37,26 +38,15 @@ public class OnBoardMiStorageCapacity implements IUasDatalinkValue
 
     /**
      * Create from encoded bytes
-     * @param bytes Byte array of length 1, 2, or 4
+     * @param bytes Byte array, maximum four bytes
      */
     public OnBoardMiStorageCapacity(byte[] bytes)
     {
-        if (bytes.length == 4)
+        if (bytes.length > MAX_BYTES)
         {
-            this.gigabytes = PrimitiveConverter.toUint32(bytes);
+            throw new IllegalArgumentException("Storage capacity field length must be 1 - 4 bytes");
         }
-        else if (bytes.length == 2)
-        {
-            this.gigabytes = PrimitiveConverter.toUint16(bytes);
-        }
-        else if (bytes.length == 1)
-        {
-            this.gigabytes = PrimitiveConverter.toUint8(bytes);
-        }
-        else
-        {
-            throw new IllegalArgumentException("Storage capacity field length must be 1, 2, or 4 bytes");
-        }
+        this.gigabytes = PrimitiveConverter.variableBytesToUint32(bytes);
     }
 
     /**

--- a/api/src/test/java/org/jmisb/api/klv/st0601/OnBoardMiStorageCapacityTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/OnBoardMiStorageCapacityTest.java
@@ -51,6 +51,20 @@ public class OnBoardMiStorageCapacityTest
         Assert.assertEquals(capacity.getBytes(), bytes);
         Assert.assertEquals(capacity.getDisplayableValue(), "65535GB");
 
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00};
+        capacity = new OnBoardMiStorageCapacity(bytes);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
+        Assert.assertEquals(capacity.getGigabytes(), 0L);
+        Assert.assertEquals(capacity.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(capacity.getDisplayableValue(), "0GB");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff};
+        capacity = new OnBoardMiStorageCapacity(bytes);
+        Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
+        Assert.assertEquals(capacity.getGigabytes(), 16777215L);
+        Assert.assertEquals(capacity.getBytes(), new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(capacity.getDisplayableValue(), "16777215GB");
+
         bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
         capacity = new OnBoardMiStorageCapacity(bytes);
         Assert.assertEquals(capacity.getDisplayName(), "On-Board MI Storage Capacity");
@@ -140,6 +154,24 @@ public class OnBoardMiStorageCapacityTest
         Assert.assertEquals(capacity.getGigabytes(), 65535);
         Assert.assertEquals(capacity.getBytes(), bytes);
         Assert.assertEquals(capacity.getDisplayableValue(), "65535GB");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.OnBoardMiStorageCapacity, bytes);
+        Assert.assertTrue(v instanceof OnBoardMiStorageCapacity);
+        Assert.assertEquals(v.getDisplayName(), "On-Board MI Storage Capacity");
+        capacity = (OnBoardMiStorageCapacity)v;
+        Assert.assertEquals(capacity.getGigabytes(), 0L);
+        Assert.assertEquals(capacity.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(capacity.getDisplayableValue(), "0GB");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.OnBoardMiStorageCapacity, bytes);
+        Assert.assertTrue(v instanceof OnBoardMiStorageCapacity);
+        Assert.assertEquals(v.getDisplayName(), "On-Board MI Storage Capacity");
+        capacity = (OnBoardMiStorageCapacity)v;
+        Assert.assertEquals(capacity.getGigabytes(), 16777215L);
+        Assert.assertEquals(capacity.getBytes(), new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(capacity.getDisplayableValue(), "16777215GB");
 
         bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OnBoardMiStorageCapacity, bytes);

--- a/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
+++ b/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
@@ -23,6 +23,15 @@ public class PrimitiveConverter
     private static final ThreadLocal<ByteBuffer> doubleBuffer =
             ThreadLocal.withInitial(() -> ByteBuffer.allocate(Double.BYTES));
 
+    static long arrayToUnsignedLongInternal(byte[] bytes) {
+        long res = 0;
+        for (byte b: bytes) {
+            int i = b & 0xFF;
+            res = (res << 8) + i;
+        }
+        return res;
+    }
+
     private PrimitiveConverter() {}
 
     /**
@@ -120,6 +129,28 @@ public class PrimitiveConverter
             return Integer.toUnsignedLong(ByteBuffer.wrap(bytes).getInt());
         }
         throw new IllegalArgumentException("Invalid buffer length");
+    }
+
+    /**
+     * Convert a variable length byte array to an unsigned 32-bit integer (long with range of uint32)
+     *
+     * @param bytes The array of length 1-4
+     * @return The unsigned 32-bit integer as a long
+     */
+    public static long variableBytesToUint32(byte[] bytes)
+    {
+        switch (bytes.length) {
+            case 4:
+                return PrimitiveConverter.toUint32(bytes);
+            case 3:
+                return PrimitiveConverter.arrayToUnsignedLongInternal(bytes);
+            case 2:
+                return PrimitiveConverter.toUint16(bytes);
+            case 1:
+                return PrimitiveConverter.toUint8(bytes);
+            default:
+                throw new IllegalArgumentException("Invalid buffer length");
+        }
     }
 
     /**

--- a/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
@@ -6,6 +6,55 @@ import org.testng.annotations.Test;
 public class PrimitiveConverterTest
 {
     @Test
+    public void testToInt16()
+    {
+        int intVal = PrimitiveConverter.toInt16(new byte[]{0x00, 0x00, 0x00, 0x0f}, 2);
+        Assert.assertEquals(intVal, 15);
+
+        intVal = PrimitiveConverter.toInt16(new byte[]{0x00, 0x00, 0x0f, 0x00}, 1);
+        Assert.assertEquals(intVal, 15);
+
+        intVal = PrimitiveConverter.toInt16(new byte[]{0x00, 0x01, 0x01, 0x00}, 1);
+        Assert.assertEquals(intVal, 257);
+
+        intVal = PrimitiveConverter.toInt16(new byte[]{0x00, 0x03});
+        Assert.assertEquals(intVal, 3);
+
+        intVal = PrimitiveConverter.toInt16(new byte[]{0x00, 0x03}, 0);
+        Assert.assertEquals(intVal, 3);
+
+        intVal = PrimitiveConverter.toInt16(new byte[]{(byte)0x7f, (byte)0xff});
+        Assert.assertEquals(intVal, 32767);
+
+        intVal = PrimitiveConverter.toInt16(new byte[]{(byte)0xff, (byte)0xff});
+        Assert.assertEquals(intVal, -1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToInt16BadLength_1()
+    {
+        PrimitiveConverter.toInt16(new byte[]{(byte)0xff});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToInt16BadLength_3()
+    {
+        PrimitiveConverter.toInt16(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToInt16BadLength_2_offset()
+    {
+        PrimitiveConverter.toInt16(new byte[]{(byte)0xff, (byte)0xff}, 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToInt16BadLength_3_offset()
+    {
+        PrimitiveConverter.toInt16(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff}, 2);
+    }
+
+    @Test
     public void testToInt32()
     {
         int intVal = PrimitiveConverter.toInt32(new byte[]{0x00, 0x00, 0x00, 0x0f});
@@ -25,6 +74,22 @@ public class PrimitiveConverterTest
     }
 
     @Test
+    public void testSignedInt16ToBytes()
+    {
+        short shortVal = -1;
+        byte[] bytes = PrimitiveConverter.int16ToBytes(shortVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff});
+
+        shortVal = 10;
+        bytes = PrimitiveConverter.int16ToBytes(shortVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x00, (byte)0x0a});
+
+        shortVal = 32767;
+        bytes = PrimitiveConverter.int16ToBytes(shortVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x7f, (byte)0xff});
+    }
+
+    @Test
     public void testSignedInt32ToBytes()
     {
         int intVal = -1;
@@ -36,11 +101,126 @@ public class PrimitiveConverterTest
         Assert.assertEquals(bytes, new byte[]{0x00, 0x00, 0x00, 0x0a});
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToUint8BadLength_2()
+    {
+        PrimitiveConverter.toUint8(new byte[]{(byte)0xff, (byte)0xff});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToUint16BadLength_1()
+    {
+        PrimitiveConverter.toUint16(new byte[]{(byte)0xff});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToUint16BadLength_3()
+    {
+        PrimitiveConverter.toUint16(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
+    }
+
     @Test
     public void testToUint32()
     {
         long longVal = PrimitiveConverter.toUint32(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
         Assert.assertEquals(longVal, (long) Math.pow(2, 32) - 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToUint32BadLength()
+    {
+        PrimitiveConverter.toUint32(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
+    }
+
+    @Test
+    public void testVariableBytesToUint32_1()
+    {
+        long longVal = PrimitiveConverter.variableBytesToUint32(new byte[]{(byte)0xff});
+        Assert.assertEquals(longVal, (long) Math.pow(2, 8) - 1);
+    }
+
+    @Test
+    public void testVariableBytesToUint32_2()
+    {
+        long longVal = PrimitiveConverter.variableBytesToUint32(new byte[]{(byte)0xff, (byte)0xff});
+        Assert.assertEquals(longVal, (long) Math.pow(2, 16) - 1);
+    }
+
+    @Test
+    public void testVariableBytesToUint32_3_ff()
+    {
+        long longVal = PrimitiveConverter.variableBytesToUint32(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(longVal, (long) Math.pow(2, 24) - 1);
+    }
+
+    @Test
+    public void testVariableBytesToUint32_3_0()
+    {
+        long longVal = PrimitiveConverter.variableBytesToUint32(new byte[]{(byte)0x00, (byte)0x00, (byte)0x00});
+        Assert.assertEquals(longVal, 0L);
+    }
+
+    @Test
+    public void testVariableBytesToUint32_4()
+    {
+        long longVal = PrimitiveConverter.variableBytesToUint32(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(longVal, (long) Math.pow(2, 32) - 1);
+    }
+
+    @Test
+    public void checkUintInternalVsStandard_1() {
+        byte[] bytes = new byte[]{(byte) 0x9c};
+        long standard = PrimitiveConverter.toUint8(bytes);
+        long internal = PrimitiveConverter.arrayToUnsignedLongInternal(bytes);
+        Assert.assertEquals(internal, standard);
+    }
+
+    @Test
+    public void checkUintInternalVsStandard_2() {
+        byte[] bytes = new byte[]{(byte) 0x9c, (byte) 0xba};
+        long standard = PrimitiveConverter.toUint16(bytes);
+        long internal = PrimitiveConverter.arrayToUnsignedLongInternal(bytes);
+        Assert.assertEquals(internal, standard);
+    }
+
+    @Test
+    public void checkUintInternalVsStandard_4() {
+        byte[] bytes = new byte[]{(byte) 0x9c, (byte) 0xba, (byte)0xab, (byte)0xd4};
+        long standard = PrimitiveConverter.toUint32(bytes);
+        long internal = PrimitiveConverter.arrayToUnsignedLongInternal(bytes);
+        Assert.assertEquals(internal, standard);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testVariableBytesToUint32BadLength()
+    {
+        PrimitiveConverter.variableBytesToUint32(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0x00, (byte)0x00});
+    }
+
+    @Test
+    public void testUnsignedInt16ToBytes()
+    {
+        int intVal = 1;
+        byte[] bytes = PrimitiveConverter.uint16ToBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{0x00, 0x01});
+
+        intVal = (int)Math.pow(2, 16) - 1;
+        bytes = PrimitiveConverter.uint16ToBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUnsignedInt16ToBytesTooSmall()
+    {
+        int val = -1;
+        PrimitiveConverter.uint16ToBytes(val);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUnsignedInt16ToBytesTooBig()
+    {
+        int val = (int) Math.pow(2, 16);
+        PrimitiveConverter.uint16ToBytes(val);
     }
 
     @Test
@@ -55,6 +235,20 @@ public class PrimitiveConverterTest
         Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUnsignedInt32ToBytesTooSmall()
+    {
+        long longVal = -1L;
+        PrimitiveConverter.uint32ToBytes(longVal);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUnsignedInt32ToBytesTooBig()
+    {
+        long longVal = (long) Math.pow(2, 32);
+        PrimitiveConverter.uint32ToBytes(longVal);
+    }
+
     @Test
     public void testUnsignedInt8ToBytes()
     {
@@ -65,6 +259,20 @@ public class PrimitiveConverterTest
         shortVal = 255;
         bytes = PrimitiveConverter.uint8ToBytes(shortVal);
         Assert.assertEquals(bytes, new byte[]{(byte)0xff});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUnsignedInt8ToBytesTooSmall()
+    {
+        short val = -1;
+        PrimitiveConverter.uint8ToBytes(val);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUnsignedInt8ToBytesTooBig()
+    {
+        short val = (short) Math.pow(2, 8);
+        PrimitiveConverter.uint8ToBytes(val);
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
The subject tag is variable length (1-4 bytes). This extends the implementation and tests to handle the three byte case.

Resolves #75.

The output is still 1, 2 or 4 bytes. This just makes input more flexible.

## Description
Updates `PrimitiveConverter` implementation to support that, and extends the test coverage
for `PrimitiveConverter`. That implementation is currently only used for the subject tag, although I'm about to implement other tags that require it (e.g. ~~Leap Seconds~~, Time Airborne, Propulsion Unit Speed).

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):
N/A
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

