### PR TITLE
Implement ST0601 Country Codes (Tag 122)

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0102/CountryCodingMethodUtilities.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/CountryCodingMethodUtilities.java
@@ -1,0 +1,102 @@
+package org.jmisb.api.klv.st0102;
+
+/**
+ * Utilities methods for converting country coding methods between enumeration
+ * and encoded values.
+ *
+ * These methods are only valid for "Tag 12" values, such as Object Country
+ * Coding in ST0102 and Country Codes in ST0601.
+ *
+ * They are not valid for ST0102 Tag 2 "Classifying Country and Releasing
+ * Instructions Country Coding Method".
+ */
+public class CountryCodingMethodUtilities
+{
+    /**
+     * Convert the given country coding method to an encoded value.
+     *
+     * This method is only valid for "Tag 12" values, such as Object Country
+     * Coding in ST0102 and Country Codes in ST0601.
+     *
+     * It is not valid for ST0102 Tag 2 "Classifying Country and Releasing
+     * Instructions Country Coding Method".
+     *
+     * @param method the country coding method
+     * @return the equivalent integer value (as a byte)
+     * @throws IllegalArgumentException if the country coding method is not
+     * valid
+     */
+    public static byte getValueForCodingMethod(CountryCodingMethod method) throws IllegalArgumentException
+    {
+        switch (method) {
+            case ISO3166_TWO_LETTER:
+                return 0x01;
+            case ISO3166_THREE_LETTER:
+                return 0x02;
+            case ISO3166_NUMERIC:
+                return 0x03;
+            case FIPS10_4_TWO_LETTER:
+                return 0x04;
+            case FIPS10_4_FOUR_LETTER:
+                return 0x05;
+            case C1059_TWO_LETTER:
+                return 0x06;
+            case C1059_THREE_LETTER:
+                return 0x07;
+            case OMITTED_VALUE:
+                return 0x08;
+            case GENC_TWO_LETTER:
+                return 0x0D;
+            case GENC_THREE_LETTER:
+                return 0x0E;
+            case GENC_NUMERIC:
+                return 0x0F;
+            case GENC_ADMINSUB:
+                return 0x40;
+            default:
+                throw new IllegalArgumentException("Invalid country coding method: " + method);
+        }
+    }
+
+    /**
+     * Convert the given country coding method to an enumerated value.
+     *
+     * This method is only valid for "Tag 12" values, such as Object Country
+     * Coding in ST0102 and Country Codes in ST0601.
+     *
+     * It is not valid for ST0102 Tag 2 "Classifying Country and Releasing
+     * Instructions Country Coding Method".
+     *
+     * @param value the encoded country coding method, or OMITTED_VALUE for unknown.
+     * @return the equivalent enumeration value
+     */
+    public static CountryCodingMethod getMethodForValue(int value)
+    {
+        switch (value) {
+            case 0x01:
+                return CountryCodingMethod.ISO3166_TWO_LETTER;
+            case 0x02:
+                return CountryCodingMethod.ISO3166_THREE_LETTER;
+            case 0x03:
+                return CountryCodingMethod.ISO3166_NUMERIC;
+            case 0x04:
+                return CountryCodingMethod.FIPS10_4_TWO_LETTER;
+            case 0x05:
+                return CountryCodingMethod.FIPS10_4_FOUR_LETTER;
+            case 0x06:
+                return CountryCodingMethod.C1059_TWO_LETTER;
+            case 0x07:
+                return CountryCodingMethod.C1059_THREE_LETTER;
+            case 0x0D:
+                return CountryCodingMethod.GENC_TWO_LETTER;
+            case 0x0E:
+                return CountryCodingMethod.GENC_THREE_LETTER;
+            case 0x0F:
+                return CountryCodingMethod.GENC_NUMERIC;
+            case 0x40:
+                return CountryCodingMethod.GENC_ADMINSUB;
+        }
+        return CountryCodingMethod.OMITTED_VALUE;
+    }
+
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/OcMethod.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/OcMethod.java
@@ -6,6 +6,7 @@ import org.jmisb.api.klv.st0102.ISecurityMetadataValue;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import org.jmisb.api.klv.st0102.CountryCodingMethodUtilities;
 
 /**
  * Object Country Coding Method (ST 0102 tag 12)
@@ -23,48 +24,9 @@ public class OcMethod implements ISecurityMetadataValue
      */
     public OcMethod(CountryCodingMethod method)
     {
-        switch (method)
-        {
-            case ISO3166_TWO_LETTER:
-                this.method = 1;
-                break;
-            case ISO3166_THREE_LETTER:
-                this.method = 2;
-                break;
-            case ISO3166_NUMERIC:
-                this.method = 3;
-                break;
-            case FIPS10_4_TWO_LETTER:
-                this.method = 4;
-                break;
-            case FIPS10_4_FOUR_LETTER:
-                this.method = 5;
-                break;
-            case C1059_TWO_LETTER:
-                this.method = 6;
-                break;
-            case C1059_THREE_LETTER:
-                this.method = 7;
-                break;
-            case OMITTED_VALUE:
-                this.method = 8;
-                break;
-            case GENC_TWO_LETTER:
-                this.method = 13;
-                break;
-            case GENC_THREE_LETTER:
-                this.method = 14;
-                break;
-            case GENC_NUMERIC:
-                this.method = 15;
-                break;
-            case GENC_ADMINSUB:
-                this.method = 64;
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid object country coding method: " + method);
-        }
+        this.method = CountryCodingMethodUtilities.getValueForCodingMethod(method);
     }
+
 
     /**
      * Create from encoded bytes
@@ -93,41 +55,9 @@ public class OcMethod implements ISecurityMetadataValue
      */
     public CountryCodingMethod getMethod()
     {
-        // For some reason, classifying country and object country coding method fields use different values to
-        // represent essentially the same set of methods. The ugliness here attempts to shield clients from that.
-        switch (method)
-        {
-            case 1:
-                return CountryCodingMethod.ISO3166_TWO_LETTER;
-            case 2:
-                return CountryCodingMethod.ISO3166_THREE_LETTER;
-            case 3:
-                return CountryCodingMethod.ISO3166_NUMERIC;
-            case 4:
-                return CountryCodingMethod.FIPS10_4_TWO_LETTER;
-            case 5:
-                return CountryCodingMethod.FIPS10_4_FOUR_LETTER;
-            case 6:
-                return CountryCodingMethod.C1059_TWO_LETTER;
-            case 7:
-                return CountryCodingMethod.C1059_THREE_LETTER;
-            case 8:
-            case 9:
-            case 10:
-            case 11:
-            case 12:
-                return CountryCodingMethod.OMITTED_VALUE;
-            case 13:
-                return CountryCodingMethod.GENC_TWO_LETTER;
-            case 14:
-                return CountryCodingMethod.GENC_THREE_LETTER;
-            case 15:
-                return CountryCodingMethod.GENC_NUMERIC;
-            case 64:
-                return CountryCodingMethod.GENC_ADMINSUB;
-        }
-        return CountryCodingMethod.OMITTED_VALUE;
+        return CountryCodingMethodUtilities.getMethodForValue(this.method);
     }
+
 
     @Override
     public byte[] getBytes()

--- a/api/src/main/java/org/jmisb/api/klv/st0601/CountryCodes.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/CountryCodes.java
@@ -1,0 +1,227 @@
+package org.jmisb.api.klv.st0601;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.jmisb.api.klv.BerDecoder;
+import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.BerField;
+import org.jmisb.api.klv.st0102.CountryCodingMethod;
+import org.jmisb.api.klv.st0102.CountryCodingMethodUtilities;
+import org.jmisb.core.klv.ArrayUtils;
+
+/**
+ * Country Codes (ST 0601 tag 122).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Country codes which are associated with the platform and its operation.
+ * <p>
+ * The Country Codes item provides country related information about the
+ * platform and its operation. The country which own and fly aircraft, along
+ * with where the platform is flying, and the country observed in the Motion
+ * Imagery scene are all needed information. For example, Country A is flying
+ * Country B’s UAV over Country C while imaging Country D and Country E performs
+ * analysis and classification of the Motion Imagery. There are five country
+ * codes of interest: Operator Country, Manufacture Country, Overflight Country,
+ * Object Country (Motion Imagery Scene) and Classifying Country. For the
+ * example above:
+ * <ul>
+ * <li>Operator = Country A</li>
+ * <li>Manufacture = Country B</li>
+ * <li>Overflight Country = Country C</li>
+ * <li>Object Country = Country D</li>
+ * <li>Classifying country = Country E</li>
+ * </ul>
+ * <p>
+ * The following lists the definitions for each of the different Country Code
+ * types:
+ * <ul>
+ * <li>Overflight Country: The country the platform is operating or flying over.
+ * This may be different than the country within the scene of the Motion
+ * Imagery.</li>
+ * <li>Operator Country: Country where the operator is located. For example, a
+ * GCS operator.</li>
+ * <li>Country of Manufacture: The Country where the platform was
+ * manufactured.</li>
+ * <li>Object Country: The country within the Motion Imagery scene or the
+ * “Object” of the Motion Imagery. Note: This value is an item in MISB ST 0102
+ * and is not included in this item’s country codes list.</li>
+ * <li>Classifying Country: The country which initially analyzes or classified
+ * the Motion Imagery. Note: this value is an item in MISB ST 0102 and is not
+ * included in this item’s country codes list.</li>
+ * </ul>
+ * </blockquote>
+ */
+// TODO: candidate for nested metadata
+public class CountryCodes implements IUasDatalinkValue
+{
+    private final CountryCodingMethod codingMethod;
+    private final String overflightCountry;
+    private final String operatorCountry;
+    private final String countryOfManufacture;
+
+    /**
+     * Create from values
+     *
+     * @param countryCodingMethod the coding method (country code namespace)
+     * @param overflightCountryCode the code for the country being overflown, or an empty string if unknown.
+     * @param operatorCountryCode the code for the country where the operator is located, of an empty string if unknown.
+     * @param countryOfManufactureCode the code for the country where the platform was manufactured, or an empty string if unknown.
+     */
+    public CountryCodes(final CountryCodingMethod countryCodingMethod, final String overflightCountryCode, final String operatorCountryCode, final String countryOfManufactureCode)
+    {
+        codingMethod = countryCodingMethod;
+        overflightCountry = overflightCountryCode;
+        operatorCountry = operatorCountryCode;
+        countryOfManufacture = countryOfManufactureCode;
+    }
+
+    /**
+     * Create from encoded bytes
+     *
+     * @param bytes encoded value
+     */
+    public CountryCodes(byte[] bytes)
+    {
+        int idx = 0;
+
+        BerField codingMethodLengthField = BerDecoder.decode(bytes, idx, false);
+        idx += codingMethodLengthField.getLength();
+        codingMethod = CountryCodingMethodUtilities.getMethodForValue(bytes[idx]); // This assumes codingMethod is the next byte
+        idx += codingMethodLengthField.getValue();
+
+        BerField overflightCountryLengthField = BerDecoder.decode(bytes, idx, false);
+        idx += overflightCountryLengthField.getLength();
+        overflightCountry = new String(bytes, idx, overflightCountryLengthField.getValue(), StandardCharsets.UTF_8);
+        idx += overflightCountryLengthField.getValue();
+
+        if (idx == bytes.length)
+        {
+            operatorCountry = "";
+            countryOfManufacture = "";
+            return;
+        }
+
+        BerField operatorCountryLengthField = BerDecoder.decode(bytes, idx, false);
+        idx += operatorCountryLengthField.getLength();
+        operatorCountry = new String(bytes, idx, operatorCountryLengthField.getValue(), StandardCharsets.UTF_8);
+        idx += operatorCountryLengthField.getValue();
+
+        if (idx == bytes.length)
+        {
+            countryOfManufacture = "";
+            return;
+        }
+
+        BerField countryOfManufactureLengthField = BerDecoder.decode(bytes, idx, false);
+        idx += countryOfManufactureLengthField.getLength();
+        countryOfManufacture = new String(bytes, idx, countryOfManufactureLengthField.getValue(), StandardCharsets.UTF_8);
+        idx += countryOfManufactureLengthField.getValue();
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        List<byte[]> chunks = new ArrayList<>();
+        int totalLength = 0;
+        byte[] codingMethodBytes = new byte[]{CountryCodingMethodUtilities.getValueForCodingMethod(codingMethod)};
+        byte[] codingMethodLengthBytes = BerEncoder.encode(codingMethodBytes.length);
+        chunks.add(codingMethodLengthBytes);
+        totalLength += codingMethodLengthBytes.length;
+        chunks.add(codingMethodBytes);
+        totalLength += codingMethodBytes.length;
+
+        byte[] overflightCountryBytes = overflightCountry.getBytes(StandardCharsets.UTF_8);
+        byte[] overflightCountryLengthBytes = BerEncoder.encode(overflightCountryBytes.length);
+        chunks.add(overflightCountryLengthBytes);
+        totalLength += overflightCountryLengthBytes.length;
+        chunks.add(overflightCountryBytes);
+        totalLength += overflightCountryBytes.length;
+
+        byte[] operatorCountryBytes = operatorCountry.getBytes(StandardCharsets.UTF_8);
+        byte[] countryOfManufactureBytes = countryOfManufacture.getBytes(StandardCharsets.UTF_8);
+
+        if ((operatorCountryBytes.length == 0) && (countryOfManufactureBytes.length == 0))
+        {
+            // truncate here
+            return ArrayUtils.arrayFromChunks(chunks, totalLength);
+        }
+        byte[] operatorCountryLengthBytes = BerEncoder.encode(operatorCountryBytes.length);
+        chunks.add(operatorCountryLengthBytes);
+        totalLength += operatorCountryLengthBytes.length;
+        chunks.add(operatorCountryBytes);
+        totalLength += operatorCountryBytes.length;
+
+        if (countryOfManufactureBytes.length == 0)
+        {
+            // truncate here
+            return ArrayUtils.arrayFromChunks(chunks, totalLength);
+        }
+        byte[] countryOfManufactureLengthBytes = BerEncoder.encode(countryOfManufactureBytes.length);
+        chunks.add(countryOfManufactureLengthBytes);
+        totalLength += countryOfManufactureLengthBytes.length;
+        chunks.add(countryOfManufactureBytes);
+        totalLength += countryOfManufactureBytes.length;
+
+        return ArrayUtils.arrayFromChunks(chunks, totalLength);
+    }
+
+    /**
+     * Get the coding method used for these country codes.
+     *
+     * @return the coding method as enumerated value.
+     */
+    public CountryCodingMethod getCodingMethod()
+    {
+        return codingMethod;
+    }
+
+    /**
+     * Get the overflight country.
+     * <p>
+     * The country the platform is operating or flying over. This may be different to the country within the scene of the Motion Imagery.
+     * </p>
+     * @return the overflight country (to be interpreted using the coding method for this object), or an empty string if not known.
+     */
+    public String getOverflightCountry()
+    {
+        return overflightCountry;
+    }
+
+    /**
+     * Get the operating country.
+     * <p>
+     * Country where the operator is located. For example, a GCS operator.
+     * </p>
+     * @return the operating country (to be interpreted using the coding method for this object), or an empty string if not known.
+     */
+    public String getOperatorCountry()
+    {
+        return operatorCountry;
+    }
+
+    /**
+     * Get the country of manufacture.
+     * <p>
+     * The Country where the platform was manufactured.
+     * </p>
+     * @return the country of manufacture (to be interpreted using the coding method for this object), or an empty string if not known.
+     */
+    public String getCountryOfManufacture()
+    {
+        return countryOfManufacture;
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return "[Country Codes]";
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Country Codes";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -282,8 +282,7 @@ public class UasDatalinkFactory
             case ActiveWavelengthList:
                 return new ActiveWavelengthList(bytes);
             case CountryCodes:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new CountryCodes(bytes);
             case NumberNavsatsInView:
                 return new NavsatsInView(bytes);
             case PositioningMethodSource:

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -251,7 +251,7 @@ public enum UasDatalinkTag
     OnBoardMiStoragePercentFull(120),
     /** Tag 121; List of wavelengths in Motion Imagery; Value is a {@link ActiveWavelengthList} */
     ActiveWavelengthList(121),
-    /** Tag 122; Country codes which are associated with the platform and its operation; Value is a {@link OpaqueValue} */
+    /** Tag 122; Country codes which are associated with the platform and its operation; Value is a {@link CountryCodes} */
     CountryCodes(122),
     /** Tag 123; Count of navigation satellites in view of platform; Value is a {@link NavsatsInView} */
     NumberNavsatsInView(123),

--- a/api/src/test/java/org/jmisb/api/klv/st0102/CountryCodingMethodUtilitiesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/CountryCodingMethodUtilitiesTest.java
@@ -1,0 +1,81 @@
+package org.jmisb.api.klv.st0102;
+
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for the Country Coding Method utilities.
+ */
+public class CountryCodingMethodUtilitiesTest
+{
+    @Test
+    public void checkToEnumeration()
+    {
+        assertEquals(CountryCodingMethod.ISO3166_TWO_LETTER, CountryCodingMethodUtilities.getMethodForValue(0x01));
+        assertEquals(CountryCodingMethod.ISO3166_THREE_LETTER, CountryCodingMethodUtilities.getMethodForValue(0x02));
+        assertEquals(CountryCodingMethod.ISO3166_NUMERIC, CountryCodingMethodUtilities.getMethodForValue(0x03));
+        assertEquals(CountryCodingMethod.FIPS10_4_TWO_LETTER, CountryCodingMethodUtilities.getMethodForValue(0x04));
+        assertEquals(CountryCodingMethod.FIPS10_4_FOUR_LETTER, CountryCodingMethodUtilities.getMethodForValue(0x05));
+        assertEquals(CountryCodingMethod.C1059_TWO_LETTER, CountryCodingMethodUtilities.getMethodForValue(0x06));
+        assertEquals(CountryCodingMethod.C1059_THREE_LETTER, CountryCodingMethodUtilities.getMethodForValue(0x07));
+        assertEquals(CountryCodingMethod.OMITTED_VALUE, CountryCodingMethodUtilities.getMethodForValue(0x08));
+        assertEquals(CountryCodingMethod.OMITTED_VALUE, CountryCodingMethodUtilities.getMethodForValue(0x09));
+        assertEquals(CountryCodingMethod.OMITTED_VALUE, CountryCodingMethodUtilities.getMethodForValue(0x0A));
+        assertEquals(CountryCodingMethod.OMITTED_VALUE, CountryCodingMethodUtilities.getMethodForValue(0x0B));
+        assertEquals(CountryCodingMethod.OMITTED_VALUE, CountryCodingMethodUtilities.getMethodForValue(0x0C));
+        assertEquals(CountryCodingMethod.GENC_TWO_LETTER, CountryCodingMethodUtilities.getMethodForValue(0x0D));
+        assertEquals(CountryCodingMethod.GENC_THREE_LETTER, CountryCodingMethodUtilities.getMethodForValue(0x0E));
+        assertEquals(CountryCodingMethod.GENC_NUMERIC, CountryCodingMethodUtilities.getMethodForValue(0x0F));
+        assertEquals(CountryCodingMethod.OMITTED_VALUE, CountryCodingMethodUtilities.getMethodForValue(0x3F));
+        assertEquals(CountryCodingMethod.GENC_ADMINSUB, CountryCodingMethodUtilities.getMethodForValue(0x40));
+        assertEquals(CountryCodingMethod.OMITTED_VALUE, CountryCodingMethodUtilities.getMethodForValue(0x41));
+    }
+
+    @Test
+    public void checkToByte()
+    {
+        assertEquals(0x01, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.ISO3166_TWO_LETTER));
+        assertEquals(0x02, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.ISO3166_THREE_LETTER));
+        assertEquals(0x03, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.ISO3166_NUMERIC));
+        assertEquals(0x04, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.FIPS10_4_TWO_LETTER));
+        assertEquals(0x05, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.FIPS10_4_FOUR_LETTER));
+        assertEquals(0x06, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.C1059_TWO_LETTER));
+        assertEquals(0x07, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.C1059_THREE_LETTER));
+        assertEquals(0x08, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.OMITTED_VALUE));
+        assertEquals(0x0D, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        assertEquals(0x0E, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.GENC_THREE_LETTER));
+        assertEquals(0x0F, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.GENC_NUMERIC));
+        assertEquals(0x40, CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.GENC_ADMINSUB));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalValueFIPS_MIXED()
+    {
+        CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.FIPS10_4_MIXED);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalValueGENC_MIXED()
+    {
+        CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.GENC_MIXED);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalValueISO_MIXED()
+    {
+        CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.ISO3166_MIXED);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testIllegalValueSTANAG_MIXED()
+    {
+        CountryCodingMethodUtilities.getValueForCodingMethod(CountryCodingMethod.STANAG_1059_MIXED);
+    }
+
+    @Test
+    public void tokenTestForDoNothingConstructor()
+    {
+        CountryCodingMethodUtilities utils = new CountryCodingMethodUtilities();
+        assertNotNull(utils);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0102/localset/OcMethodTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/localset/OcMethodTest.java
@@ -13,6 +13,7 @@ public class OcMethodTest
         Assert.assertEquals(method.getBytes().length, 1);
         Assert.assertEquals(method.getBytes()[0], 15);
         Assert.assertEquals(method.getMethod(), CountryCodingMethod.GENC_NUMERIC);
+        Assert.assertEquals(method.getDisplayableValue(), "GENC_NUMERIC");
     }
 
     @Test
@@ -22,11 +23,13 @@ public class OcMethodTest
         Assert.assertEquals(method.getMethod(), CountryCodingMethod.ISO3166_NUMERIC);
         Assert.assertEquals(method.getBytes().length, 1);
         Assert.assertEquals(method.getBytes()[0], 0x03);
+        Assert.assertEquals(method.getDisplayableValue(), "ISO3166_NUMERIC");
 
         method = new OcMethod(new byte[]{0x0a});
         Assert.assertEquals(method.getMethod(), CountryCodingMethod.OMITTED_VALUE);
         Assert.assertEquals(method.getBytes().length, 1);
         Assert.assertEquals(method.getBytes()[0], 0x0a);
+        Assert.assertEquals(method.getDisplayableValue(), "OMITTED_VALUE");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -39,5 +42,11 @@ public class OcMethodTest
     public void testIllegalCode()
     {
         new OcMethod(new byte[]{0x10});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadLength()
+    {
+        new OcMethod(new byte[]{0x01, 0x02});
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/CountryCodesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/CountryCodesTest.java
@@ -1,0 +1,76 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0102.CountryCodingMethod;
+import org.testng.Assert;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for Country Codes
+ */
+public class CountryCodesTest
+{
+    static final byte[] ST_EXAMPLE_BYTES = new byte[]{0x01, 0x0E, 0x03, 0x43, 0x41, 0x4E, 0x00, 0x03, 0x46, 0x52, 0x41};
+
+    @Test
+    public void testFromValues()
+    {
+        CountryCodes countryCodes = new CountryCodes(CountryCodingMethod.GENC_THREE_LETTER, "CAN", "", "FRA");
+        checkExampleValues(countryCodes);
+    }
+
+    @Test
+    public void testFromBytes()
+    {
+        CountryCodes countryCodes = new CountryCodes(ST_EXAMPLE_BYTES);
+        checkExampleValues(countryCodes);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.CountryCodes, ST_EXAMPLE_BYTES);
+        Assert.assertTrue(v instanceof CountryCodes);
+        CountryCodes countryCodes = (CountryCodes)v;
+        checkExampleValues(countryCodes);
+    }
+
+    private void checkExampleValues(CountryCodes countryCodes)
+    {
+        assertEquals(countryCodes.getDisplayName(), "Country Codes");
+        assertEquals(countryCodes.getDisplayableValue(), "[Country Codes]");
+        assertEquals(countryCodes.getCodingMethod(), CountryCodingMethod.GENC_THREE_LETTER);
+        assertEquals(countryCodes.getOverflightCountry(), "CAN");
+        assertEquals(countryCodes.getOperatorCountry(), "");
+        assertEquals(countryCodes.getCountryOfManufacture(), "FRA");
+        assertEquals(countryCodes.getBytes(), ST_EXAMPLE_BYTES);
+    }
+
+    @Test
+    public void testTruncatedBytesLast()
+    {
+        CountryCodes countryCodes = new CountryCodes(new byte[]{0x01, 0x01, 0x02, 0x41, 0x55, 0x02, 0x55, 0x53});
+        assertEquals(countryCodes.getDisplayName(), "Country Codes");
+        assertEquals(countryCodes.getDisplayableValue(), "[Country Codes]");
+        assertEquals(countryCodes.getCodingMethod(), CountryCodingMethod.ISO3166_TWO_LETTER);
+        assertEquals(countryCodes.getOverflightCountry(), "AU");
+        assertEquals(countryCodes.getOperatorCountry(), "US");
+        assertEquals(countryCodes.getCountryOfManufacture(), "");
+        assertEquals(countryCodes.getBytes(), new byte[]{0x01, 0x01, 0x02, 0x41, 0x55, 0x02, 0x55, 0x53});
+    }
+
+    @Test
+    public void testTruncatedBytesBoth()
+    {
+        CountryCodes countryCodes = new CountryCodes(new byte[]{0x01, 0x0E, 0x03, 0x43, 0x41, 0x4E});
+        assertEquals(countryCodes.getDisplayName(), "Country Codes");
+        assertEquals(countryCodes.getDisplayableValue(), "[Country Codes]");
+        assertEquals(countryCodes.getCodingMethod(), CountryCodingMethod.GENC_THREE_LETTER);
+        assertEquals(countryCodes.getOverflightCountry(), "CAN");
+        assertEquals(countryCodes.getOperatorCountry(), "");
+        assertEquals(countryCodes.getCountryOfManufacture(), "");
+        assertEquals(countryCodes.getBytes(), new byte[]{0x01, 0x0E, 0x03, 0x43, 0x41, 0x4E});
+    }
+
+}


### PR DESCRIPTION
## Motivation and Context
Implements a tag we don't yet support.

## Description
Implements IUasMetadataValue, although the handling is slightly complicated by this having a couple of truncation cases. In addition, the coding method is encoded per ST0102 Object Country Code, so I refactored the conversion logic that was in `org.jmisb.api.klv.st0102.localset.OcMethod` into a utilities class, to make is reusable. (I did consider making that part of the `CountryCodingMethod` enumeration, but that made confusion with the ST0102 Tag 2 conversion more likely, so went with a separate class). 

Adds tests for all of the new `CountryCodes` class, the new utililties class, plus some extra tests for `OcMethod`.

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

