### PR TITLE
Use StandardCharsets where possible

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0102/ObjectCountryCodeString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/ObjectCountryCodeString.java
@@ -1,6 +1,5 @@
 package org.jmisb.api.klv.st0102;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PayloadList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PayloadList.java
@@ -1,6 +1,5 @@
 package org.jmisb.api.klv.st0601;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
## Motivation and Context
We have a couple of unused Charsets imports. This is all that is left of an earlier cleanup PR.

## Description
Modifies one stray (unused) import from PayloadList, and removes a stray (unused) import from the st0102 object country code string.

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

