### PR TITLE
Move some duplicated code to PrimitiveConverter

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0903/vmask/BitMaskSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vmask/BitMaskSeries.java
@@ -75,7 +75,7 @@ public class BitMaskSeries implements IVmtiMetadataValue
         List<byte[]> chunks = new ArrayList<>();
         for (PixelRunPair run: getRuns())
         {
-            byte[] pixelNumberBytes = getBytes(run.getPixelNumber());
+            byte[] pixelNumberBytes = PrimitiveConverter.uintToVariableBytesV6(run.getPixelNumber());
             byte[] pixelNumberLengthBytes = BerEncoder.encode(pixelNumberBytes.length);
             byte[] runBytes = BerEncoder.encode(run.getRun());
             int bytesForThisRun = pixelNumberLengthBytes.length + pixelNumberBytes.length + runBytes.length;
@@ -112,38 +112,6 @@ public class BitMaskSeries implements IVmtiMetadataValue
     public List<PixelRunPair> getRuns()
     {
         return bitMask;
-    }
-
-    private byte[] getBytes(long pixelNumber)
-    {
-        // TODO: move to primitive converter - shared with PixelNumber in VTarget
-        if (pixelNumber > 1099511627775L)
-        {
-            byte[] bytes = PrimitiveConverter.int64ToBytes(pixelNumber);
-            return new byte[]{bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]};
-        }
-        else if (pixelNumber > 4294967295L)
-        {
-            byte[] bytes = PrimitiveConverter.int64ToBytes(pixelNumber);
-            return new byte[]{bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]};
-        }
-        else if (pixelNumber > 16777215L)
-        {
-            return PrimitiveConverter.uint32ToBytes(pixelNumber);
-        }
-        else if (pixelNumber > 65535)
-        {
-            byte[] bytes = PrimitiveConverter.uint32ToBytes(pixelNumber);
-            return new byte[]{bytes[1], bytes[2], bytes[3]};
-        }
-        else if (pixelNumber > 255L)
-        {
-            return PrimitiveConverter.uint16ToBytes((int)pixelNumber);
-        }
-        else
-        {
-            return PrimitiveConverter.uint8ToBytes((short)pixelNumber);
-        }
     }
 
     private PixelRunPair parsePixelRunPair(byte[] valueBytes)

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vmask/PixelPolygon.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vmask/PixelPolygon.java
@@ -78,7 +78,7 @@ public class PixelPolygon implements IVmtiMetadataValue
         List<byte[]> chunks = new ArrayList<>();
         for (Long point: getPolygon())
         {
-            byte[] pointBytes = getBytes(point);
+            byte[] pointBytes = PrimitiveConverter.uintToVariableBytesV6(point);
             byte[] lengthBytes = BerEncoder.encode(pointBytes.length);
             chunks.add(lengthBytes);
             len += lengthBytes.length;
@@ -123,37 +123,5 @@ public class PixelPolygon implements IVmtiMetadataValue
             pixelNumber += ((int) bytes[i] & 0xFF);
         }
         return pixelNumber;
-    }
-
-    private byte[] getBytes(long pixelNumber)
-    {
-        // TODO: move to primitive converter - shared with PixelNumber in VTarget
-        if (pixelNumber > 1099511627775L)
-        {
-            byte[] bytes = PrimitiveConverter.int64ToBytes(pixelNumber);
-            return new byte[]{bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]};
-        }
-        else if (pixelNumber > 4294967295L)
-        {
-            byte[] bytes = PrimitiveConverter.int64ToBytes(pixelNumber);
-            return new byte[]{bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]};
-        }
-        else if (pixelNumber > 16777215L)
-        {
-            return PrimitiveConverter.uint32ToBytes(pixelNumber);
-        }
-        else if (pixelNumber > 65535)
-        {
-            byte[] bytes = PrimitiveConverter.uint32ToBytes(pixelNumber);
-            return new byte[]{bytes[1], bytes[2], bytes[3]};
-        }
-        else if (pixelNumber > 255L)
-        {
-            return PrimitiveConverter.uint16ToBytes((int)pixelNumber);
-        }
-        else
-        {
-            return PrimitiveConverter.uint8ToBytes((short)pixelNumber);
-        }
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/AbstractPixelIndex.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/AbstractPixelIndex.java
@@ -41,25 +41,7 @@ public abstract class AbstractPixelIndex implements IVmtiMetadataValue
     @Override
     public byte[] getBytes()
     {
-        // TODO: move this to PrimitiveConverter once the PRs settle down.
-        if (value < 256)
-        {
-            return PrimitiveConverter.uint8ToBytes((short)value);
-        }
-        else if (value < 65536)
-        {  
-            return PrimitiveConverter.uint16ToBytes((int)value);
-        }
-
-        byte[] bytes = PrimitiveConverter.uint32ToBytes(value);
-        if (bytes[0] == 0x00)
-        {
-            return new byte[]{bytes[1], bytes[2], bytes[3]};
-        }
-        else
-        {
-            return bytes;
-        }
+        return PrimitiveConverter.uint32ToVariableBytes(value);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/PixelNumber.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/PixelNumber.java
@@ -40,35 +40,7 @@ public abstract class PixelNumber implements IVmtiMetadataValue
     @Override
     public byte[] getBytes()
     {
-        // TODO: move to primitive converter - shared with PixelPolygon in VMask LS.
-        if (pixelNumber > 1099511627775L)
-        {
-            byte[] bytes = PrimitiveConverter.int64ToBytes(pixelNumber);
-            return new byte[]{bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]};
-        }
-        else if (pixelNumber > 4294967295L)
-        {
-            byte[] bytes = PrimitiveConverter.int64ToBytes(pixelNumber);
-            return new byte[]{bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]};
-        }
-        else if (pixelNumber > 16777215L) 
-        {
-            return PrimitiveConverter.uint32ToBytes(pixelNumber);
-        }
-        else if (pixelNumber > 65535)
-        {
-            byte[] bytes = PrimitiveConverter.uint32ToBytes(pixelNumber);
-            return new byte[]{bytes[1], bytes[2], bytes[3]};
-        }
-        else if (pixelNumber > 255L)
-        {
-            return PrimitiveConverter.uint16ToBytes((int)pixelNumber);
-        }
-        else
-        {
-            return PrimitiveConverter.uint8ToBytes((short)pixelNumber);
-        }
-
+        return PrimitiveConverter.uintToVariableBytesV6(pixelNumber);
     }
 
     @Override

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PropulsionUnitSpeedTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PropulsionUnitSpeedTest.java
@@ -62,7 +62,7 @@ public class PropulsionUnitSpeedTest
         speed = new PropulsionUnitSpeed(bytes);
         Assert.assertEquals(speed.getDisplayName(), "Propulsion Unit Speed");
         Assert.assertEquals(speed.getSpeed(), 16777215L);
-        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
         Assert.assertEquals(speed.getDisplayableValue(), "16777215rpm");
 
         bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
@@ -170,7 +170,7 @@ public class PropulsionUnitSpeedTest
         Assert.assertEquals(v.getDisplayName(), "Propulsion Unit Speed");
         speed = (PropulsionUnitSpeed)v;
         Assert.assertEquals(speed.getSpeed(), 16777215L);
-        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(speed.getBytes(), new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
         Assert.assertEquals(speed.getDisplayableValue(), "16777215rpm");
 
         bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};

--- a/api/src/test/java/org/jmisb/api/klv/st0601/TimeAirborneTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/TimeAirborneTest.java
@@ -62,7 +62,7 @@ public class TimeAirborneTest
         time = new TimeAirborne(bytes);
         Assert.assertEquals(time.getDisplayName(), "Time Airborne");
         Assert.assertEquals(time.getSeconds(), 16777215L);
-        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
         Assert.assertEquals(time.getDisplayableValue(), "16777215s");
 
         bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
@@ -170,7 +170,7 @@ public class TimeAirborneTest
         Assert.assertEquals(v.getDisplayName(), "Time Airborne");
         time = (TimeAirborne)v;
         Assert.assertEquals(time.getSeconds(), 16777215L);
-        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(time.getBytes(), new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
         Assert.assertEquals(time.getDisplayableValue(), "16777215s");
 
         bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};

--- a/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
+++ b/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
@@ -46,7 +46,12 @@ public class PrimitiveConverter
     {
         if (longValue > 65535)
         {
-            return PrimitiveConverter.uint32ToBytes(longValue);
+            byte[] bytes = PrimitiveConverter.uint32ToBytes(longValue);
+            if (bytes[0] == 0x00)
+            {
+                return new byte[]{bytes[1], bytes[2], bytes[3]};
+            }
+            return bytes;
         }
         else if (longValue > 255)
         {
@@ -55,6 +60,34 @@ public class PrimitiveConverter
         else
         {
             return PrimitiveConverter.uint8ToBytes((short)longValue);
+        }
+    }
+
+    /**
+     * Convert an unsigned 6 byte unsigned integer (long with range of uint48) to a byte array.
+     * <p>
+     * This only uses the minimum required number of bytes to represent the
+     * value. So if the value will fit into two bytes, the results will be only
+     * two bytes.
+     *
+     * @param longValue The unsigned integer as long
+     * @return The array of length 1-6 bytes.
+     */
+    public static byte[] uintToVariableBytesV6(long longValue)
+    {
+        if (longValue > 1099511627775L)
+        {
+            byte[] bytes = PrimitiveConverter.int64ToBytes(longValue);
+            return new byte[]{bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]};
+        }
+        else if (longValue > 4294967295L)
+        {
+            byte[] bytes = PrimitiveConverter.int64ToBytes(longValue);
+            return new byte[]{bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]};
+        }
+        else
+        {
+            return uint32ToVariableBytes(longValue);
         }
     }
 

--- a/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
@@ -335,11 +335,11 @@ public class PrimitiveConverterTest
 
         longVal = 65536L;
         bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
-        Assert.assertEquals(bytes, new byte[]{(byte)0x00, (byte)0x01, (byte)0x00, (byte)0x00});
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00});
 
         longVal = 16777215L;
         bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
-        Assert.assertEquals(bytes, new byte[]{(byte)0x00, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
 
         longVal = 16777216L;
         bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
@@ -348,6 +348,58 @@ public class PrimitiveConverterTest
         longVal = (long) Math.pow(2, 32) - 1;
         bytes = PrimitiveConverter.uint32ToVariableBytes(longVal);
         Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+    }
+
+    @Test
+    public void testUnsignedInt32ToVariableBytesV6()
+    {
+        long longVal = 1L;
+        byte[] bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{0x01});
+
+        longVal = 255L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff});
+
+        longVal = 256L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00});
+
+        longVal = 65535L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff});
+
+        longVal = 65536L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00});
+
+        longVal = 16777215L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
+
+        longVal = 16777216L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        longVal = 4294967295L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        longVal = 4294967296L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        longVal = 1099511627775L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        longVal = 1099511627776L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        longVal = 281474976710655L;
+        bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
During ST0903 work, there were a couple of byte conversions that seemed like they should be shared code, but I was worried about merge conflicts, so I duplicated the code and added TODO items. This  change pays down that technical debt.

## Description
Moves code around, adds tests.

There are two changes in tests for ST0601 classes where my earlier implementation only did 1, 2 and 4 bytes. The PrimitiveConverter will now do 3 bytes as well, so the tests needed update.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

