### PR TITLE
Add support for Leap Seconds (ST0601 Tag 136).

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/LeapSeconds.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/LeapSeconds.java
@@ -1,0 +1,83 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * Leap Seconds (ST 0601 tag 136).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Number of leap seconds to adjust Precision Time Stamp (Tag 2) to UTC.
+ * <p>
+ * KLV format: int, Min: -(2^31), Max: (2^31)-1.
+ * <p>
+ * Length: variable, Max Length: 4, Required Length: N/A.
+ * <p>
+ * Resolution: 1 second.
+ * <p>
+ * Add this value to Precision Time Stamp (Tag 2) to convert to UTC.
+ * <p>
+ * When adjusting Precision Time Stamp to UTC multiply this leap second value by
+ * 1,000,000 to convert it to microseconds.
+ * <p>
+ * See handbook for more details on Leap Seconds and the MISP Time System.
+ * <p>
+ * See "Packet Timestamp" section for more information on the use of this item.
+ * </blockquote>
+ */
+public class LeapSeconds implements IUasDatalinkValue
+{
+    private int seconds;
+    private static long MIN_VAL = -2147483648; // -2^31
+    private static long MAX_VAL = 2147483647; // 2^31-1
+    private static int MAX_BYTES = 4;
+
+    /**
+     * Create from value
+     * @param seconds time in seconds. Legal values are in [-2^31,2^31-1].
+     */
+    public LeapSeconds(int seconds)
+    {
+        this.seconds = seconds;
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes Byte array, maximum four bytes
+     */
+    public LeapSeconds(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " field length must be 1 - 4 bytes");
+        }
+        this.seconds = PrimitiveConverter.toInt32(bytes);
+    }
+
+    /**
+     * Get the number of leap seconds
+     * @return The leap second offset, in seconds
+     */
+    public int getSeconds()
+    {
+        return seconds;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        return PrimitiveConverter.int32ToVariableBytes(this.seconds);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return seconds + "s";
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Leap Seconds";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -316,8 +316,7 @@ public class UasDatalinkFactory
             case CommunicationsMethod:
                 return new UasDatalinkString(UasDatalinkString.COMMUNICATIONS_METHOD, bytes);
             case LeapSeconds:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new LeapSeconds(bytes);
             case CorrectionOffset:
                 // TODO
                 return new OpaqueValue(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -279,7 +279,7 @@ public enum UasDatalinkTag
     ZoomPercentage(134),
     /** Tag 135; Type of communications used with platform; Value is a {@link UasDatalinkString} */
     CommunicationsMethod(135),
-    /** Tag 136; Number of leap seconds to adjust Precision Time Stamp (Tag 2) to UTC; Value is a {@link OpaqueValue} */
+    /** Tag 136; Number of leap seconds to adjust Precision Time Stamp (Tag 2) to UTC; Value is a {@link LeapSeconds} */
     LeapSeconds(136),
     /** Tag 137; Post-flight time adjustment to correct Precision Time Stamp (Tag 2) as needed; Value is a {@link OpaqueValue} */
     CorrectionOffset(137),

--- a/api/src/test/java/org/jmisb/api/klv/st0601/LeapSecondsTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/LeapSecondsTest.java
@@ -1,0 +1,189 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class LeapSecondsTest
+{
+    @Test
+    public void testMinMax()
+    {
+        LeapSeconds time = new LeapSeconds(2147483647);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        byte[] bytes = time.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(time.getSeconds(), 2147483647);
+        Assert.assertEquals(time.getDisplayableValue(), "2147483647s");
+
+        time = new LeapSeconds(-2147483648);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        bytes = time.getBytes();
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00});
+        Assert.assertEquals(time.getSeconds(), -2147483648);
+        Assert.assertEquals(time.getDisplayableValue(), "-2147483648s");
+
+        bytes = new byte[]{(byte)0x7F};
+        time = new LeapSeconds(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), 127);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x7F});
+        Assert.assertEquals(time.getDisplayableValue(), "127s");
+
+        bytes = new byte[]{(byte)0x80};
+        time = new LeapSeconds(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), -128);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "-128s");
+
+        bytes = new byte[]{(byte)0x7F, (byte)0xFF};
+        time = new LeapSeconds(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), 32767);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x7F, (byte)0xFF});
+        Assert.assertEquals(time.getDisplayableValue(), "32767s");
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00};
+        time = new LeapSeconds(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), -32768);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "-32768s");
+
+        bytes = new byte[]{(byte)0x7F, (byte)0xFF, (byte)0xFF};
+        time = new LeapSeconds(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), 8388607);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00, (byte)0x7F, (byte)0xFF, (byte)0xFF});
+        Assert.assertEquals(time.getDisplayableValue(), "8388607s");
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00, (byte)0x00};
+        time = new LeapSeconds(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), -8388608);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0xFF, (byte)0x80, (byte)0x00, (byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "-8388608s");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        time = new LeapSeconds(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0x7f, (byte)0xff, (byte)0xff, (byte)0xff};
+        time = new LeapSeconds(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), 2147483647);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "2147483647s");
+        
+        bytes = new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00};
+        time = new LeapSeconds(bytes);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), -2147483648);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "-2147483648s");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadLength()
+    {
+        byte[] fiveByteArray = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        new LeapSeconds(fiveByteArray);
+    }
+
+    @Test
+    public void stExample()
+    {
+        int value = 30;
+        byte[] origBytes = new byte[]{(byte)0x1E};
+
+        LeapSeconds time = new LeapSeconds(origBytes);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), value);
+        Assert.assertEquals(time.getBytes(), origBytes);
+        Assert.assertEquals(time.getDisplayableValue(), "30s");
+
+        time = new LeapSeconds(value);
+        Assert.assertEquals(time.getDisplayName(), "Leap Seconds");
+        Assert.assertEquals(time.getSeconds(), value);
+        Assert.assertEquals(time.getBytes(), origBytes);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException {
+        byte[] bytes = new byte[]{(byte)0x00};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.LeapSeconds, bytes);
+        Assert.assertTrue(v instanceof LeapSeconds);
+        Assert.assertEquals(v.getDisplayName(), "Leap Seconds");
+        LeapSeconds time = (LeapSeconds)v;
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0x7f};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.LeapSeconds, bytes);
+        Assert.assertTrue(v instanceof LeapSeconds);
+        Assert.assertEquals(v.getDisplayName(), "Leap Seconds");
+        time = (LeapSeconds)v;
+        Assert.assertEquals(time.getSeconds(), 127);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "127s");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.LeapSeconds, bytes);
+        Assert.assertTrue(v instanceof LeapSeconds);
+        Assert.assertEquals(v.getDisplayName(), "Leap Seconds");
+        time = (LeapSeconds)v;
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.LeapSeconds, bytes);
+        Assert.assertTrue(v instanceof LeapSeconds);
+        Assert.assertEquals(v.getDisplayName(), "Leap Seconds");
+        time = (LeapSeconds)v;
+        Assert.assertEquals(time.getSeconds(), -32768);
+        Assert.assertEquals(time.getBytes(), bytes);
+        Assert.assertEquals(time.getDisplayableValue(), "-32768s");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.LeapSeconds, bytes);
+        Assert.assertTrue(v instanceof LeapSeconds);
+        Assert.assertEquals(v.getDisplayName(), "Leap Seconds");
+        time = (LeapSeconds)v;
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.LeapSeconds, bytes);
+        Assert.assertTrue(v instanceof LeapSeconds);
+        Assert.assertEquals(v.getDisplayName(), "Leap Seconds");
+        time = (LeapSeconds)v;
+        Assert.assertEquals(time.getSeconds(), -8388608);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0xff, (byte)0x80, (byte)0x00, (byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "-8388608s");
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.LeapSeconds, bytes);
+        Assert.assertTrue(v instanceof LeapSeconds);
+        Assert.assertEquals(v.getDisplayName(), "Leap Seconds");
+        time = (LeapSeconds)v;
+        Assert.assertEquals(time.getSeconds(), 0L);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00});
+        Assert.assertEquals(time.getDisplayableValue(), "0s");
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        v = UasDatalinkFactory.createValue(UasDatalinkTag.LeapSeconds, bytes);
+        Assert.assertTrue(v instanceof LeapSeconds);
+        Assert.assertEquals(v.getDisplayName(), "Leap Seconds");
+        time = (LeapSeconds)v;
+        Assert.assertEquals(time.getSeconds(), -1);
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0xff});
+        Assert.assertEquals(time.getDisplayableValue(), "-1s");
+    }
+}

--- a/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
+++ b/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
@@ -63,7 +63,7 @@ public class PrimitiveConverter
     /**
      * Convert a byte array to a signed 32-bit integer
      *
-     * @param bytes The array of length 4, 2, or 1
+     * @param bytes The array of length 1 - 4
      * @return The signed 32-bit integer
      */
     public static int toInt32(byte[] bytes)
@@ -71,6 +71,9 @@ public class PrimitiveConverter
         if (bytes.length == 4)
         {
             return ByteBuffer.wrap(bytes).getInt();
+        } else if (bytes.length == 3) {
+            int res = ByteBuffer.wrap(bytes, 0, 2).getShort();
+            return (res << 8) + (bytes[2] & 0xFF);
         } else if (bytes.length == 2)
         {
             return ByteBuffer.wrap(bytes).getShort();
@@ -140,6 +143,32 @@ public class PrimitiveConverter
     {
         intBuffer.get().putInt(0, val);
         return intBuffer.get().array();
+    }
+
+    /**
+     * Convert an signed 32-bit integer to a byte array.
+     * <p>
+     * This is similar to int32ToBytes, except that it only uses the minimum
+     * required number of bytes to represent the value. So if the value will
+     * fit into two bytes, the results will be only two bytes.
+     * 
+     * @param intValue The signed 32-bit integer
+     * @return The array of length 1-4 bytes.
+     */
+    public static byte[] int32ToVariableBytes(int intValue)
+    {
+        if ((intValue > 32767) || (intValue < -32768))
+        {
+            return PrimitiveConverter.int32ToBytes(intValue);
+        }
+        else if (((short)intValue > 127) || ((short)intValue < -128))
+        {
+            return PrimitiveConverter.int16ToBytes((short)intValue);
+        }
+        else
+        {
+            return new byte[]{(byte)intValue};
+        }
     }
 
     /**

--- a/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
@@ -63,13 +63,22 @@ public class PrimitiveConverterTest
         intVal = PrimitiveConverter.toInt32(new byte[]{0x00, 0x00, 0x00, 0x00});
         Assert.assertEquals(intVal, 0);
 
+        intVal = PrimitiveConverter.toInt32(new byte[]{0x00, 0x00, 0x00});
+        Assert.assertEquals(intVal, 0);
+
         intVal = PrimitiveConverter.toInt32(new byte[]{0x00, 0x03});
+        Assert.assertEquals(intVal, 3);
+        
+        intVal = PrimitiveConverter.toInt32(new byte[]{0x00, 0x00, 0x03});
         Assert.assertEquals(intVal, 3);
 
         intVal = PrimitiveConverter.toInt32(new byte[]{0x11});
         Assert.assertEquals(intVal, 17);
 
         intVal = PrimitiveConverter.toInt32(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(intVal, -1);
+        
+        intVal = PrimitiveConverter.toInt32(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
         Assert.assertEquals(intVal, -1);
     }
 
@@ -99,6 +108,62 @@ public class PrimitiveConverterTest
         intVal = 10;
         bytes = PrimitiveConverter.int32ToBytes(intVal);
         Assert.assertEquals(bytes, new byte[]{0x00, 0x00, 0x00, 0x0a});
+    }
+
+    @Test
+    public void testSignedInt32ToVariableBytes()
+    {
+        int intVal = -1;
+        byte[] bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff});
+
+        intVal = 0;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{0x00});
+
+        intVal = 10;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{0x0a});
+        
+        intVal = 127;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{0x7f});
+        
+        intVal = -127;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x81});
+
+        intVal = -128;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80});
+
+        intVal = 128;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x00, (byte)0x80});
+        
+        intVal = -129;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xFF, (byte)0x7F});
+        
+        intVal = 32767;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x7F, (byte)0xFF});
+
+        intVal = -32767;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x01});
+        
+        intVal = -32768;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x00});
+        
+        intVal = 32768;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x00, (byte)0x00, (byte)0x80, (byte)0x00});
+        
+        intVal = -32769;
+        bytes = PrimitiveConverter.int32ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xFF, (byte)0xFF, (byte)0x7F, (byte)0xFF});
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
## Motivation and Context
Adds support for a tag we didn't previously support.

## Description
Fairly standard IUasDatalinkValue impl. Shares some variable-length encoding / decoding in PrimitiveConverter.

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

