### PR TITLE
Fix Object Country Code encoding

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0102/ObjectCountryCodeString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/ObjectCountryCodeString.java
@@ -1,0 +1,51 @@
+package org.jmisb.api.klv.st0102;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Represents an Object Country Code value in ST 0102
+ */
+public class ObjectCountryCodeString implements ISecurityMetadataValue
+{
+    private String stringValue;
+
+    /**
+     * Create from value
+     * @param value The string value
+     */
+    public ObjectCountryCodeString(String value)
+    {
+        this.stringValue = value;
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes Encoded byte array
+     */
+    public ObjectCountryCodeString(byte[] bytes)
+    {
+        this.stringValue = new String(bytes, StandardCharsets.UTF_16);
+    }
+
+    /**
+     * Get the value
+     * @return The string value
+     */
+    public String getValue()
+    {
+        return stringValue;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        return stringValue.getBytes(StandardCharsets.UTF_16BE);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return stringValue;
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/LocalSetFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/LocalSetFactory.java
@@ -43,6 +43,7 @@ public class LocalSetFactory
             case OcCodingMethod:
                 return new OcMethod(bytes);
             case ObjectCountryCodes:
+                return new ObjectCountryCodeString(bytes);
             case ClassificationComments:
                 return new SecurityMetadataString(bytes);
             case ItemDesignatorId:

--- a/api/src/main/java/org/jmisb/api/klv/st0102/universalset/UniversalSetFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/universalset/UniversalSetFactory.java
@@ -41,6 +41,7 @@ public class UniversalSetFactory
                 return new SecurityMetadataString(bytes);
             case OcCodingMethod:
             case ObjectCountryCodes:
+                return new ObjectCountryCodeString(bytes);
             case ClassificationComments:
                 return new SecurityMetadataString(bytes);
             case ItemDesignatorId:

--- a/api/src/test/java/org/jmisb/api/klv/st0102/ObjectCountryCodeStringTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/ObjectCountryCodeStringTest.java
@@ -1,0 +1,25 @@
+package org.jmisb.api.klv.st0102;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ObjectCountryCodeStringTest
+{
+    @Test
+    public void testConstructFromValue()
+    {
+        ObjectCountryCodeString objectCountryCode = new ObjectCountryCodeString("US;CA");
+        Assert.assertEquals(objectCountryCode.getBytes().length, 10);
+        Assert.assertEquals(objectCountryCode.getDisplayableValue(), "US;CA");
+        Assert.assertEquals(objectCountryCode.getBytes(), new byte[]{(byte) 0x00, (byte) 0x55, (byte) 0x00, (byte) 0x53, (byte) 0x00, (byte) 0x3b, (byte) 0x00, (byte) 0x43, (byte) 0x00, (byte) 0x41});
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        ObjectCountryCodeString objectCountryCode = new ObjectCountryCodeString(new byte[]{(byte) 0x00, (byte) 0x55, (byte) 0x00, (byte) 0x53, (byte) 0x00, (byte) 0x3b, (byte) 0x00, (byte) 0x43, (byte) 0x00, (byte) 0x41});
+        Assert.assertEquals(objectCountryCode.getValue(), "US;CA");
+        Assert.assertEquals(objectCountryCode.getDisplayableValue(), "US;CA");
+        Assert.assertEquals(objectCountryCode.getBytes(), new byte[]{(byte) 0x00, (byte) 0x55, (byte) 0x00, (byte) 0x53, (byte) 0x00, (byte) 0x3b, (byte) 0x00, (byte) 0x43, (byte) 0x00, (byte) 0x41});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0102/localset/LocallSetFactoryTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/localset/LocallSetFactoryTest.java
@@ -3,18 +3,31 @@ package org.jmisb.api.klv.st0102.localset;
 import org.jmisb.api.klv.st0102.SecurityMetadataKey;
 import org.jmisb.api.klv.st0102.ISecurityMetadataValue;
 import org.jmisb.api.klv.st0102.ItemDesignatorId;
+import org.jmisb.api.klv.st0102.ObjectCountryCodeString;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class LocallSetFactoryTest {
 
     @Test
-    public void testItemDesignatorIdCreate() {
+    public void testItemDesignatorIdCreate()
+    {
         byte[] itemDesignatorId = new byte[]{(byte) 0x00, (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04, (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08, (byte) 0x09, (byte) 0x0A, (byte) 0x0B, (byte) 0x0C, (byte) 0x0D, (byte) 0x0E, (byte) 0x0F};
         ISecurityMetadataValue value = LocalSetFactory.createValue(SecurityMetadataKey.ItemDesignatorId, itemDesignatorId);
         Assert.assertTrue(value instanceof ItemDesignatorId);
         ItemDesignatorId id = (ItemDesignatorId) value;
         Assert.assertEquals(id.getBytes(), itemDesignatorId);
         Assert.assertEquals(id.getItemDesignatorId(), itemDesignatorId);
+    }
+
+    @Test
+    public void testObjectCountryCodeCreate()
+    {
+        byte[] bytes = new byte[]{(byte) 0x00, (byte) 0x55, (byte) 0x00, (byte) 0x53, (byte) 0x00, (byte) 0x3b, (byte) 0x00, (byte) 0x43, (byte) 0x00, (byte) 0x41};
+        ISecurityMetadataValue value = LocalSetFactory.createValue(SecurityMetadataKey.ObjectCountryCodes, bytes);
+        Assert.assertTrue(value instanceof ObjectCountryCodeString);
+        ObjectCountryCodeString objectCountryCode = (ObjectCountryCodeString) value;
+        Assert.assertEquals(objectCountryCode.getBytes(), bytes);
+        Assert.assertEquals(objectCountryCode.getDisplayableValue(), "US;CA");
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0102/localset/OcMethodTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/localset/OcMethodTest.java
@@ -1,7 +1,6 @@
 package org.jmisb.api.klv.st0102.localset;
 
 import org.jmisb.api.klv.st0102.CountryCodingMethod;
-import org.jmisb.api.klv.st0102.localset.OcMethod;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
## Motivation and Context
Updates the Object Country Code encoding to be UTF-16. I assume this is some legacy thing, but that is what ST0102 requires (via RFC2781).

Resolves #100

## Description
Modifies the KLV ST0102 code to use a new UTF-16 string class (ObjectCountryCodeString).
Adds tests to match.

## How Has This Been Tested?
Unit testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

