### PR TITLE
Remove debugging output from WaypointListTest

### DIFF
--- a/api/src/test/java/org/jmisb/api/klv/st0601/WaypointListTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/WaypointListTest.java
@@ -123,7 +123,6 @@ public class WaypointListTest
         Assert.assertEquals(wp3.getLocation().getLatitude(), 38.889822, 0.000001);
         Assert.assertEquals(wp3.getLocation().getLongitude(), -77.010092, 0.000001);
         Assert.assertEquals(wp3.getLocation().getHAE(), 300.0, 0.0001);
-        System.out.println("WaypointList");
         Assert.assertEquals(list.getBytes(), st_example_bytes);
         Assert.assertEquals(list.getDisplayableValue(), "[Waypoint List]");
         Assert.assertEquals(list.getDisplayName(), "Waypoint List");


### PR DESCRIPTION
## Motivation and Context
This removes one `System.out.println` debugging entry from WaypointListTest.
Not sure how I managed to leave that behind.  Doesn't do anything, just adds to the noise during a build.

## Description
Just deleted it.

## How Has This Been Tested?
Reran build.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

