### PR TITLE
Remove out-of-date comment from VTrackerLS factory

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLS.java
@@ -65,8 +65,6 @@ public class VTrackerLS {
      */
     public static IVmtiMetadataValue createValue(VTrackerMetadataKey tag, byte[] bytes) throws KlvParseException
     {
-        // Keep the case statements in enum ordinal order so we can keep track of what is implemented.
-        // Mark all unimplemented tags with TODO.
         switch (tag) {
             case trackId:
                 return new TrackId(bytes);


### PR DESCRIPTION
## Motivation and Context
Just a minor comment cleanup - I was reviewing the TODO items, and this one showed up.

## Description
Just removes out-of-date comment.

## How Has This Been Tested?
Ran build / unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

