### PR TITLE
Add test for factory method for MIIS Core Identifier.

### DIFF
--- a/api/src/test/java/org/jmisb/api/klv/st0601/MiisCoreIdentifierTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/MiisCoreIdentifierTest.java
@@ -1,23 +1,27 @@
 package org.jmisb.api.klv.st0601;
 
+import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st1204.CoreIdentifier;
+import org.testng.Assert;
 import static org.testng.Assert.*;
 import org.testng.annotations.Test;
 
 public class MiisCoreIdentifierTest {
     
+    private static final byte[] ST_EXAMPLE_BYTES = new byte[] {(byte)0x01, (byte)0x70, (byte)0xF5, (byte)0x92, (byte)0xF0, (byte)0x23, (byte)0x73, (byte)0x36, (byte)0x4A, (byte)0xF8, (byte)0xAA, (byte)0x91, (byte)0x62, (byte)0xC0, (byte)0x0F, (byte)0x2E, (byte)0xB2, (byte)0xDA, (byte)0x16, (byte)0xB7, (byte)0x43, (byte)0x41, (byte)0x00, (byte)0x08, (byte)0x41, (byte)0xA0, (byte)0xBE, (byte)0x36, (byte)0x5B, (byte)0x5A, (byte)0xB9, (byte)0x6A, (byte)0x36, (byte)0x45};
+    private static final String ST_EXAMPLE_TEXT = "0170:F592-F023-7336-4AF8-AA91-62C0-0F2E-B2DA/16B7-4341-0008-41A0-BE36-5B5A-B96A-3645:D3";
+        
     public MiisCoreIdentifierTest() {
     }
 
     @Test
     public void verifyFromText() {
         // ST0601 example
-        CoreIdentifier coreIdentifier = CoreIdentifier.fromString("0170:F592-F023-7336-4AF8-AA91-62C0-0F2E-B2DA/16B7-4341-0008-41A0-BE36-5B5A-B96A-3645:D3");
+        CoreIdentifier coreIdentifier = CoreIdentifier.fromString(ST_EXAMPLE_TEXT);
         MiisCoreIdentifier identifier = new MiisCoreIdentifier(coreIdentifier);
-        assertEquals(identifier.getDisplayableValue(), "0170:F592-F023-7336-4AF8-AA91-62C0-0F2E-B2DA/16B7-4341-0008-41A0-BE36-5B5A-B96A-3645:D3");
+        assertEquals(identifier.getDisplayableValue(), ST_EXAMPLE_TEXT);
         assertEquals(identifier.getDisplayName(), "MIIS Core Identifier");
-        byte[] expectedBytes = new byte[] {(byte)0x01, (byte)0x70, (byte)0xF5, (byte)0x92, (byte)0xF0, (byte)0x23, (byte)0x73, (byte)0x36, (byte)0x4A, (byte)0xF8, (byte)0xAA, (byte)0x91, (byte)0x62, (byte)0xC0, (byte)0x0F, (byte)0x2E, (byte)0xB2, (byte)0xDA, (byte)0x16, (byte)0xB7, (byte)0x43, (byte)0x41, (byte)0x00, (byte)0x08, (byte)0x41, (byte)0xA0, (byte)0xBE, (byte)0x36, (byte)0x5B, (byte)0x5A, (byte)0xB9, (byte)0x6A, (byte)0x36, (byte)0x45};
-        assertEquals(identifier.getBytes(), expectedBytes);
+        assertEquals(identifier.getBytes(), ST_EXAMPLE_BYTES);
         assertNotNull(identifier.getCoreIdentifier());
         assertEquals(identifier.getCoreIdentifier().getVersion(), 1);
         assertTrue(identifier.getCoreIdentifier().hasValidCheckValue());
@@ -26,12 +30,24 @@ public class MiisCoreIdentifierTest {
     @Test
     public void verifyFromBytes() {
         // ST0601 example
-        byte[] bytes = new byte[] {(byte)0x01, (byte)0x70, (byte)0xF5, (byte)0x92, (byte)0xF0, (byte)0x23, (byte)0x73, (byte)0x36, (byte)0x4A, (byte)0xF8, (byte)0xAA, (byte)0x91, (byte)0x62, (byte)0xC0, (byte)0x0F, (byte)0x2E, (byte)0xB2, (byte)0xDA, (byte)0x16, (byte)0xB7, (byte)0x43, (byte)0x41, (byte)0x00, (byte)0x08, (byte)0x41, (byte)0xA0, (byte)0xBE, (byte)0x36, (byte)0x5B, (byte)0x5A, (byte)0xB9, (byte)0x6A, (byte)0x36, (byte)0x45};
-        MiisCoreIdentifier identifier = new MiisCoreIdentifier(bytes);
-        assertEquals(identifier.getDisplayableValue(), "0170:F592-F023-7336-4AF8-AA91-62C0-0F2E-B2DA/16B7-4341-0008-41A0-BE36-5B5A-B96A-3645:D3");
+        MiisCoreIdentifier identifier = new MiisCoreIdentifier(ST_EXAMPLE_BYTES);
+        assertEquals(identifier.getDisplayableValue(), ST_EXAMPLE_TEXT);
         assertEquals(identifier.getDisplayName(), "MIIS Core Identifier");
-        byte[] expectedBytes = new byte[] {(byte)0x01, (byte)0x70, (byte)0xF5, (byte)0x92, (byte)0xF0, (byte)0x23, (byte)0x73, (byte)0x36, (byte)0x4A, (byte)0xF8, (byte)0xAA, (byte)0x91, (byte)0x62, (byte)0xC0, (byte)0x0F, (byte)0x2E, (byte)0xB2, (byte)0xDA, (byte)0x16, (byte)0xB7, (byte)0x43, (byte)0x41, (byte)0x00, (byte)0x08, (byte)0x41, (byte)0xA0, (byte)0xBE, (byte)0x36, (byte)0x5B, (byte)0x5A, (byte)0xB9, (byte)0x6A, (byte)0x36, (byte)0x45};
-        assertEquals(identifier.getBytes(), expectedBytes);
+        assertEquals(identifier.getBytes(), ST_EXAMPLE_BYTES);
+        assertNotNull(identifier.getCoreIdentifier());
+        assertEquals(identifier.getCoreIdentifier().getVersion(), 1);
+        assertTrue(identifier.getCoreIdentifier().hasValidCheckValue());
+    }
+    
+    @Test
+    public void verifyFromFactory() throws KlvParseException {
+        // ST0601 example
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.MiisCoreIdentifier, ST_EXAMPLE_BYTES);
+        Assert.assertTrue(v instanceof MiisCoreIdentifier);
+        MiisCoreIdentifier identifier = (MiisCoreIdentifier) v;
+        assertEquals(identifier.getDisplayableValue(), ST_EXAMPLE_TEXT);
+        assertEquals(identifier.getDisplayName(), "MIIS Core Identifier");
+        assertEquals(identifier.getBytes(), ST_EXAMPLE_BYTES);
         assertNotNull(identifier.getCoreIdentifier());
         assertEquals(identifier.getCoreIdentifier().getVersion(), 1);
         assertTrue(identifier.getCoreIdentifier().hasValidCheckValue());


### PR DESCRIPTION
## Motivation and Context
This should have been in #65, but clearly wasn't. It shows up as a test coverage omission in UasDatalinkFactory.

## Description
No code changes, just improves test coverage. I did refactor the other tests a bit to avoid duplicate the byte array and strings.

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):
N/A
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

