### PR TITLE
Use two-byte BER-long for up to 255 

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/BerEncoder.java
+++ b/api/src/main/java/org/jmisb/api/klv/BerEncoder.java
@@ -40,7 +40,7 @@ public class BerEncoder
         }
         else if (ber == Ber.LONG_FORM)
         {
-            if (value <= 127)
+            if (value <= 255)
             {
                 // 1 byte
                 bytes = new byte[2];

--- a/api/src/test/java/org/jmisb/api/klv/BerEncoderTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/BerEncoderTest.java
@@ -30,6 +30,17 @@ public class BerEncoderTest
         byte[] bytes = BerEncoder.encode(5, Ber.LONG_FORM);
         Assert.assertEquals(bytes, new byte[]{(byte)0x81, (byte)0x05});
 
+        // We can do up to 255 with a single byte
+        bytes = BerEncoder.encode(127, Ber.LONG_FORM);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x81, (byte)0x7f});
+        bytes = BerEncoder.encode(128, Ber.LONG_FORM);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x81, (byte)0x80});
+        bytes = BerEncoder.encode(255, Ber.LONG_FORM);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x81, (byte)0xff});
+
+        bytes = BerEncoder.encode(256, Ber.LONG_FORM);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x82, (byte)0x01, (byte)0x00});
+
         // 1,000 needs 2 bytes, and should be 0x03 0xe8
         bytes = BerEncoder.encode(1000, Ber.LONG_FORM);
         Assert.assertEquals(bytes, new byte[]{(byte)0x82, (byte)0x03, (byte)0xe8});

--- a/api/src/test/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetTest.java
@@ -12,6 +12,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.core.klv.ArrayUtils;
 
 public class SecurityMetadataLocalSetTest extends LoggerChecks
 {
@@ -144,9 +145,9 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks
         Assert.assertEquals(fullMessage.getField(SecurityMetadataKey.ItemDesignatorId).getBytes(), ItemDesignatorIdValue);
 
         byte[] bytes = fullMessage.frameMessage(false);
-        // System.out.println(ArrayUtils.toHexString(bytes));
+        System.out.println(ArrayUtils.toHexString(bytes));
 
-        Assert.assertEquals(bytes[21], Classification.TOP_SECRET.getCode());
+        Assert.assertEquals(bytes[20], Classification.TOP_SECRET.getCode());
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetTest.java
@@ -145,7 +145,7 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks
         Assert.assertEquals(fullMessage.getField(SecurityMetadataKey.ItemDesignatorId).getBytes(), ItemDesignatorIdValue);
 
         byte[] bytes = fullMessage.frameMessage(false);
-        System.out.println(ArrayUtils.toHexString(bytes));
+        // System.out.println(ArrayUtils.toHexString(bytes));
 
         Assert.assertEquals(bytes[20], Classification.TOP_SECRET.getCode());
     }


### PR DESCRIPTION
## Motivation and Context
Resolves #124. We were switching to three-byte form at 128, which is valid, but not the minimal length encoding for lengths (for example) in the range 128-255. 

## Description
Changes the switchover point to 256. Adds tests

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

