### PR TITLE
Implement Airbase Locations for ST0601

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/AirbaseLocations.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AirbaseLocations.java
@@ -1,0 +1,296 @@
+package org.jmisb.api.klv.st0601;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jmisb.api.klv.BerDecoder;
+import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.BerField;
+import org.jmisb.api.klv.st0601.dto.Location;
+import org.jmisb.api.klv.st1201.FpEncoder;
+import org.jmisb.core.klv.ArrayUtils;
+
+/**
+ * Airbase Locations (ST 0601 tag 130).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * The Airbase Locations item is a Variable Length Pack (VLP) describing either
+ * the take-off location, the recovery location or both within a Location
+ * Defined Length Pack (DLP).
+ * <p>
+ * Both the take-off and recovery locations are coordinates with WGS84 Latitude,
+ * Longitude and Height Above Ellipsoid (HAE). Each location is described in a
+ * DLP containing IMAPB values for latitude, longitude and HAE. The latitude and
+ * longitude are each four (4) bytes and the HAE is three (3) bytes.
+ * </blockquote>
+ * <p>
+ * See the Location data transfer object documentation for description of the
+ * components within a Location.
+ */
+public class AirbaseLocations implements IUasDatalinkValue
+{
+    private Location takeoffLocation;
+    private Location recoveryLocation;
+    private boolean takeoffLocationIsUnknown;
+    private boolean recoveryLocationIsUnknown;
+
+    private final FpEncoder latDecoder = new FpEncoder(-90, 90, 4);
+    private final FpEncoder lonDecoder = new FpEncoder(-180, 180, 4);
+    private final FpEncoder haeDecoder = new FpEncoder(-900, 9000, 3);
+
+    /**
+     * Create from values
+     *
+     * @param takeoff the takeoff location (latitude/longitude, optional height)
+     * @param recovery the recovery location (latitude/longitude, optional height)
+     */
+    public AirbaseLocations(Location takeoff, Location recovery)
+    {
+        takeoffLocation = takeoff;
+        takeoffLocationIsUnknown = false;
+        recoveryLocation = recovery;
+        recoveryLocationIsUnknown = false;
+    }
+
+    // Used by the static methods only. At least one of takeoff or recovery must
+    // be present.
+    private AirbaseLocations()
+    {
+    }
+
+    /**
+     * Create from value with a known takeoff location but unknown recovery location.
+     *
+     * @param takeoff the takeoff location (latitude/longitude, optional height)
+     */
+    static AirbaseLocations withUnknownRecovery(Location takeoff)
+    {
+        AirbaseLocations airbaseLocations = new AirbaseLocations();
+        airbaseLocations.takeoffLocation = takeoff;
+        airbaseLocations.takeoffLocationIsUnknown = false;
+        airbaseLocations.recoveryLocation = null;
+        airbaseLocations.recoveryLocationIsUnknown = true;
+        return airbaseLocations;
+    }
+
+    /**
+     * Create from value with a known recovery location but unknown takeoff location.
+     *
+     * @param recovery the recovery location (latitude/longitude, optional height)
+     */
+    static AirbaseLocations withUnknownTakeoff(Location recovery)
+    {
+        AirbaseLocations airbaseLocations = new AirbaseLocations();
+        airbaseLocations.takeoffLocation = null;
+        airbaseLocations.takeoffLocationIsUnknown = true;
+        airbaseLocations.recoveryLocation = recovery;
+        airbaseLocations.recoveryLocationIsUnknown = false;
+        return airbaseLocations;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes encoded value
+     */
+    public AirbaseLocations(byte[] bytes)
+    {
+        int idx = 0;
+        BerField takeoffLenField = BerDecoder.decode(bytes, idx, false);
+        idx += takeoffLenField.getLength();
+        switch (takeoffLenField.getValue()) {
+            case 11:
+                takeoffLocationIsUnknown = false;
+                takeoffLocation = new Location();
+                takeoffLocation.setLatitude(latDecoder.decode(bytes, idx));
+                idx += 4;
+                takeoffLocation.setLongitude(lonDecoder.decode(bytes, idx));
+                idx += 4;
+                double hae = haeDecoder.decode(bytes, idx);
+                takeoffLocation.setHAE(hae);
+                idx += 3;
+                break;
+            case 8:
+                takeoffLocationIsUnknown = false;
+                takeoffLocation = new Location();
+                takeoffLocation.setLatitude(latDecoder.decode(bytes, idx));
+                idx += 4;
+                takeoffLocation.setLongitude(lonDecoder.decode(bytes, idx));
+                idx += 4;
+                takeoffLocation.setHAE(-1000.0);
+                break;
+            case 0:
+                takeoffLocation = null;
+                takeoffLocationIsUnknown = true;
+                break;
+            default:
+                throw new IllegalArgumentException(this.getDisplayName() + " has unsupported length.");
+        }
+        if (idx == bytes.length)
+        {
+            // If we're out of length here, the pack is truncated.
+            // That means recovery location == takeoff location.
+            recoveryLocation = new Location();
+            recoveryLocation.setLatitude(takeoffLocation.getLatitude());
+            recoveryLocation.setLongitude(takeoffLocation.getLongitude());
+            recoveryLocation.setHAE(takeoffLocation.getHAE());
+        }
+        else
+        {
+            BerField recoveryLenField = BerDecoder.decode(bytes, idx, false);
+            idx += recoveryLenField.getLength();
+            switch (recoveryLenField.getValue()) {
+                case 11:
+                    recoveryLocationIsUnknown = false;
+                    recoveryLocation = new Location();
+                    recoveryLocation.setLatitude(latDecoder.decode(bytes, idx));
+                    idx += 4;
+                    recoveryLocation.setLongitude(lonDecoder.decode(bytes, idx));
+                    idx += 4;
+                    double hae = haeDecoder.decode(bytes, idx);
+                    recoveryLocation.setHAE(hae);
+                    idx += 3;
+                    break;
+                case 8:
+                    recoveryLocationIsUnknown = false;
+                    recoveryLocation = new Location();
+                    recoveryLocation.setLatitude(latDecoder.decode(bytes, idx));
+                    idx += 4;
+                    recoveryLocation.setLongitude(lonDecoder.decode(bytes, idx));
+                    idx += 4;
+                    recoveryLocation.setHAE(-1000.0);
+                    break;
+                case 0:
+                    recoveryLocation = null;
+                    recoveryLocationIsUnknown = true;
+                    break;
+                default:
+                    throw new IllegalArgumentException(this.getDisplayName() + " has unsupported length.");
+            }
+        }
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        List<byte[]> chunks = new ArrayList<>();
+        int totalLength = 0;
+        if (takeoffLocationIsUnknown)
+        {
+            byte[] takeoffLenBytes = BerEncoder.encode(0);
+            chunks.add(takeoffLenBytes);
+            totalLength += takeoffLenBytes.length;
+        }
+        else
+        {
+            int takeoffLen = 0;
+            byte[] latBytes = latDecoder.encode(takeoffLocation.getLatitude());
+            takeoffLen += latBytes.length;
+            byte[] lonBytes = lonDecoder.encode(takeoffLocation.getLongitude());
+            takeoffLen += lonBytes.length;
+            byte[] haeBytes = new byte[]{};
+            if (!(takeoffLocation.getHAE() < -900.0))
+            {
+                haeBytes = haeDecoder.encode(takeoffLocation.getHAE());
+                takeoffLen += haeBytes.length;
+            }
+            byte[] takeoffLenBytes = BerEncoder.encode(takeoffLen);
+            chunks.add(takeoffLenBytes);
+            chunks.add(latBytes);
+            chunks.add(lonBytes);
+            chunks.add(haeBytes);
+            totalLength += takeoffLen;
+            totalLength += takeoffLenBytes.length;
+        }
+        if (recoveryLocationIsUnknown)
+        {
+            byte[] recoveryLenBytes = BerEncoder.encode(0);
+            chunks.add(recoveryLenBytes);
+            totalLength += recoveryLenBytes.length;
+        }
+        else if (takeoffAndRecoveryLocationsAreTheSame())
+        {
+            // Nothing - its just omitted
+        }
+        else
+        {
+            int recoveryLen = 0;
+            byte[] latBytes = latDecoder.encode(recoveryLocation.getLatitude());
+            recoveryLen += latBytes.length;
+            byte[] lonBytes = lonDecoder.encode(recoveryLocation.getLongitude());
+            recoveryLen += lonBytes.length;
+            byte[] haeBytes = new byte[]{};
+            if (!(recoveryLocation.getHAE() < -900.0))
+            {
+                haeBytes = haeDecoder.encode(recoveryLocation.getHAE());
+                recoveryLen += haeBytes.length;
+            }
+            byte[] recoveryLenBytes = BerEncoder.encode(recoveryLen);
+            chunks.add(recoveryLenBytes);
+            chunks.add(latBytes);
+            chunks.add(lonBytes);
+            chunks.add(haeBytes);
+            totalLength += recoveryLen;
+            totalLength += recoveryLenBytes.length;
+        }
+        return ArrayUtils.arrayFromChunks(chunks, totalLength);
+    }
+
+    /**
+     * Get the Takeoff Location.
+     * <p>
+     * @return the location, or null if it is not known.
+     */
+    public Location getTakeoffLocation()
+    {
+        return takeoffLocation;
+    }
+
+    /**
+     * Get the Recovery Location.
+     * <p>
+     * @return the location, or null if it is not known.
+     */
+    public Location getRecoveryLocation()
+    {
+        return recoveryLocation;
+    }
+
+    /**
+     * Whether the takeoff location is unknown.
+     * <p>
+     * @return true if its unknown, false if its known
+     */
+    public boolean isTakeoffLocationUnknown()
+    {
+        return takeoffLocationIsUnknown;
+    }
+
+    /**
+     * Whether the recovery location is unknown.
+     * <p>
+     * @return true if its unknown, false if its known
+     */
+    public boolean isRecoveryLocationUnknown()
+    {
+        return recoveryLocationIsUnknown;
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return "[Airbase Locations]";
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Airbase Locations";
+    }
+
+    private boolean takeoffAndRecoveryLocationsAreTheSame()
+    {
+        return (takeoffLocation != null) && (takeoffLocation.equals(recoveryLocation));
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -302,8 +302,7 @@ public class UasDatalinkFactory
             case TargetId:
                 return new UasDatalinkString(UasDatalinkString.TARGET_ID, bytes);
             case AirbaseLocations:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new AirbaseLocations(bytes);
             case TakeOffTime:
                 // TODO
                 return new OpaqueValue(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -155,7 +155,7 @@ public enum UasDatalinkTag
     EventStartTimeUtc(72),
     /** Tag 73; MISB ST 0806 RVT Local Set metadata items; Value is a {@link OpaqueValue} */
     RvtLocalDataSet(73),
-    /** Tag 74; MISB ST 0903 VMTI Local Set metadata items; Value is a {@link OpaqueValue} */
+    /** Tag 74; MISB ST 0903 VMTI Local Set metadata items; Value is a {@link NestedVmtiLocalSet} */
     VmtiLocalDataSet(74),
     /** Tag 75; Sensor ellipsoid height as measured from the reference WGS84 ellipsoid; Value is a {@link SensorEllipsoidHeight} */
     SensorEllipsoidHeight(75),
@@ -267,7 +267,7 @@ public enum UasDatalinkTag
     WavelengthsList(128),
     /** Tag 129; Alpha-numeric identification of a target; Value is a {@link UasDatalinkString} */
     TargetId(129),
-    /** Tag 130; Geographic location of the take-off site and recovery site; Value is a {@link OpaqueValue} */
+    /** Tag 130; Geographic location of the take-off site and recovery site; Value is a {@link AirbaseLocations} */
     AirbaseLocations(130),
     /** Tag 131; Time when aircraft became airborne; Value is a {@link OpaqueValue} */
     TakeOffTime(131),

--- a/api/src/main/java/org/jmisb/api/klv/st0601/dto/Location.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/dto/Location.java
@@ -10,7 +10,7 @@ public class Location
 {
     private double latitude;
     private double longitude;
-    private double hae;
+    private double hae = -1000;
 
     /**
      * Get the location latitude
@@ -50,7 +50,9 @@ public class Location
 
     /**
      * Get the elevation of the location
-     * @return the elevation in metres above the WGS84 ellipsoid
+     *
+     * @return the elevation in metres above the WGS84 ellipsoid, or -1000 for
+     * invalid / unknown
      */
     public double getHAE()
     {
@@ -59,10 +61,48 @@ public class Location
 
     /**
      * Set the elevation of the location
-     * @param hae the elevation in metres above the WGS84 ellipsoid
+     *
+     * @param hae the elevation in metres above the WGS84 ellipsoid, or -1000
+     * for invalid / unknown
      */
     public void setHAE(double hae)
     {
         this.hae = hae;
     }
+
+    @Override
+    public int hashCode()
+    {
+        int hash = 7;
+        hash = 61 * hash + (int) (Double.doubleToLongBits(this.latitude) ^ (Double.doubleToLongBits(this.latitude) >>> 32));
+        hash = 61 * hash + (int) (Double.doubleToLongBits(this.longitude) ^ (Double.doubleToLongBits(this.longitude) >>> 32));
+        hash = 61 * hash + (int) (Double.doubleToLongBits(this.hae) ^ (Double.doubleToLongBits(this.hae) >>> 32));
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Location other = (Location) obj;
+        if (Double.doubleToLongBits(this.latitude) != Double.doubleToLongBits(other.latitude)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.longitude) != Double.doubleToLongBits(other.longitude)) {
+            return false;
+        }
+        if (Double.doubleToLongBits(this.hae) != Double.doubleToLongBits(other.hae)) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/AirbaseLocationsTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/AirbaseLocationsTest.java
@@ -1,0 +1,209 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0601.dto.Location;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
+
+public class AirbaseLocationsTest
+{
+    private final byte[] ST_EXAMPLE_BYTES = new byte[]{(byte) 0x0B, (byte) 0x40, (byte) 0x6B, (byte) 0xC2, (byte) 0x09, (byte) 0x19, (byte) 0xBD, (byte) 0xA5, (byte) 0x54, (byte) 0x07, (byte) 0x0E, (byte) 0x00, (byte) 0x0B, (byte) 0x40, (byte) 0x78, (byte) 0x3C, (byte) 0xB8, (byte) 0x19, (byte) 0xA2, (byte) 0x92, (byte) 0x74, (byte) 0x07, (byte) 0xC6, (byte) 0x00};
+    private final byte[] ST_EXAMPLE_BYTES_NO_HAE = new byte[]{(byte) 0x08, (byte) 0x40, (byte) 0x6B, (byte) 0xC2, (byte) 0x09, (byte) 0x19, (byte) 0xBD, (byte) 0xA5, (byte) 0x54, (byte) 0x08, (byte) 0x40, (byte) 0x78, (byte) 0x3C, (byte) 0xB8, (byte) 0x19, (byte) 0xA2, (byte) 0x92, (byte) 0x74};
+    private final byte[] ST_EXAMPLE_BYTES_UNKNOWN_TAKEOFF = new byte[]{(byte) 0x00, (byte) 0x0B, (byte) 0x40, (byte) 0x78, (byte) 0x3C, (byte) 0xB8, (byte) 0x19, (byte) 0xA2, (byte) 0x92, (byte) 0x74, (byte) 0x07, (byte) 0xC6, (byte) 0x00};
+    private final byte[] ST_EXAMPLE_BYTES_UNKNOWN_RECOVERY = new byte[]{(byte) 0x0B, (byte) 0x40, (byte) 0x6B, (byte) 0xC2, (byte) 0x09, (byte) 0x19, (byte) 0xBD, (byte) 0xA5, (byte) 0x54, (byte) 0x07, (byte) 0x0E, (byte) 0x00, (byte) 0x00};
+    private final byte[] ST_EXAMPLE_BYTES_OMIT_RECOVERY = new byte[]{(byte) 0x0B, (byte) 0x40, (byte) 0x6B, (byte) 0xC2, (byte) 0x09, (byte) 0x19, (byte) 0xBD, (byte) 0xA5, (byte) 0x54, (byte) 0x07, (byte) 0x0E, (byte) 0x00};
+
+    private final double TAKEOFF_LAT = 38.841859;
+    private final double TAKEOFF_LON = -77.036784;
+    private final double TAKEOFF_HAE = 3;
+    private final double RECOVERY_LAT = 38.939353;
+    private final double RECOVERY_LON = -77.459811;
+    private final double RECOVERY_HAE = 95;
+
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        Location takeoffLocation = new Location();
+        takeoffLocation.setLatitude(TAKEOFF_LAT);
+        takeoffLocation.setLongitude(TAKEOFF_LON);
+        takeoffLocation.setHAE(TAKEOFF_HAE);
+        Location recoveryLocation = new Location();
+        recoveryLocation.setLatitude(RECOVERY_LAT);
+        recoveryLocation.setLongitude(RECOVERY_LON);
+        recoveryLocation.setHAE(RECOVERY_HAE);
+        AirbaseLocations airbaseLocations = new AirbaseLocations(takeoffLocation, recoveryLocation);
+        checkValuesForExample(airbaseLocations);
+    }
+
+    @Test
+    public void testConstructFromValueUnknownTakeoff()
+    {
+        Location recoveryLocation = new Location();
+        recoveryLocation.setLatitude(RECOVERY_LAT);
+        recoveryLocation.setLongitude(RECOVERY_LON);
+        recoveryLocation.setHAE(RECOVERY_HAE);
+        AirbaseLocations airbaseLocations = AirbaseLocations.withUnknownTakeoff(recoveryLocation);
+        checkValuesForExampleUnknownTakeoff(airbaseLocations);
+    }
+
+    @Test
+    public void testConstructFromValueUnknownRecovery()
+    {
+        Location takeoffLocation = new Location();
+        takeoffLocation.setLatitude(TAKEOFF_LAT);
+        takeoffLocation.setLongitude(TAKEOFF_LON);
+        takeoffLocation.setHAE(TAKEOFF_HAE);
+        AirbaseLocations airbaseLocations = AirbaseLocations.withUnknownRecovery(takeoffLocation);
+        checkValuesForExampleUnknownRecovery(airbaseLocations);
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        AirbaseLocations airbaseLocations = new AirbaseLocations(ST_EXAMPLE_BYTES);
+        checkValuesForExample(airbaseLocations);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.AirbaseLocations, ST_EXAMPLE_BYTES);
+        assertTrue(v instanceof AirbaseLocations);
+        AirbaseLocations airbaseLocations = (AirbaseLocations)v;
+        checkValuesForExample(airbaseLocations);
+    }
+
+    @Test
+    public void testFactoryNoHAE() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.AirbaseLocations, ST_EXAMPLE_BYTES_NO_HAE);
+        assertTrue(v instanceof AirbaseLocations);
+        AirbaseLocations airbaseLocations = (AirbaseLocations)v;
+        checkValuesForExampleNoHAE(airbaseLocations);
+    }
+
+    @Test
+    public void testFactoryUnknownTakeoffLocation() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.AirbaseLocations, ST_EXAMPLE_BYTES_UNKNOWN_TAKEOFF);
+        assertTrue(v instanceof AirbaseLocations);
+        AirbaseLocations airbaseLocations = (AirbaseLocations)v;
+        checkValuesForExampleUnknownTakeoff(airbaseLocations);
+    }
+
+    @Test
+    public void testFactoryUnknownRecoveryLocation() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.AirbaseLocations, ST_EXAMPLE_BYTES_UNKNOWN_RECOVERY);
+        assertTrue(v instanceof AirbaseLocations);
+        AirbaseLocations airbaseLocations = (AirbaseLocations)v;
+        checkValuesForExampleUnknownRecovery(airbaseLocations);
+    }
+
+    @Test
+    public void testFactoryOmittedRecoveryLocation() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.AirbaseLocations, ST_EXAMPLE_BYTES_OMIT_RECOVERY);
+        assertTrue(v instanceof AirbaseLocations);
+        AirbaseLocations airbaseLocations = (AirbaseLocations)v;
+        checkValuesForExampleOmitRecovery(airbaseLocations);
+    }
+
+    private void checkValuesForExample(AirbaseLocations airbaseLocations)
+    {
+        assertEquals(airbaseLocations.getBytes(), ST_EXAMPLE_BYTES);
+        checkDisplayValues(airbaseLocations);
+        checkTakeoffLocationST(airbaseLocations);
+        checkRecoveryLocationST(airbaseLocations);
+    }
+
+    private void checkValuesForExampleNoHAE(AirbaseLocations airbaseLocations)
+    {
+        assertEquals(airbaseLocations.getBytes(), ST_EXAMPLE_BYTES_NO_HAE);
+        checkDisplayValues(airbaseLocations);
+        checkTakeoffLocationLatLon(airbaseLocations);
+        assertEquals(airbaseLocations.getTakeoffLocation().getHAE(), -1000, 0.00001);
+        checkRecoveryLocationLatLon(airbaseLocations);
+        assertEquals(airbaseLocations.getRecoveryLocation().getHAE(), -1000, 0.00001);
+    }
+
+    private void checkValuesForExampleUnknownRecovery(AirbaseLocations airbaseLocations)
+    {
+        assertEquals(airbaseLocations.getBytes(), ST_EXAMPLE_BYTES_UNKNOWN_RECOVERY);
+        checkDisplayValues(airbaseLocations);
+        checkTakeoffLocationST(airbaseLocations);
+        assertTrue(airbaseLocations.isRecoveryLocationUnknown());
+        assertNull(airbaseLocations.getRecoveryLocation());
+    }
+
+    private void checkValuesForExampleUnknownTakeoff(AirbaseLocations airbaseLocations)
+    {
+        assertEquals(airbaseLocations.getBytes(), ST_EXAMPLE_BYTES_UNKNOWN_TAKEOFF);
+        checkDisplayValues(airbaseLocations);
+        assertTrue(airbaseLocations.isTakeoffLocationUnknown());
+        assertNull(airbaseLocations.getTakeoffLocation());
+        checkRecoveryLocationST(airbaseLocations);
+    }
+
+    private void checkValuesForExampleOmitRecovery(AirbaseLocations airbaseLocations)
+    {
+        assertEquals(airbaseLocations.getBytes(), ST_EXAMPLE_BYTES_OMIT_RECOVERY);
+        checkDisplayValues(airbaseLocations);
+        checkTakeoffLocationST(airbaseLocations);
+        assertFalse(airbaseLocations.isRecoveryLocationUnknown());
+        // In this case, the takeoff and recovery locations really are meant to be the same
+        assertEquals(airbaseLocations.getRecoveryLocation().getLatitude(), TAKEOFF_LAT, 0.00001);
+        assertEquals(airbaseLocations.getRecoveryLocation().getLongitude(), TAKEOFF_LON, 0.00001);
+        assertEquals(airbaseLocations.getRecoveryLocation().getHAE(), TAKEOFF_HAE, 0.00001);
+    }
+
+    protected void checkDisplayValues(AirbaseLocations airbaseLocations)
+    {
+        assertEquals(airbaseLocations.getDisplayableValue(), "[Airbase Locations]");
+        assertEquals(airbaseLocations.getDisplayName(), "Airbase Locations");
+    }
+
+    protected void checkTakeoffLocationST(AirbaseLocations airbaseLocations)
+    {
+        checkTakeoffLocationLatLon(airbaseLocations);
+        assertEquals(airbaseLocations.getTakeoffLocation().getHAE(), TAKEOFF_HAE, 0.00001);
+    }
+
+    protected void checkRecoveryLocationST(AirbaseLocations airbaseLocations)
+    {
+        checkRecoveryLocationLatLon(airbaseLocations);
+        assertEquals(airbaseLocations.getRecoveryLocation().getHAE(), RECOVERY_HAE, 0.00001);
+    }
+
+    protected void checkRecoveryLocationLatLon(AirbaseLocations airbaseLocations)
+    {
+        assertFalse(airbaseLocations.isRecoveryLocationUnknown());
+        assertEquals(airbaseLocations.getRecoveryLocation().getLatitude(), RECOVERY_LAT, 0.00001);
+        assertEquals(airbaseLocations.getRecoveryLocation().getLongitude(), RECOVERY_LON, 0.00001);
+    }
+
+    protected void checkTakeoffLocationLatLon(AirbaseLocations airbaseLocations)
+    {
+        assertFalse(airbaseLocations.isTakeoffLocationUnknown());
+        assertEquals(airbaseLocations.getTakeoffLocation().getLatitude(), TAKEOFF_LAT, 0.00001);
+        assertEquals(airbaseLocations.getTakeoffLocation().getLongitude(), TAKEOFF_LON, 0.00001);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLengthTakeoff()
+    {
+        byte[] takeoffByteArrayLength1 = new byte[]{(byte) 0x01, (byte) 0x00, (byte) 0x00};
+        new AirbaseLocations(takeoffByteArrayLength1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLengthRecovery()
+    {
+        byte[] recoveryByteArrayLength1 = new byte[]{(byte) 0x0B, (byte) 0x40, (byte) 0x6B, (byte) 0xC2, (byte) 0x09, (byte) 0x19, (byte) 0xBD, (byte) 0xA5, (byte) 0x54, (byte) 0x07, (byte) 0x0E, (byte) 0x00, (byte) 0x01, (byte)0x00};
+        new AirbaseLocations(recoveryByteArrayLength1);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/dto/LocationTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/dto/LocationTest.java
@@ -1,0 +1,100 @@
+package org.jmisb.api.klv.st0601.dto;
+
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for Location DTO
+ */
+public class LocationTest
+{
+
+    @Test
+    public void hashTest()
+    {
+        Location loc = makeLocation();
+        assertEquals(loc.hashCode(), 0xc1f03e83);
+        loc.setLatitude(2.001);
+        assertEquals(loc.hashCode(), 0xe7b6b704);
+    }
+
+    @Test
+    public void equalsSameObject()
+    {
+        Location loc = makeLocation();
+        assertTrue(loc.equals(loc));
+    }
+
+    @Test
+    public void equalsSameValues()
+    {
+        Location loc1 = makeLocation();
+        Location loc2 = makeLocation();
+        assertTrue(loc1.equals(loc2));
+        assertTrue(loc2.equals(loc1));
+        assertTrue(loc1 != loc2);
+    }
+
+    @Test
+    public void equalsNull()
+    {
+        Location loc = makeLocation();
+        assertFalse(loc.equals(null));
+    }
+
+    @Test
+    public void equalsDifferentClass()
+    {
+        Location loc = makeLocation();
+        assertFalse(loc.equals(new String("blah")));
+    }
+
+    protected Location makeLocation()
+    {
+        Location loc = new Location();
+        loc.setLatitude(2.0);
+        loc.setLongitude(3.0);
+        loc.setHAE(1.0);
+        return loc;
+    }
+
+    @Test
+    public void equalsDifferentLat()
+    {
+        Location loc1 = makeLocation();
+        Location loc2 = makeLocation();
+        assertTrue(loc1.equals(loc2));
+        loc2.setLatitude(99.9);
+        assertFalse(loc1.equals(loc2));
+    }
+
+    @Test
+    public void equalsDifferentLon()
+    {
+        Location loc1 = makeLocation();
+        Location loc2 = makeLocation();
+        assertTrue(loc1.equals(loc2));
+        loc2.setLongitude(99.9);
+        assertFalse(loc1.equals(loc2));
+    }
+
+    @Test
+    public void equalsDifferentHae()
+    {
+        Location loc1 = makeLocation();
+        Location loc2 = makeLocation();
+        assertTrue(loc1.equals(loc2));
+        loc2.setHAE(99.9);
+        assertFalse(loc1.equals(loc2));
+    }
+
+    @Test
+    public void equalsOperations()
+    {
+        Location loc1 = makeLocation();
+        Location loc2 = makeLocation();
+        assertEquals(loc1, loc2);
+        loc2.setHAE(99.9);
+        assertNotEquals(loc1, loc2);
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Implements ST0601 Tag 130, which we don't currently support.

## Description
Mostly fairly standard IUasDatalinkValue implementation. There are a few special cases for unknown and takeoff == recovery locations which makes the code more complex and leads to a couple of static constructor methods.
I think I have them all, including unit tests for each combination.

There is one unrelated javadoc fix in the UasDatalinkTag enum, which I missed during the ST0903 incorporation.

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

