### PR TITLE
Fix encoding for 1 byte FpEncoder (ST1201).

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st1201/FpEncoder.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1201/FpEncoder.java
@@ -112,8 +112,8 @@ public class FpEncoder
             switch (fieldLength)
             {
                 case 1:
-                    char c = (char) d;
-                    encoded = ByteBuffer.allocate(1).putChar(c).array();
+                    byte b = (byte) d;
+                    encoded = ByteBuffer.allocate(1).put(b).array();
                     break;
                 case 2:
                     short s = (short) d;
@@ -136,6 +136,8 @@ public class FpEncoder
                     long l = (long) d;
                     encoded = ByteBuffer.allocate(8).putLong(l).array();
                     break;
+                default:
+                    throw new UnsupportedOperationException("Only field lengths of [1,2,3,4,8] are supported");
             }
         }
         return encoded;
@@ -212,6 +214,8 @@ public class FpEncoder
                     long l = wrapped.getLong();
                     val = sR * (l - zOffset) + a;
                     break;
+                default:
+                    throw new UnsupportedOperationException("Only field lengths of [1,2,3,4,8] are supported");
             }
             if (val < a || val > b)
             {

--- a/api/src/test/java/org/jmisb/api/klv/st1201/FpEncoderTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1201/FpEncoderTest.java
@@ -47,6 +47,13 @@ public class FpEncoderTest
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testOutOfRangeOver()
+    {
+        FpEncoder encoder = new FpEncoder(-100.0, 100.0, 4);
+        encoder.encode(100.1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMismatchedLength()
     {
         FpEncoder encoder = new FpEncoder(-100.0, +100.0, 2);
@@ -80,6 +87,27 @@ public class FpEncoderTest
         value = Double.NaN;
         encoded = fpEncoder.encode(value);
         Assert.assertEquals(encoded[0], (byte)0xd0);
+    }
+
+    @Test
+    public void testEncodeLen1()
+    {
+        FpEncoder fpEncoder = new FpEncoder(0.0, 10.0, 1);
+        double value = 6.0;
+        byte[] expected = {0x30};
+        byte[] encoded = fpEncoder.encode(value);
+        Assert.assertEquals(encoded.length, 1);
+        Assert.assertEquals(encoded, expected);
+    }
+
+    @Test
+    public void testDecodeLen1()
+    {
+        FpEncoder fpEncoder = new FpEncoder(0.0, 10.0, 1);
+        double expected = 6.0;
+        byte[] value = {0x30};
+        double decoded = fpEncoder.decode(value);
+        Assert.assertEquals(decoded, expected);
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
While looking at the spotbugs reports (for a missing `default` in case statement), I tried to add a test for FpEncoder for 1 byte, which failed.
This corrects the code and adds the test. This is a bit separate from the spotbugs work, so providing it in advance.

## Description
It turns out `putChar()` actually writes two bytes - see https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html#putChar-char-
This (unexpected to me) event causes a buffer overflow since we only allocate 1 byte. Instead, use plain `put()` which takes a single byte.

## How Has This Been Tested?
Unit test added.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

