### PR TITLE
Implement ST0601 Control Command and Control Command Verification

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommand.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommand.java
@@ -1,0 +1,187 @@
+package org.jmisb.api.klv.st0601;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.jmisb.api.klv.Ber;
+import org.jmisb.api.klv.BerDecoder;
+import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.BerField;
+import org.jmisb.core.klv.ArrayUtils;
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * Control Command (ST 0601 tag 115).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Record of command from GCS to Aircraft.
+ * <p>
+ * A copy of the command and control values used to request platform/sensor to
+ * perform an action.
+ * <p>
+ * Tag 116 uses the Command ID to signal validation.
+ * <p>
+ * Command is a "string" format defined by platform vendor.
+ * <p>
+ * Control Command Verification (Tag 116) shows acknowledgment of the command
+ * <p>
+ * The purpose of the Control Command (Tag 115) and Command Acknowledgement (Tag
+ * 116) items are to report the commands issued to the platform/sensor and the
+ * acknowledgment of those commands. The Control Command defines a command ID
+ * and the command string which describes the command or action to perform. At
+ * some later time, the command is acknowledged by the platform and Tag 116
+ * records the acknowledgment, by just restating the Command ID.
+ * </blockquote>
+ */
+public class ControlCommand implements IUasDatalinkValue
+{
+    private int id;
+    private String commandText;
+    private long timestamp;
+    private boolean timestampIsValid = false;
+
+    /**
+     * Create from values
+     *
+     * @param commandId the value to track the command. This is an increasing
+     * and unique number assigned to each command as it is issued.
+     * @param command utf8 value which describes the command. This string has a
+     * maximum length of 127 characters. The format and content of the string is
+     * vendor defined.
+     * @param pts the Precision Time Stamp when first issuing the command to the
+     * platform.
+     */
+    public ControlCommand(int commandId, String command, long pts)
+    {
+        if (command.length() > 127)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " command is 127 characters maximum");
+        }
+        this.id = commandId;
+        this.commandText = command;
+        this.timestamp = pts;
+        this.timestampIsValid = true;
+    }
+
+    /**
+     * Create from values.
+     *
+     * This version of the constructor omits the PTS, which defaults to the
+     * timestamp of the parent packet.
+     *
+     * @param commandId the value to track the command. This is an increasing
+     * and unique number assigned to each command as it is issued.
+     * @param command utf8 value which describes the command. This string has a
+     * maximum length of 127 characters. The format and content of the string is
+     * vendor defined.
+     */
+    public ControlCommand(int commandId, String command)
+    {
+        if (command.length() > 127)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " command is 127 characters maximum");
+        }
+        this.id = commandId;
+        this.commandText = command;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes encoded value
+     */
+    public ControlCommand(byte[] bytes)
+    {
+        int idx = 0;
+        BerField idField = BerDecoder.decode(bytes, idx, true);
+        idx += idField.getLength();
+        id = idField.getValue();
+        BerField commandLengthField = BerDecoder.decode(bytes, idx, false);
+        idx += commandLengthField.getLength();
+        commandText = new String(bytes, idx, commandLengthField.getValue(), StandardCharsets.UTF_8);
+        idx += commandLengthField.getValue();
+        if (bytes.length > idx)
+        {
+            timestamp = PrimitiveConverter.toInt64(bytes, idx);
+            timestampIsValid = true;
+        }
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        List<byte[]> chunks = new ArrayList<>();
+        int totalLength = 0;
+        byte[] idBytes = BerEncoder.encode(id, Ber.OID);
+        chunks.add(idBytes);
+        totalLength += idBytes.length;
+        byte[] commandBytes = commandText.getBytes(StandardCharsets.UTF_8);
+        byte[] commandLengthBytes = BerEncoder.encode(commandBytes.length);
+        chunks.add(commandLengthBytes);
+        totalLength += commandLengthBytes.length;
+        chunks.add(commandBytes);
+        totalLength += commandBytes.length;
+        if (timestampIsValid)
+        {
+            byte[] timestampBytes = PrimitiveConverter.int64ToBytes(timestamp);
+            chunks.add(timestampBytes);
+            totalLength += timestampBytes.length;
+        }
+        return ArrayUtils.arrayFromChunks(chunks, totalLength);
+    }
+
+    /**
+     * Get the command id value.
+     *
+     * @return the id as an integer.
+     */
+    public int getCommandId()
+    {
+        return id;
+    }
+
+    /**
+     * Get the command text.
+     *
+     * @return the command (vendor specific) text.
+     */
+    public String getCommand()
+    {
+        return commandText;
+    }
+
+    /**
+     * Get the timestamp associated with this command.
+     *
+     * This can be invalid - check the timestampIsValid() to tell.
+     *
+     * @return timestamp, or 0 if not valid.
+     */
+    public long getTimestamp()
+    {
+        return timestamp;
+    }
+
+    /**
+     * Check if the timestamp is a valid value.
+     *
+     * @return true if it is valid, otherwise false.
+     */
+    public boolean timestampIsValid()
+    {
+        return timestampIsValid;
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return "" + id + ", " + commandText;
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Control Command";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommandVerification.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommandVerification.java
@@ -1,0 +1,98 @@
+package org.jmisb.api.klv.st0601;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.jmisb.api.klv.Ber;
+import org.jmisb.api.klv.BerDecoder;
+import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.BerField;
+import org.jmisb.api.klv.st0601.dto.Location;
+import org.jmisb.api.klv.st0601.dto.Waypoint;
+import org.jmisb.api.klv.st1201.FpEncoder;
+import org.jmisb.core.klv.ArrayUtils;
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * Control Command Verification List (ST 0601 tag 116).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Acknowledgment of one or more control commands were received by the platform.
+ * <p>
+ * The Control Command Verification List is a variable length pack of one or
+ * more BER-OID values. Each value is a verification or acknowledgment of a
+ * Control Command sent to the platform – see Tag 115 for more details.
+ * </blockquote>
+ */
+public class ControlCommandVerification implements IUasDatalinkValue
+{
+    private final List<Integer> commands = new ArrayList<>();
+
+    /**
+     * Create from value.
+     *
+     * @param commandIds list of command id values
+     */
+    public ControlCommandVerification(List<Integer> commandIds)
+    {
+        this.commands.clear();
+        this.commands.addAll(commandIds);
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes encoded command identifiers list
+     */
+    public ControlCommandVerification(byte[] bytes)
+    {
+        int idx = 0;
+        while (idx < bytes.length) {
+            BerField idField = BerDecoder.decode(bytes, idx, true);
+            this.commands.add(idField.getValue());
+            idx += idField.getLength();
+        }
+    }
+
+    /**
+     * Get the command ids that make up this command verification list.
+     *
+     * @return the ordered list of ids.
+     */
+    public List<Integer> getCommandIds()
+    {
+        return this.commands;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        List<byte[]> chunks = new ArrayList<>();
+        int totalLength = 0;
+        for (int id: commands)
+        {
+            byte[] idBytes = BerEncoder.encode(id, Ber.OID);
+            totalLength += idBytes.length;
+            chunks.add(idBytes);
+        }
+        return ArrayUtils.arrayFromChunks(chunks, totalLength);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        List<String> idsAsText = new ArrayList<>();
+        commands.forEach((id) -> {
+            idsAsText.add("" + id);
+        });
+        return "" + String.join(",", idsAsText);
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "Control Command Verification";
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -268,8 +268,7 @@ public class UasDatalinkFactory
             case RadarAltimeter:
                 return new RadarAltimeter(bytes);
             case ControlCommand:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new ControlCommand(bytes);
             case ControlCommandVerification:
                 // TODO
                 return new OpaqueValue(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -270,8 +270,7 @@ public class UasDatalinkFactory
             case ControlCommand:
                 return new ControlCommand(bytes);
             case ControlCommandVerification:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new ControlCommandVerification(bytes);
             case SensorAzimuthRate:
                 return new SensorAzimuthRate(bytes);
             case SensorElevationRate:

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -237,9 +237,9 @@ public enum UasDatalinkTag
     AltitudeAgl(113),
     /** Tag 114; Height above the ground/water as reported by a RADAR altimeter; Value is a {@link RadarAltimeter} */
     RadarAltimeter(114),
-    /** Tag 115; Record of command from GCS to Aircraft; Value is a {@link OpaqueValue} */
+    /** Tag 115; Record of command from GCS to Aircraft; Value is a {@link ControlCommand} */
     ControlCommand(115),
-    /** Tag 116; Acknowledgement of one or more control commands were received by the platform; Value is a {@link OpaqueValue} */
+    /** Tag 116; Acknowledgment of one or more control commands were received by the platform; Value is a {@link ControlCommandVerification} */
     ControlCommandVerification(116),
     /** Tag 117; The rate the sensors azimuth angle is changing; Value is a {@link SensorAzimuthRate} */
     SensorAzimuthRate(117),

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WavelengthsList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WavelengthsList.java
@@ -1,6 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.jmisb.api.klv.BerDecoder;
@@ -91,7 +92,7 @@ public class WavelengthsList implements IUasDatalinkValue {
             offset += IMAPB_BYTES;
             wavelengths.setMax(max);
             int nameLength = packLength - (2* IMAPB_BYTES + idField.getLength());
-            String name = new String(bytes, offset, nameLength);
+            String name = new String(bytes, offset, nameLength, StandardCharsets.UTF_8);
             wavelengths.setName(name);
             offset += nameLength;
             wavelengthsList.add(wavelengths);

--- a/api/src/test/java/org/jmisb/api/klv/st0601/ControlCommandTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/ControlCommandTest.java
@@ -1,0 +1,120 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
+
+public class ControlCommandTest
+{
+    private final byte[] ST_EXAMPLE_BYTES = new byte[]{(byte)0x05, (byte)0x11, (byte)0x46, (byte)0x6C, (byte)0x79, (byte)0x20, (byte)0x74, (byte)0x6F, (byte)0x20, (byte)0x57, (byte)0x61, (byte)0x79, (byte)0x70, (byte)0x6F, (byte)0x69, (byte)0x6E, (byte)0x74, (byte)0x20, (byte)0x31};
+    private final int ST_EXAMPLE_ID = 5;
+    private final String ST_EXAMPLE_COMMAND = "Fly to Waypoint 1";
+    private final long EXAMPLE_TIMESTAMP = 1587194489117472L;
+
+    private final byte[] ST_EXAMPLE_BYTES_PLUS_TIMESTAMP = new byte[]{(byte)0x05, (byte)0x11, (byte)0x46, (byte)0x6C, (byte)0x79, (byte)0x20, (byte)0x74, (byte)0x6F, (byte)0x20, (byte)0x57, (byte)0x61, (byte)0x79, (byte)0x70, (byte)0x6F, (byte)0x69, (byte)0x6E, (byte)0x74, (byte)0x20, (byte)0x31, (byte)0x00, (byte)0x05, (byte)0xA3, (byte)0x8B, (byte)0x83, (byte)0xB6, (byte)0x9B, (byte)0x20};
+
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        ControlCommand controlCommand = new ControlCommand(ST_EXAMPLE_ID, ST_EXAMPLE_COMMAND);
+        checkValuesForExample(controlCommand);
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        ControlCommand controlCommand = new ControlCommand(ST_EXAMPLE_BYTES);
+        checkValuesForExample(controlCommand);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.ControlCommand, ST_EXAMPLE_BYTES);
+        assertTrue(v instanceof ControlCommand);
+        ControlCommand controlCommand = (ControlCommand)v;
+        checkValuesForExample(controlCommand);
+    }
+
+    @Test
+    public void testFactoryWithPTS() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.ControlCommand, ST_EXAMPLE_BYTES_PLUS_TIMESTAMP);
+        assertTrue(v instanceof ControlCommand);
+        ControlCommand controlCommand = (ControlCommand)v;
+        checkValuesForExamplePlusPTS(controlCommand);
+    }
+
+    @Test
+    public void testConstructFromValueWithPTS()
+    {
+        // From ST:
+        ControlCommand controlCommand = new ControlCommand(ST_EXAMPLE_ID, ST_EXAMPLE_COMMAND, EXAMPLE_TIMESTAMP);
+        checkValuesForExamplePlusPTS(controlCommand);
+    }
+
+    private void checkValuesForExample(ControlCommand controlCommand)
+    {
+        assertEquals(controlCommand.getBytes(), ST_EXAMPLE_BYTES);
+        assertEquals(controlCommand.getCommandId(), ST_EXAMPLE_ID);
+        assertEquals(controlCommand.getCommand(), ST_EXAMPLE_COMMAND);
+        assertFalse(controlCommand.timestampIsValid());
+        assertEquals(controlCommand.getDisplayableValue(), "5, Fly to Waypoint 1");
+        assertEquals(controlCommand.getDisplayName(), "Control Command");
+    }
+
+    private void checkValuesForExamplePlusPTS(ControlCommand controlCommand)
+    {
+        assertEquals(controlCommand.getBytes(), ST_EXAMPLE_BYTES_PLUS_TIMESTAMP);
+        assertEquals(controlCommand.getCommandId(), ST_EXAMPLE_ID);
+        assertEquals(controlCommand.getCommand(), ST_EXAMPLE_COMMAND);
+        assertTrue(controlCommand.timestampIsValid());
+        assertEquals(controlCommand.getTimestamp(), EXAMPLE_TIMESTAMP);
+        assertEquals(controlCommand.getDisplayableValue(), "5, Fly to Waypoint 1");
+        assertEquals(controlCommand.getDisplayName(), "Control Command");
+    }
+
+    public void testLengthStringOK()
+    {
+        String command127 = "01234567890123456789012345678901234567890123456789"
+                + "01234567890123456789012345678901234567890123456789"
+                + "012345678901234567890123456";
+
+        ControlCommand controlCommand = new ControlCommand(1, command127);
+        assertNotNull(controlCommand);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLengthString128()
+    {
+        String command128 = "01234567890123456789012345678901234567890123456789"
+                + "01234567890123456789012345678901234567890123456789"
+                + "0123456789012345678901234567";
+
+        new ControlCommand(1, command128);
+    }
+
+    public void testLengthStringOKpts()
+    {
+        String command127 = "01234567890123456789012345678901234567890123456789"
+                + "01234567890123456789012345678901234567890123456789"
+                + "012345678901234567890123456";
+
+        ControlCommand controlCommand = new ControlCommand(1, command127, 2);
+        assertNotNull(controlCommand);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLengthString128pts()
+    {
+        String command128 = "01234567890123456789012345678901234567890123456789"
+                + "01234567890123456789012345678901234567890123456789"
+                + "0123456789012345678901234567";
+
+        new ControlCommand(1, command128, 2);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/ControlCommandVerificationTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/ControlCommandVerificationTest.java
@@ -1,0 +1,50 @@
+package org.jmisb.api.klv.st0601;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jmisb.api.common.KlvParseException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
+
+public class ControlCommandVerificationTest
+{
+    private final byte[] ST_EXAMPLE_BYTES = new byte[]{(byte)0x03, (byte)0x07};
+
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        List<Integer> ids = new ArrayList<>();
+        ids.add(3);
+        ids.add(7);
+        ControlCommandVerification controlCommandVerification = new ControlCommandVerification(ids);
+        checkValuesForExample(controlCommandVerification);
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        ControlCommandVerification controlCommandVerification = new ControlCommandVerification(ST_EXAMPLE_BYTES);
+        checkValuesForExample(controlCommandVerification);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.ControlCommandVerification, ST_EXAMPLE_BYTES);
+        assertTrue(v instanceof ControlCommandVerification);
+        ControlCommandVerification controlCommandVerification = (ControlCommandVerification)v;
+        checkValuesForExample(controlCommandVerification);
+    }
+
+    private void checkValuesForExample(ControlCommandVerification controlCommandVerification)
+    {
+        assertEquals(controlCommandVerification.getCommandIds().size(), 2);
+        assertEquals(controlCommandVerification.getCommandIds().get(0).intValue(), 3);
+        assertEquals(controlCommandVerification.getCommandIds().get(1).intValue(), 7);
+        assertEquals(controlCommandVerification.getBytes(), ST_EXAMPLE_BYTES);
+        assertEquals(controlCommandVerification.getDisplayableValue(), "3,7");
+        assertEquals(controlCommandVerification.getDisplayName(), "Control Command Verification");
+    }
+}

--- a/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
+++ b/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
@@ -321,16 +321,28 @@ public class PrimitiveConverter
     }
 
     /**
-     * Convert a byte array to a signed 64-bit integer
+     * Convert a byte array to a signed 64-bit integer.
      *
      * @param bytes The array of length 8
      * @return The signed 64-bit integer
      */
     public static long toInt64(byte[] bytes)
     {
-        if (bytes.length == 8)
+        return toInt64(bytes, 0);
+    }
+
+    /**
+     * Convert a byte array with offset to a signed 64-bit integer.
+     *
+     * @param bytes The array of length 8
+     * @param offset the offset into the array where the conversion should start
+     * @return The signed 64-bit integer
+     */
+    public static long toInt64(byte[] bytes, int offset)
+    {
+        if (offset + Long.BYTES <= bytes.length)
         {
-            return ByteBuffer.wrap(bytes).getLong();
+            return ByteBuffer.wrap(bytes, offset, Long.BYTES).getLong();
         }
         else
         {

--- a/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
@@ -444,4 +444,36 @@ public class PrimitiveConverterTest
         PrimitiveConverter.toInt32(new byte[]{0x00, 0x00, 0x00, 0x0f, 0x00});
     }
 
+    @Test
+    public void testToInt64()
+    {
+        long val = PrimitiveConverter.toInt64(new byte[]{(byte)0x00, (byte)0x04, (byte)0x59, (byte)0xF4, (byte)0xA6, (byte)0xAA, (byte)0x4A, (byte)0xA8});
+        Assert.assertEquals(val, 1224807209913000L);
+    }
+
+    @Test
+    public void testToInt64Offset()
+    {
+        long val = PrimitiveConverter.toInt64(new byte[]{(byte)0x12, (byte)0x34, (byte)0x00, (byte)0x04, (byte)0x59, (byte)0xF4, (byte)0xA6, (byte)0xAA, (byte)0x4A, (byte)0xA8, (byte)0x56}, 2);
+        Assert.assertEquals(val, 1224807209913000L);
+    }
+
+    @Test
+    public void testToInt64OffsetExact()
+    {
+        long val = PrimitiveConverter.toInt64(new byte[]{(byte)0x12, (byte)0x34, (byte)0x00, (byte)0x04, (byte)0x59, (byte)0xF4, (byte)0xA6, (byte)0xAA, (byte)0x4A, (byte)0xA8}, 2);
+        Assert.assertEquals(val, 1224807209913000L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToInt64InvalidArg()
+    {
+        PrimitiveConverter.toInt64(new byte[]{(byte)0x00, (byte)0x04, (byte)0x59, (byte)0xF4, (byte)0xA6, (byte)0xAA, (byte)0x4A});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToInt64OffsetInvalidArg()
+    {
+        PrimitiveConverter.toInt64(new byte[]{(byte)0x12, (byte)0x34, (byte)0x00, (byte)0x04, (byte)0x59, (byte)0xF4, (byte)0xA6, (byte)0xAA, (byte)0x4A}, 2);
+    }
 }


### PR DESCRIPTION
## Motivation and Context
Implements ST0601 Tag 115 and Tag 116, which we didn't previously support.

## Description
Fairly standard IUasDatalinkValue implementation. Minor extension to the PrimitiveConverter to handle byte[] -> long at an offset into the byte array, and extra tests for that.

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

