### PR TITLE
Initial work on extracting time support to st0603 module

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/PrecisionTimeStamp.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PrecisionTimeStamp.java
@@ -1,11 +1,6 @@
 package org.jmisb.api.klv.st0601;
 
-import org.jmisb.core.klv.PrimitiveConverter;
-
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
 import org.jmisb.api.klv.st0603.ST0603TimeStamp;
 
 /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PrecisionTimeStamp.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PrecisionTimeStamp.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import org.jmisb.api.klv.st0603.ST0603TimeStamp;
 
 /**
  * Precision Time Stamp (ST 0601 tag 2)
@@ -18,23 +19,15 @@ import java.time.temporal.ChronoUnit;
  * Resolution: 1 microsecond.
  * </blockquote>
  */
-public class PrecisionTimeStamp implements IUasDatalinkValue
+public class PrecisionTimeStamp extends ST0603TimeStamp implements IUasDatalinkValue
 {
-    // Yes, using a long here means overflow in the year 2262, but there's no unsigned long in java
-    // and the cost of using something like BigInteger seems unnecessary
-    private long microseconds;
-
     /**
      * Create from value
      * @param microseconds Microseconds since the epoch
      */
     public PrecisionTimeStamp(long microseconds)
     {
-        if (microseconds < 0)
-        {
-            throw new IllegalArgumentException("Precision Timestamp must be in range [0,2^64-1]");
-        }
-        this.microseconds = microseconds;
+        super(microseconds);
     }
 
     /**
@@ -43,58 +36,16 @@ public class PrecisionTimeStamp implements IUasDatalinkValue
      */
     public PrecisionTimeStamp(byte[] bytes)
     {
-        if (bytes.length != 8)
-        {
-            throw new IllegalArgumentException("Precision Time Stamp encoding is an 8-byte unsigned int");
-        }
-        microseconds = PrimitiveConverter.toInt64(bytes);
+        super(bytes);
     }
 
     /**
      * Create from {@code LocalDateTime}
-     * @param localDateTime The UTC date and time
+     * @param localDateTime The date and time
      */
     public PrecisionTimeStamp(LocalDateTime localDateTime)
     {
-        try
-        {
-            microseconds = ChronoUnit.MICROS.between(Instant.EPOCH, localDateTime.toInstant(ZoneOffset.UTC));
-        }
-        catch (ArithmeticException e)
-        {
-            throw new IllegalArgumentException("Precision Timestamp must be before April 11, 2262 23:47:16.854Z");
-        }
-    }
-
-    /**
-     * Get the value
-     * @return Number of microseconds since the epoch
-     */
-    public long getMicroseconds()
-    {
-        return microseconds;
-    }
-
-    @Override
-    public byte[] getBytes()
-    {
-        return PrimitiveConverter.int64ToBytes(microseconds);
-    }
-
-    /**
-     * Get the value as a {@code LocalDateTime}
-     * @return The UTC date and time
-     */
-    LocalDateTime getLocalDateTime()
-    {
-        return LocalDateTime.ofEpochSecond(microseconds / 1000000,
-            (int)(microseconds % 1000000) * 1000, ZoneOffset.UTC);
-    }
-
-    @Override
-    public String getDisplayableValue()
-    {
-        return "" + microseconds;
+        super(localDateTime);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0603/TimeStatus.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0603/TimeStatus.java
@@ -1,0 +1,183 @@
+package org.jmisb.api.klv.st0603;
+
+/**
+ * ST0603 Time Status.
+ * <p>
+ * From ST0603.5 section 7.4:
+ * </p>
+ * <blockquote>
+ * <p>
+ * Systems producing a timestamp representing Absolute Time for Motion Imagery
+ * and metadata will have differing requirements for the accuracy and precision
+ * of the timestamp. System designers need to specify both the precision and the
+ * accuracy of the timestamp, so that users of the data understand what can be
+ * expected in data analysis.
+ * </p>
+ * <p>
+ * The purpose of the Time Status is twofold:
+ * </p>
+ * <p>
+ * 1. Provide information on the reference clock used to produce a timestamp,
+ * and
+ * </p>
+ * <p>
+ * 2. Provide a bit-efficient timestamp qualifier for use within Motion Imagery.
+ * </p>
+ * <p>
+ * There are cases where a suitable reference for a timestamp is not available,
+ * or the synchronization to a reference may be temporarily lost. The Time
+ * Status provides end-user information regarding the reference for the
+ * timestamp in these instances.
+ * </p>
+ * </blockquote>
+ * <p>
+ * The Time Status is a set of three flags. The reverse flag depends on the
+ * discontinuity flag, since it describes the direction of the discontinuity
+ * (jump).
+ */
+public class TimeStatus
+{
+    private boolean lockUnknown;
+    private boolean discontinuity;
+    private boolean reverse;
+
+    private static final byte LOCK_UNKNOWN_BITMASK = (byte)(0b1 << 7);
+    private static final byte DISCONTINUITY_BITMASK = (byte)(0b1 << 6);
+    private static final byte REVERSE_BITMASK = (byte)(0b1 << 5);
+
+    /**
+     * Constructor.
+     *
+     * This will create a "non-locked, forward linear" status.
+     */
+    public TimeStatus()
+    {
+        lockUnknown = true;
+        discontinuity = false;
+        reverse = false;
+    }
+
+    /**
+     * Create from encoded byte.
+     *
+     * @param encoded Encoded byte
+     */
+    public TimeStatus(byte encoded)
+    {
+        lockUnknown = ((encoded & LOCK_UNKNOWN_BITMASK) == LOCK_UNKNOWN_BITMASK);
+        discontinuity = ((encoded & DISCONTINUITY_BITMASK) == DISCONTINUITY_BITMASK);
+        if (discontinuity)
+        {
+            reverse = ((encoded & REVERSE_BITMASK) == REVERSE_BITMASK);
+        }
+        else
+        {
+            reverse = false;
+        }
+    }
+
+    /**
+     * Whether the time is locked or not.
+     * <p>
+     * Locked means that the internal clock is locked to absolute time reference.
+     * Not locked also covers the "lock status is unknown" case.
+     * </p>
+     * @return true if the time is locked, false if the time is not locked.
+     */
+    public boolean isLocked()
+    {
+        return !lockUnknown;
+    }
+
+    /**
+     * Set whether the time is locked or not.
+     * <p>
+     * Locked means that the internal clock is locked to absolute time reference.
+     * Not locked also covers the "lock status is unknown" case.
+     * </p>
+     * @param locked true if the time is locked, false if the time is not locked.
+     */
+    public void setLocked(boolean locked)
+    {
+        this.lockUnknown = !locked;
+    }
+
+    /**
+     * Whether the time is discontinuous.
+     * <p>
+     * A discontinuity means that time has not incremented forward in a linear
+     * fashion. That is, a forward non-linear or reverse jump as a by-product of
+     * relocking the clock to a reference, or other correction.
+     * </p>
+     * @return true if there is a discontinuity, or false if time is
+     * incrementing in a normal linear fashion.
+     */
+    public boolean isDiscontinuity()
+    {
+        return discontinuity;
+    }
+
+    /**
+     * Set whether the time is discontinuous.
+     * <p>
+     * A discontinuity means that time has not incremented forward in a linear
+     * fashion. That is, a forward non-linear or reverse jump as a by-product of
+     * relocking the clock to a reference, or other correction.
+     * </p>
+     *
+     * @param discontinuity true if there is a discontinuity, or false if time
+     * is incrementing in a normal linear fashion.
+     * @param reverse true if the discontinuity is a reverse jump, or false if
+     * the discontinuity is a forward jump.
+     */
+    public void setDiscontinuity(final boolean discontinuity, final boolean reverse)
+    {
+        this.discontinuity = discontinuity;
+        if (discontinuity)
+        {
+            this.reverse = reverse;
+        }
+        else
+        {
+            this.reverse = false;
+        }
+    }
+
+    /**
+     * Whether the discontinuity is in the reverse direction.
+     * <p>
+     * Only meaningful if there is a discontinuity (see isDiscontinuity()).
+     * </p>
+     *
+     * @return true if the discontinuity is reverse direction (step back),
+     * otherwise false.
+     */
+    public boolean isReverse()
+    {
+        return reverse;
+    }
+
+    /**
+     * Get the encoded value for this TimeStatus.
+     * <p>
+     * The encoded value is a set of bit flags in a byte. See ST0603.5 Table 3.
+     * @return the encoded value, as a single byte.
+     */
+    byte getEncodedValue()
+    {
+        byte value = 0b00011111;
+        if (discontinuity)
+        {
+            value |= DISCONTINUITY_BITMASK;
+            if (reverse)
+            {
+                value |= REVERSE_BITMASK;
+            }
+        }
+        if (lockUnknown)
+        {
+            value |= LOCK_UNKNOWN_BITMASK;
+        }
+        return value;
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0603/package-info.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0603/package-info.java
@@ -1,0 +1,30 @@
+/**
+ * ST 0603: MISP Time System and Timestamps.
+ * <p>
+ * From ST0603:
+ * </p>
+ * <blockquote>
+ * <p>
+ * An absolute, reliable time system is essential to precisely mark temporal
+ * events with timestamps for collected Motion Imagery and metadata. Such
+ * timestamps facilitate photogrammetric analysis, interoperability and
+ * exploitation of Motion Imagery products.
+ * </p>
+ * <p>
+ * This standard specifies the MISP Time System, which is an absolute time scale
+ * from which timestamps are derived. Three types of timestamps are defined: 1)
+ * a Precision Time Stamp, which represents Absolute Time specified to
+ * microsecond resolution; 2) a Nano Precision Time Stamp, which represents
+ * Absolute Time specified to nanosecond resolution; and, 3) a Commercial Time
+ * Stamp, which represents a relative time consistent with time code used in the
+ * commercial broadcast industry, specified to video frame resolution. The
+ * Precision Time Stamp and the Nano Precision Time Stamp aide in correlating
+ * Motion Imagery with metadata.
+ * </p>
+ * <p>
+ * This standard also specifies a Time Status byte, which is intended to provide
+ * additional information regarding the source used for timestamps
+ * </p>
+ * </blockquote>
+ */
+package org.jmisb.api.klv.st0603;

--- a/api/src/main/java/org/jmisb/api/klv/st0903/PrecisionTimeStamp.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/PrecisionTimeStamp.java
@@ -1,12 +1,7 @@
 package org.jmisb.api.klv.st0903;
 
-import org.jmisb.api.klv.st0903.shared.ST0603TimeStamp;
-import org.jmisb.core.klv.PrimitiveConverter;
-
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
+import java.time.LocalDateTime;
+import org.jmisb.api.klv.st0603.ST0603TimeStamp;
 
 /**
  * Precision Time Stamp (ST0903 VMTI LS Tag 2).
@@ -59,10 +54,10 @@ public class PrecisionTimeStamp extends ST0603TimeStamp implements IVmtiMetadata
     }
 
     /**
-     * Create from {@code ZonedDateTime}
-     * @param dateTime The UTC date and time
+     * Create from {@code LocalDateTime}
+     * @param dateTime The date and time
      */
-    public PrecisionTimeStamp(ZonedDateTime dateTime)
+    public PrecisionTimeStamp(LocalDateTime dateTime)
     {
         super(dateTime);
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/EndTime.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/EndTime.java
@@ -1,6 +1,7 @@
 package org.jmisb.api.klv.st0903.vtracker;
 
-import org.jmisb.api.klv.st0903.shared.ST0603TimeStamp;
+import java.time.LocalDateTime;
+import org.jmisb.api.klv.st0603.ST0603TimeStamp;
 import java.time.ZonedDateTime;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 
@@ -36,10 +37,10 @@ public class EndTime extends ST0603TimeStamp implements IVmtiMetadataValue
     }
 
     /**
-     * Create from {@code ZonedDateTime}
-     * @param dateTime The UTC date and time
+     * Create from {@code LocalDateTime}
+     * @param dateTime The date and time
      */
-    public EndTime(ZonedDateTime dateTime)
+    public EndTime(LocalDateTime dateTime)
     {
         super(dateTime);
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/StartTime.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/StartTime.java
@@ -1,6 +1,7 @@
 package org.jmisb.api.klv.st0903.vtracker;
 
-import org.jmisb.api.klv.st0903.shared.ST0603TimeStamp;
+import java.time.LocalDateTime;
+import org.jmisb.api.klv.st0603.ST0603TimeStamp;
 import java.time.ZonedDateTime;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 
@@ -35,10 +36,10 @@ public class StartTime extends ST0603TimeStamp implements IVmtiMetadataValue
     }
 
     /**
-     * Create from {@code ZonedDateTime}
-     * @param dateTime The UTC date and time
+     * Create from {@code LocalDateTime}
+     * @param dateTime The date and time
      */
-    public StartTime(ZonedDateTime dateTime)
+    public StartTime(LocalDateTime dateTime)
     {
         super(dateTime);
     }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/PrecisionTimeStampTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PrecisionTimeStampTest.java
@@ -22,7 +22,7 @@ public class PrecisionTimeStampTest
         PrecisionTimeStamp pts = new PrecisionTimeStamp(bytes);
         Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
         Assert.assertEquals(pts.getDisplayableValue(), "1224807209913000");
-        LocalDateTime dateTime = pts.getLocalDateTime();
+        LocalDateTime dateTime = pts.getDateTime();
 
         Assert.assertEquals(dateTime.getYear(), 2008);
         Assert.assertEquals(dateTime.getMonth(), Month.OCTOBER);
@@ -53,7 +53,7 @@ public class PrecisionTimeStampTest
         Assert.assertEquals(v.getDisplayName(), "Precision Time Stamp");
         PrecisionTimeStamp pts = (PrecisionTimeStamp)v;
         Assert.assertEquals(pts.getDisplayableValue(), "1224807209913000");
-        LocalDateTime dateTime = pts.getLocalDateTime();
+        LocalDateTime dateTime = pts.getDateTime();
 
         Assert.assertEquals(dateTime.getYear(), 2008);
         Assert.assertEquals(dateTime.getMonth(), Month.OCTOBER);
@@ -70,8 +70,8 @@ public class PrecisionTimeStampTest
         LocalDateTime now = LocalDateTime.now();
         PrecisionTimeStamp pts = new PrecisionTimeStamp(now);
         Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
-        Assert.assertEquals(pts.getLocalDateTime().getDayOfMonth(), now.getDayOfMonth());
-        Assert.assertEquals(pts.getLocalDateTime().getHour(), now.getHour());
+        Assert.assertEquals(pts.getDateTime().getDayOfMonth(), now.getDayOfMonth());
+        Assert.assertEquals(pts.getDateTime().getHour(), now.getHour());
         long ptsMicroseconds = pts.getMicroseconds();
         long nowMicroseconds = ChronoUnit.MICROS.between(Instant.EPOCH, now.toInstant(ZoneOffset.UTC));
         Assert.assertEquals(ptsMicroseconds, nowMicroseconds);
@@ -82,9 +82,9 @@ public class PrecisionTimeStampTest
     {
         PrecisionTimeStamp pts = new PrecisionTimeStamp(0L);
         Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
-        Assert.assertEquals(pts.getLocalDateTime().getYear(), 1970);
-        Assert.assertEquals(pts.getLocalDateTime().getMonth(), Month.JANUARY);
-        Assert.assertEquals(pts.getLocalDateTime().getDayOfMonth(), 1);
+        Assert.assertEquals(pts.getDateTime().getYear(), 1970);
+        Assert.assertEquals(pts.getDateTime().getMonth(), Month.JANUARY);
+        Assert.assertEquals(pts.getDateTime().getDayOfMonth(), 1);
         Assert.assertEquals(pts.getDisplayableValue(), "0");
 
         // Create max value and ensure no exception is thrown

--- a/api/src/test/java/org/jmisb/api/klv/st0603/ST0603TimeStampTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0603/ST0603TimeStampTest.java
@@ -1,4 +1,4 @@
-package org.jmisb.api.klv.st0903;
+package org.jmisb.api.klv.st0603;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import org.jmisb.api.common.KlvParseException;
 
-public class PrecisionTimeStampTest
+public class ST0603TimeStampTest
 {
     // Example from MISB ST doc
     @Test
@@ -20,8 +20,7 @@ public class PrecisionTimeStampTest
     {
         // Convert byte[] -> value
         byte[] bytes = new byte[]{(byte)0x00, (byte)0x03, (byte)0x82, (byte)0x44, (byte)0x30, (byte)0xF6, (byte)0xCE, (byte)0x40};
-        PrecisionTimeStamp pts = new PrecisionTimeStamp(bytes);
-        Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
+        ST0603TimeStamp pts = new ST0603TimeStamp(bytes);
         Assert.assertEquals(pts.getDisplayableValue(), "987654321000000");
         LocalDateTime dateTime = pts.getDateTime();
 
@@ -35,8 +34,7 @@ public class PrecisionTimeStampTest
 
         // Convert value -> byte[]
         long microseconds = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli() * 1000;
-        PrecisionTimeStamp pts2 = new PrecisionTimeStamp(microseconds);
-        Assert.assertEquals(pts2.getDisplayName(), "Precision Time Stamp");
+        ST0603TimeStamp pts2 = new ST0603TimeStamp(microseconds);
         Assert.assertEquals(pts2.getBytes(), new byte[]{(byte)0x00, (byte)0x03, (byte)0x82, (byte)0x44, (byte)0x30, (byte)0xF6, (byte)0xCE, (byte)0x40});
 
         Assert.assertEquals(microseconds, 987654321000000L);
@@ -44,31 +42,10 @@ public class PrecisionTimeStampTest
     }
 
     @Test
-    public void testFactoryExample() throws KlvParseException
-    {
-        byte[] bytes = new byte[]{(byte)0x00, (byte)0x03, (byte)0x82, (byte)0x44, (byte)0x30, (byte)0xF6, (byte)0xCE, (byte)0x40};
-        IVmtiMetadataValue v = VmtiLocalSet.createValue(VmtiMetadataKey.PrecisionTimeStamp, bytes);
-        Assert.assertTrue(v instanceof PrecisionTimeStamp);
-        Assert.assertEquals(v.getDisplayName(), "Precision Time Stamp");
-        PrecisionTimeStamp pts = (PrecisionTimeStamp)v;
-        Assert.assertEquals(pts.getDisplayableValue(), "987654321000000");
-        LocalDateTime dateTime = pts.getDateTime();
-
-        Assert.assertEquals(dateTime.getYear(), 2001);
-        Assert.assertEquals(dateTime.getMonth(), Month.APRIL);
-        Assert.assertEquals(dateTime.getDayOfMonth(), 19);
-        Assert.assertEquals(dateTime.getHour(), 4);
-        Assert.assertEquals(dateTime.getMinute(), 25);
-        Assert.assertEquals(dateTime.getSecond(), 21);
-        Assert.assertEquals(dateTime.getNano(), 0);
-    }
-
-    @Test
     public void testNow()
     {
-        LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
-        PrecisionTimeStamp pts = new PrecisionTimeStamp(now);
-        Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
+        LocalDateTime now = LocalDateTime.now();
+        ST0603TimeStamp pts = new ST0603TimeStamp(now);
         Assert.assertEquals(pts.getDateTime().getDayOfMonth(), now.getDayOfMonth());
         Assert.assertEquals(pts.getDateTime().getHour(), now.getHour());
         long ptsMicroseconds = pts.getMicroseconds();
@@ -79,34 +56,32 @@ public class PrecisionTimeStampTest
     @Test
     public void testMinAndMax()
     {
-        PrecisionTimeStamp pts = new PrecisionTimeStamp(0L);
-        Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
+        ST0603TimeStamp pts = new ST0603TimeStamp(0L);
         Assert.assertEquals(pts.getDateTime().getYear(), 1970);
         Assert.assertEquals(pts.getDateTime().getMonth(), Month.JANUARY);
         Assert.assertEquals(pts.getDateTime().getDayOfMonth(), 1);
         Assert.assertEquals(pts.getDisplayableValue(), "0");
 
         // Create max value and ensure no exception is thrown
-        pts = new PrecisionTimeStamp(Long.MAX_VALUE);
-        Assert.assertEquals(pts.getDisplayName(), "Precision Time Stamp");
+        pts = new ST0603TimeStamp(Long.MAX_VALUE);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testTooSmall()
     {
-        new PrecisionTimeStamp(-1);
+        new ST0603TimeStamp(-1);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testTooBig()
     {
         // Oct 12, 2263 at 08:30
-        new PrecisionTimeStamp(LocalDateTime.of(2263, 10, 12, 8, 30, 0, 0));
+        new ST0603TimeStamp(LocalDateTime.of(2263, 10, 12, 8, 30, 0, 0));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength()
     {
-        new PrecisionTimeStamp(new byte[]{0x00, 0x00, 0x00, 0x00});
+        new ST0603TimeStamp(new byte[]{0x00, 0x00, 0x00, 0x00});
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0603/TimeStatusTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0603/TimeStatusTest.java
@@ -1,0 +1,115 @@
+package org.jmisb.api.klv.st0603;
+
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for ST0603 Time Status byte.
+ */
+public class TimeStatusTest
+{
+    @Test
+    public void testDefaultConstructor()
+    {
+        TimeStatus timeStatus = new TimeStatus();
+        assertFalse(timeStatus.isLocked());
+        assertFalse(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b10011111);
+    }
+
+    @Test
+    public void testFromEncodedValueConstructor()
+    {
+        TimeStatus timeStatus = new TimeStatus((byte)0b10011111);
+        assertFalse(timeStatus.isLocked());
+        assertFalse(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b10011111);
+    }
+
+    @Test
+    public void testFromEncodedValueConstructorLocked()
+    {
+        TimeStatus timeStatus = new TimeStatus((byte)0b00011111);
+        assertTrue(timeStatus.isLocked());
+        assertFalse(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b00011111);
+    }
+
+    @Test
+    public void testFromEncodedValueConstructorForwardDiscontinuity()
+    {
+        TimeStatus timeStatus = new TimeStatus((byte)0b11011111);
+        assertFalse(timeStatus.isLocked());
+        assertTrue(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b11011111);
+    }
+
+    @Test
+    public void testFromEncodedValueConstructorReverseDiscontinuity()
+    {
+        TimeStatus timeStatus = new TimeStatus((byte)0b11111111);
+        assertFalse(timeStatus.isLocked());
+        assertTrue(timeStatus.isDiscontinuity());
+        assertTrue(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b11111111);
+    }
+
+    @Test
+    public void testLockModifier()
+    {
+        TimeStatus timeStatus = new TimeStatus();
+        assertFalse(timeStatus.isLocked());
+        assertFalse(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b10011111);
+        timeStatus.setLocked(true);
+        assertTrue(timeStatus.isLocked());
+        assertFalse(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b00011111);
+        timeStatus.setLocked(false);
+        assertFalse(timeStatus.isLocked());
+        assertFalse(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b10011111);
+    }
+
+    @Test
+    public void testDiscontinuityModifier()
+    {
+        TimeStatus timeStatus = new TimeStatus();
+        assertFalse(timeStatus.isLocked());
+        assertFalse(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b10011111);
+        timeStatus.setDiscontinuity(true, false);
+        assertFalse(timeStatus.isLocked());
+        assertTrue(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b11011111);
+        timeStatus.setDiscontinuity(false, false);
+        assertFalse(timeStatus.isLocked());
+        assertFalse(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b10011111);
+        timeStatus.setDiscontinuity(false, true);
+        assertFalse(timeStatus.isLocked());
+        assertFalse(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b10011111);
+        timeStatus.setDiscontinuity(true, true);
+        assertFalse(timeStatus.isLocked());
+        assertTrue(timeStatus.isDiscontinuity());
+        assertTrue(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b11111111);
+        timeStatus.setDiscontinuity(false, true);
+        assertFalse(timeStatus.isLocked());
+        assertFalse(timeStatus.isDiscontinuity());
+        assertFalse(timeStatus.isReverse());
+        assertEquals(timeStatus.getEncodedValue(), (byte)0b10011111);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/EndTimeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/EndTimeTest.java
@@ -5,8 +5,10 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import org.jmisb.api.common.KlvParseException;
@@ -22,7 +24,7 @@ public class EndTimeTest
         EndTime pts = new EndTime(bytes);
         Assert.assertEquals(pts.getDisplayName(), "End Time");
         Assert.assertEquals(pts.getDisplayableValue(), "987654321000000");
-        ZonedDateTime dateTime = pts.getDateTime();
+        LocalDateTime dateTime = pts.getDateTime();
 
         Assert.assertEquals(dateTime.getYear(), 2001);
         Assert.assertEquals(dateTime.getMonth(), Month.APRIL);
@@ -33,7 +35,7 @@ public class EndTimeTest
         Assert.assertEquals(dateTime.getNano(), 0);
 
         // Convert value -> byte[]
-        long microseconds = dateTime.toInstant().toEpochMilli() * 1000;
+        long microseconds = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli() * 1000;
         EndTime pts2 = new EndTime(microseconds);
         Assert.assertEquals(pts2.getDisplayName(), "End Time");
         Assert.assertEquals(pts2.getBytes(), new byte[]{(byte)0x00, (byte)0x03, (byte)0x82, (byte)0x44, (byte)0x30, (byte)0xF6, (byte)0xCE, (byte)0x40});
@@ -51,7 +53,7 @@ public class EndTimeTest
         Assert.assertEquals(v.getDisplayName(), "End Time");
         EndTime pts = (EndTime)v;
         Assert.assertEquals(pts.getDisplayableValue(), "987654321000000");
-        ZonedDateTime dateTime = pts.getDateTime();
+        LocalDateTime dateTime = pts.getDateTime();
 
         Assert.assertEquals(dateTime.getYear(), 2001);
         Assert.assertEquals(dateTime.getMonth(), Month.APRIL);
@@ -65,13 +67,13 @@ public class EndTimeTest
     @Test
     public void testNow()
     {
-        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
         EndTime pts = new EndTime(now);
         Assert.assertEquals(pts.getDisplayName(), "End Time");
         Assert.assertEquals(pts.getDateTime().getDayOfMonth(), now.getDayOfMonth());
         Assert.assertEquals(pts.getDateTime().getHour(), now.getHour());
         long ptsMicroseconds = pts.getMicroseconds();
-        long nowMicroseconds = ChronoUnit.MICROS.between(Instant.EPOCH, now.toInstant());
+        long nowMicroseconds = ChronoUnit.MICROS.between(Instant.EPOCH, now.toInstant(ZoneOffset.UTC));
         Assert.assertEquals(ptsMicroseconds, nowMicroseconds);
     }
 
@@ -100,7 +102,7 @@ public class EndTimeTest
     public void testTooBig()
     {
         // Oct 12, 2263 at 08:30
-        new EndTime(ZonedDateTime.of(2263, 10, 12, 8, 30, 0, 0, ZoneId.of("UTC")));
+        new EndTime(LocalDateTime.of(2263, 10, 12, 8, 30, 0, 0));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/StartTimeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/StartTimeTest.java
@@ -5,8 +5,10 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import org.jmisb.api.common.KlvParseException;
@@ -22,7 +24,7 @@ public class StartTimeTest
         StartTime pts = new StartTime(bytes);
         Assert.assertEquals(pts.getDisplayName(), "Start Time");
         Assert.assertEquals(pts.getDisplayableValue(), "987654321000000");
-        ZonedDateTime dateTime = pts.getDateTime();
+        LocalDateTime dateTime = pts.getDateTime();
 
         Assert.assertEquals(dateTime.getYear(), 2001);
         Assert.assertEquals(dateTime.getMonth(), Month.APRIL);
@@ -33,7 +35,7 @@ public class StartTimeTest
         Assert.assertEquals(dateTime.getNano(), 0);
 
         // Convert value -> byte[]
-        long microseconds = dateTime.toInstant().toEpochMilli() * 1000;
+        long microseconds = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli() * 1000;
         StartTime pts2 = new StartTime(microseconds);
         Assert.assertEquals(pts2.getDisplayName(), "Start Time");
         Assert.assertEquals(pts2.getBytes(), new byte[]{(byte)0x00, (byte)0x03, (byte)0x82, (byte)0x44, (byte)0x30, (byte)0xF6, (byte)0xCE, (byte)0x40});
@@ -51,7 +53,7 @@ public class StartTimeTest
         Assert.assertEquals(v.getDisplayName(), "Start Time");
         StartTime pts = (StartTime)v;
         Assert.assertEquals(pts.getDisplayableValue(), "987654321000000");
-        ZonedDateTime dateTime = pts.getDateTime();
+        LocalDateTime dateTime = pts.getDateTime();
 
         Assert.assertEquals(dateTime.getYear(), 2001);
         Assert.assertEquals(dateTime.getMonth(), Month.APRIL);
@@ -65,13 +67,13 @@ public class StartTimeTest
     @Test
     public void testNow()
     {
-        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
         StartTime pts = new StartTime(now);
         Assert.assertEquals(pts.getDisplayName(), "Start Time");
         Assert.assertEquals(pts.getDateTime().getDayOfMonth(), now.getDayOfMonth());
         Assert.assertEquals(pts.getDateTime().getHour(), now.getHour());
         long ptsMicroseconds = pts.getMicroseconds();
-        long nowMicroseconds = ChronoUnit.MICROS.between(Instant.EPOCH, now.toInstant());
+        long nowMicroseconds = ChronoUnit.MICROS.between(Instant.EPOCH, now.toInstant(ZoneOffset.UTC));
         Assert.assertEquals(ptsMicroseconds, nowMicroseconds);
     }
 
@@ -100,7 +102,7 @@ public class StartTimeTest
     public void testTooBig()
     {
         // Oct 12, 2263 at 08:30
-        new StartTime(ZonedDateTime.of(2263, 10, 12, 8, 30, 0, 0, ZoneId.of("UTC")));
+        new StartTime(LocalDateTime.of(2263, 10, 12, 8, 30, 0, 0));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
## Motivation and Context
This is a start on refactoring of common time stamp (ST0603) code into a separate module.
Relates to #97, but doesn't complete it.

## Description
Pulls out the common code into a new module. This is pretty minimal at the moment, but does make more shared code.

Also added the "time status" byte from ST0603.5 section 7.4. We need this to drop into the ST0604 video timestamp (see #102). It also helped to get the test coverage up which made Coveralls happier after the migration to common code reduced the coverage numbers (same amount of tests, just less covered lines, so lower percentage?)

## How Has This Been Tested?
Unit tests, with good coverage.
Ran the viewer application across a couple of test files - no problems noted.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

