### PR TITLE
Implement Time Airborne (ST0601 Tag 110) and Propulsion Unit Speed (Tag 111)

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/PropulsionUnitSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PropulsionUnitSpeed.java
@@ -1,0 +1,82 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * Propulsion Unit Speed (ST 0601 tag 111).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * The speed the engine (or electric motor) is rotating at.
+ * <p>
+ * KLV format: uint, Min: 0, Max: (2^32)-1.
+ * <p>
+ * Length: variable, Max Length: 4, Required Length: N/A.
+ * <p>
+ * Resolution: 1 revolution/minute.
+ * <p>
+ * RPMs can apply to combustion engine or electric motor propelling the aircraft.
+ * <p>
+ * With multi-rotor aircraft, use an average or other representative value.
+ * </blockquote>
+ */
+public class PropulsionUnitSpeed implements IUasDatalinkValue
+{
+    private long speed;
+    private static long MIN_VAL = 0;
+    private static long MAX_VAL = 4294967295L; // 2^32-1
+    private static int MAX_BYTES = 4;
+
+    /**
+     * Create from value
+     * @param speed speed in revolutions per minute (RPM). Legal values are in [0,2^31-1].
+     */
+    public PropulsionUnitSpeed(long speed)
+    {
+        if (speed > MAX_VAL || speed < MIN_VAL)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " must be in range [0,2^32-1]");
+        }
+        this.speed = speed;
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes Byte array, maximum four bytes
+     */
+    public PropulsionUnitSpeed(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " field length must be 1 - 4 bytes");
+        }
+        this.speed = PrimitiveConverter.variableBytesToUint32(bytes);
+    }
+
+    /**
+     * Get the propulsion unit speed.
+     * @return The speed in revolutions per minute (RPM).
+     */
+    public long getSpeed()
+    {
+        return speed;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        return PrimitiveConverter.uint32ToVariableBytes(this.speed);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return speed + "rpm";
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Propulsion Unit Speed";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TimeAirborne.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TimeAirborne.java
@@ -1,0 +1,88 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * Time Airborne (ST 0601 tag 110).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Number of seconds aircraft has been airborne.
+ * <p>
+ * KLV format: uint, Min: 0, Max: (2^32)-1.
+ * <p>
+ * Length: variable, Max Length: 4, Required Length: N/A.
+ * <p>
+ * Resolution: 1 second.
+ * <p>
+ * This item is related to the "Take-Off Time" (Tag 131). Suggest using "Time
+ * airborne" (Tag 110) or "Take-Off Time" (Tag 131) but not both in the same
+ * MISB ST 0601 Local Set.
+ * <p>
+ * Time Airborne is a continual count of the number of seconds since the
+ * aircraft took off from the ground (or ship). The Take-Off time (Tag 131) is
+ * the timestamp indicating when the aircraft became airborne. The Time Airborne
+ * and Take-Off Time are related mathematically using the Precision Time Stamp
+ * (Tag 2), so the Local Set needs only one of these items to compute the other.
+ * </blockquote>
+ */
+public class TimeAirborne implements IUasDatalinkValue
+{
+    private long seconds;
+    private static long MIN_VAL = 0;
+    private static long MAX_VAL = 4294967295L; // 2^32-1
+    private static int MAX_BYTES = 4;
+
+    /**
+     * Create from value
+     * @param seconds time in seconds. Legal values are in [0,2^31-1].
+     */
+    public TimeAirborne(long seconds)
+    {
+        if (seconds > MAX_VAL || seconds < MIN_VAL)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " must be in range [0,2^32-1]");
+        }
+        this.seconds = seconds;
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes Byte array, maximum four bytes
+     */
+    public TimeAirborne(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " field length must be 1 - 4 bytes");
+        }
+        this.seconds = PrimitiveConverter.variableBytesToUint32(bytes);
+    }
+
+    /**
+     * Get the time airborne
+     * @return The time airborne, in seconds
+     */
+    public long getSeconds()
+    {
+        return seconds;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        return PrimitiveConverter.uint32ToVariableBytes(this.seconds);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return seconds + "s";
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Time Airborne";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -259,11 +259,9 @@ public class UasDatalinkFactory
             case RangeToRecoveryLocation:
                 return new RangeToRecoveryLocation(bytes);
             case TimeAirborne:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new TimeAirborne(bytes);
             case PropulsionUnitSpeed:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new PropulsionUnitSpeed(bytes);
             case PlatformCourseAngle:
                 return new PlatformCourseAngle(bytes);
             case AltitudeAgl:

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -227,9 +227,9 @@ public enum UasDatalinkTag
     BroadcastSource(108),
     /** Tag 109; Distance from current position to airframe recovery position; Value is a {@link RangeToRecoveryLocation} */
     RangeToRecoveryLocation(109),
-    /** Tag 110; Number of seconds aircraft has been airborne; Value is a {@link OpaqueValue} */
+    /** Tag 110; Number of seconds aircraft has been airborne; Value is a {@link TimeAirborne} */
     TimeAirborne(110),
-    /** Tag 111; The speed the engine (or electric motor) is rotating at; Value is a {@link OpaqueValue} */
+    /** Tag 111; The speed the engine (or electric motor) is rotating at; Value is a {@link PropulsionUnitSpeed} */
     PropulsionUnitSpeed(111),
     /** Tag 112; Direction the aircraft is moving relative to True North; Value is a {@link PlatformCourseAngle} */
     PlatformCourseAngle(112),

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PropulsionUnitSpeedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PropulsionUnitSpeedTest.java
@@ -1,0 +1,194 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PropulsionUnitSpeedTest
+{
+    @Test
+    public void testMinMax()
+    {
+        PropulsionUnitSpeed speed = new PropulsionUnitSpeed(0);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        byte[] bytes = speed.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getSpeed(), 0);
+        Assert.assertEquals(speed.getDisplayableValue(), "0rpm");
+
+        speed = new PropulsionUnitSpeed(4294967295L);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        bytes = speed.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(speed.getSpeed(), 4294967295L);
+        Assert.assertEquals(speed.getDisplayableValue(), "4294967295rpm");
+
+        bytes = new byte[]{(byte)0x00};
+        speed = new PropulsionUnitSpeed(bytes);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        Assert.assertEquals(speed.getSpeed(), 0L);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0rpm");
+
+        bytes = new byte[]{(byte)0xff};
+        speed = new PropulsionUnitSpeed(bytes);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        Assert.assertEquals(speed.getSpeed(), 255);
+        Assert.assertEquals(speed.getBytes(), bytes);
+        Assert.assertEquals(speed.getDisplayableValue(), "255rpm");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00};
+        speed = new PropulsionUnitSpeed(bytes);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        Assert.assertEquals(speed.getSpeed(), 0L);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0rpm");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff};
+        speed = new PropulsionUnitSpeed(bytes);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        Assert.assertEquals(speed.getSpeed(), 65535);
+        Assert.assertEquals(speed.getBytes(), bytes);
+        Assert.assertEquals(speed.getDisplayableValue(), "65535rpm");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00};
+        speed = new PropulsionUnitSpeed(bytes);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        Assert.assertEquals(speed.getSpeed(), 0L);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0rpm");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff};
+        speed = new PropulsionUnitSpeed(bytes);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        Assert.assertEquals(speed.getSpeed(), 16777215L);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(speed.getDisplayableValue(), "16777215rpm");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        speed = new PropulsionUnitSpeed(bytes);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        Assert.assertEquals(speed.getSpeed(), 0L);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0rpm");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        speed = new PropulsionUnitSpeed(bytes);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        Assert.assertEquals(speed.getSpeed(), 4294967295L);
+        Assert.assertEquals(speed.getBytes(), bytes);
+        Assert.assertEquals(speed.getDisplayableValue(), "4294967295rpm");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testOutOfBoundsMin()
+    {
+        new PropulsionUnitSpeed(-1L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testOutOfBoundsMax()
+    {
+        new PropulsionUnitSpeed(4294967296L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadLength()
+    {
+        byte[] fiveByteArray = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        new PropulsionUnitSpeed(fiveByteArray);
+    }
+
+    @Test
+    public void stExample()
+    {
+        long value = 3000L;
+        byte[] origBytes = new byte[]{(byte)0x0B, (byte)0xB8};
+
+        PropulsionUnitSpeed speed = new PropulsionUnitSpeed(origBytes);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        Assert.assertEquals(speed.getSpeed(), value);
+        Assert.assertEquals(speed.getBytes(), origBytes);
+        Assert.assertEquals(speed.getDisplayableValue(), "3000rpm");
+
+        speed = new PropulsionUnitSpeed(value);
+        Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
+        Assert.assertEquals(speed.getSpeed(), value);
+        Assert.assertEquals(speed.getBytes(), origBytes);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException {
+        byte[] bytes = new byte[]{(byte)0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.PropulsionUnitSpeed, bytes);
+        Assert.assertTrue(v instanceof PropulsionUnitSpeed);
+        Assert.assertEquals(v.getDisplayName(), "Propulsion Unit Speed");
+        PropulsionUnitSpeed speed = (PropulsionUnitSpeed)v;
+        Assert.assertEquals(speed.getSpeed(), 0L);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0rpm");
+
+        bytes = new byte[]{(byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PropulsionUnitSpeed, bytes);
+        Assert.assertTrue(v instanceof PropulsionUnitSpeed);
+        Assert.assertEquals(v.getDisplayName(), "Propulsion Unit Speed");
+        speed = (PropulsionUnitSpeed)v;
+        Assert.assertEquals(speed.getSpeed(), 255);
+        Assert.assertEquals(speed.getBytes(), bytes);
+        Assert.assertEquals(speed.getDisplayableValue(), "255rpm");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PropulsionUnitSpeed, bytes);
+        Assert.assertTrue(v instanceof PropulsionUnitSpeed);
+        Assert.assertEquals(v.getDisplayName(), "Propulsion Unit Speed");
+        speed = (PropulsionUnitSpeed)v;
+        Assert.assertEquals(speed.getSpeed(), 0L);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0rpm");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PropulsionUnitSpeed, bytes);
+        Assert.assertTrue(v instanceof PropulsionUnitSpeed);
+        Assert.assertEquals(v.getDisplayName(), "Propulsion Unit Speed");
+        speed = (PropulsionUnitSpeed)v;
+        Assert.assertEquals(speed.getSpeed(), 65535);
+        Assert.assertEquals(speed.getBytes(), bytes);
+        Assert.assertEquals(speed.getDisplayableValue(), "65535rpm");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PropulsionUnitSpeed, bytes);
+        Assert.assertTrue(v instanceof PropulsionUnitSpeed);
+        Assert.assertEquals(v.getDisplayName(), "Propulsion Unit Speed");
+        speed = (PropulsionUnitSpeed)v;
+        Assert.assertEquals(speed.getSpeed(), 0L);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0rpm");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PropulsionUnitSpeed, bytes);
+        Assert.assertTrue(v instanceof PropulsionUnitSpeed);
+        Assert.assertEquals(v.getDisplayName(), "Propulsion Unit Speed");
+        speed = (PropulsionUnitSpeed)v;
+        Assert.assertEquals(speed.getSpeed(), 16777215L);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(speed.getDisplayableValue(), "16777215rpm");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PropulsionUnitSpeed, bytes);
+        Assert.assertTrue(v instanceof PropulsionUnitSpeed);
+        Assert.assertEquals(v.getDisplayName(), "Propulsion Unit Speed");
+        speed = (PropulsionUnitSpeed)v;
+        Assert.assertEquals(speed.getSpeed(), 0L);
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(speed.getDisplayableValue(), "0rpm");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.PropulsionUnitSpeed, bytes);
+        Assert.assertTrue(v instanceof PropulsionUnitSpeed);
+        Assert.assertEquals(v.getDisplayName(), "Propulsion Unit Speed");
+        speed = (PropulsionUnitSpeed)v;
+        Assert.assertEquals(speed.getSpeed(), 4294967295L);
+        Assert.assertEquals(speed.getBytes(), bytes);
+        Assert.assertEquals(speed.getDisplayableValue(), "4294967295rpm");
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/TimeAirborneTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/TimeAirborneTest.java
@@ -1,0 +1,194 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TimeAirborneTest
+{
+    @Test
+    public void testMinMax()
+    {
+        TimeAirborne time = new TimeAirborne(0);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        byte[] bytes = time.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getSeconds(), 0);
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        time = new TimeAirborne(4294967295L);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        bytes = time.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(time.getSeconds(), 4294967295L);
+        Assert.assertEquals(time.getDisplayableValue(), "4294967295s");
+
+        bytes = new byte[]{(byte)0x00};
+        time = new TimeAirborne(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0xff};
+        time = new TimeAirborne(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        Assert.assertEquals(time.getSeconds(), 255);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "255s");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00};
+        time = new TimeAirborne(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff};
+        time = new TimeAirborne(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        Assert.assertEquals(time.getSeconds(), 65535);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "65535s");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00};
+        time = new TimeAirborne(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff};
+        time = new TimeAirborne(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        Assert.assertEquals(time.getSeconds(), 16777215L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(time.getDisplayableValue(), "16777215s");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        time = new TimeAirborne(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        time = new TimeAirborne(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        Assert.assertEquals(time.getSeconds(), 4294967295L);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "4294967295s");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testOutOfBoundsMin()
+    {
+        new TimeAirborne(-1L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testOutOfBoundsMax()
+    {
+        new TimeAirborne(4294967296L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadLength()
+    {
+        byte[] fiveByteArray = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        new TimeAirborne(fiveByteArray);
+    }
+
+    @Test
+    public void stExample()
+    {
+        long value = 19887L;
+        byte[] origBytes = new byte[]{(byte)0x4D, (byte)0xaf};
+
+        TimeAirborne time = new TimeAirborne(origBytes);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        Assert.assertEquals(time.getSeconds(), value);
+        Assert.assertEquals(time.getBytes(), origBytes);
+        Assert.assertEquals(time.getDisplayableValue(), "19887s");
+
+        time = new TimeAirborne(value);
+        Assert.assertEquals(time.getDisplayName(), "Time Airborne");
+        Assert.assertEquals(time.getSeconds(), value);
+        Assert.assertEquals(time.getBytes(), origBytes);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException {
+        byte[] bytes = new byte[]{(byte)0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.TimeAirborne, bytes);
+        Assert.assertTrue(v instanceof TimeAirborne);
+        Assert.assertEquals(v.getDisplayName(), "Time Airborne");
+        TimeAirborne time = (TimeAirborne)v;
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TimeAirborne, bytes);
+        Assert.assertTrue(v instanceof TimeAirborne);
+        Assert.assertEquals(v.getDisplayName(), "Time Airborne");
+        time = (TimeAirborne)v;
+        Assert.assertEquals(time.getSeconds(), 255);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "255s");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TimeAirborne, bytes);
+        Assert.assertTrue(v instanceof TimeAirborne);
+        Assert.assertEquals(v.getDisplayName(), "Time Airborne");
+        time = (TimeAirborne)v;
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TimeAirborne, bytes);
+        Assert.assertTrue(v instanceof TimeAirborne);
+        Assert.assertEquals(v.getDisplayName(), "Time Airborne");
+        time = (TimeAirborne)v;
+        Assert.assertEquals(time.getSeconds(), 65535);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "65535s");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TimeAirborne, bytes);
+        Assert.assertTrue(v instanceof TimeAirborne);
+        Assert.assertEquals(v.getDisplayName(), "Time Airborne");
+        time = (TimeAirborne)v;
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TimeAirborne, bytes);
+        Assert.assertTrue(v instanceof TimeAirborne);
+        Assert.assertEquals(v.getDisplayName(), "Time Airborne");
+        time = (TimeAirborne)v;
+        Assert.assertEquals(time.getSeconds(), 16777215L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(time.getDisplayableValue(), "16777215s");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TimeAirborne, bytes);
+        Assert.assertTrue(v instanceof TimeAirborne);
+        Assert.assertEquals(v.getDisplayName(), "Time Airborne");
+        time = (TimeAirborne)v;
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.TimeAirborne, bytes);
+        Assert.assertTrue(v instanceof TimeAirborne);
+        Assert.assertEquals(v.getDisplayName(), "Time Airborne");
+        time = (TimeAirborne)v;
+        Assert.assertEquals(time.getSeconds(), 4294967295L);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "4294967295s");
+    }
+}

--- a/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
+++ b/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
@@ -32,6 +32,32 @@ public class PrimitiveConverter
         return res;
     }
 
+    /**
+     * Convert an unsigned 32-bit unsigned integer (long with range of uint32) to a byte array.
+     * <p>
+     * This is similar to uint32ToBytes, except that it only uses the minimum
+     * required number of bytes to represent the value. So if the value will
+     * fit into two bytes, the results will be only two bytes.
+     *
+     * @param longValue The unsigned 32-bit integer as long
+     * @return The array of length 1-4 bytes.
+     */
+    public static byte[] uint32ToVariableBytes(long longValue)
+    {
+        if (longValue > 65535)
+        {
+            return PrimitiveConverter.uint32ToBytes(longValue);
+        }
+        else if (longValue > 255)
+        {
+            return PrimitiveConverter.uint16ToBytes((int)longValue);
+        }
+        else
+        {
+            return PrimitiveConverter.uint8ToBytes((short)longValue);
+        }
+    }
+
     private PrimitiveConverter() {}
 
     /**

--- a/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
@@ -250,6 +250,42 @@ public class PrimitiveConverterTest
     }
 
     @Test
+    public void testUnsignedInt32ToVariableBytes()
+    {
+        long longVal = 1L;
+        byte[] bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{0x01});
+
+        longVal = 255L;
+        bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff});
+
+        longVal = 256L;
+        bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00});
+
+        longVal = 65535L;
+        bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff});
+
+        longVal = 65536L;
+        bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x00, (byte)0x01, (byte)0x00, (byte)0x00});
+
+        longVal = 16777215L;
+        bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        longVal = 16777216L;
+        bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        longVal = (long) Math.pow(2, 32) - 1;
+        bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+    }
+
+    @Test
     public void testUnsignedInt8ToBytes()
     {
         short shortVal = 0;


### PR DESCRIPTION
## Motivation and Context
Adds support for two tags we previously didn't support.

## Description
These follow a fairly standard implementation of IUasDatalinkValue.

PrimitiveConverter is extended to provide shared implementation.

Includes applicable javadoc and full test coverage.

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

