### PR TITLE
Add enum values to ST0903 DetectionStatus

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0903/shared/VmtiEnumeration.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/shared/VmtiEnumeration.java
@@ -59,4 +59,29 @@ public abstract class VmtiEnumeration implements IVmtiMetadataValue
     {
         return getDisplayValues().getOrDefault((int) value, "Unknown");
     }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 37 * hash + this.value;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final VmtiEnumeration other = (VmtiEnumeration) obj;
+        if (this.value != other.value) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/DetectionStatus.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/DetectionStatus.java
@@ -20,12 +20,12 @@ import org.jmisb.api.klv.st0903.shared.VmtiEnumeration;
  * <p>
  * Active: Detections for the entity established or updated based on associated
  * VMTI report or prediction. An entity can resume this state by transition from
- * Stopped or Dropped to “moving” when a VMTI detection (or a prediction) with a
+ * Stopped or Dropped to "moving when a VMTI detection (or a prediction) with a
  * new position has become associated with it.
  * <p>
  * Dropped: The entity could not be correlated with any VMTI detection for an
  * interval of time exceeding a specified threshold. An entity can remain in a
- * Dropped or “lost” condition for an indeterminate period if there is some
+ * Dropped or "lost" condition for an indeterminate period if there is some
  * likelihood it may resume (Active) again. Eventually, it may become Inactive.
  * <p>
  * Stopped: The entity has either become stationary or was always in a fixed
@@ -34,12 +34,52 @@ import org.jmisb.api.klv.st0903.shared.VmtiEnumeration;
  */
 public class DetectionStatus extends VmtiEnumeration implements IVmtiMetadataValue
 {
+    /**
+     * The VMTI detections for the entity have ended.
+     *
+     * The entity may have merged with one or more other entities; have split
+     * into two or more new entities; or have ceased to exist because no VMTI
+     * detection can be correlated with it.
+     */
+    static final DetectionStatus INACTIVE;
+    /**
+     * Detections for the entity established or updated based on associated VMTI
+     * report or prediction.
+     *
+     * An entity can resume this state by transition from Stopped or Dropped to
+     * "moving" when a VMTI detection (or a prediction) with a new position has
+     * become associated with it.
+     */
+    static final DetectionStatus ACTIVE;
+    /**
+     * The entity could not be correlated with any VMTI detection for an
+     * interval of time exceeding a specified threshold.
+     *
+     * An entity can remain in a Dropped or "lost" condition for an
+     * indeterminate period if there is some likelihood it may resume (Active)
+     * again. Eventually, it may become Inactive.
+     */
+    static final DetectionStatus DROPPED;
+    /**
+     * The entity has either become stationary or was always in a fixed
+     * location.
+     */
+    static final DetectionStatus STOPPED;
+
     static final Map<Integer, String> DISPLAY_VALUES = Arrays.stream(new Object[][]{
         {0, "Inactive"},
         {1, "Active"},
         {2, "Dropped"},
         {3, "Stopped"}
     }).collect(Collectors.toMap(kv -> (Integer) kv[0], kv -> (String) kv[1]));
+
+    static
+    {
+        INACTIVE = new DetectionStatus((byte)0x00);
+        ACTIVE = new DetectionStatus((byte)0x01);
+        DROPPED = new DetectionStatus((byte)0x02);
+        STOPPED = new DetectionStatus((byte)0x03);
+    }
 
     /**
      * Create from value

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/DetectionStatusTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/DetectionStatusTest.java
@@ -1,9 +1,11 @@
 package org.jmisb.api.klv.st0903.vtracker;
 
-import org.jmisb.api.klv.st0601.*;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.testng.Assert;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
 
 public class DetectionStatusTest {
@@ -26,6 +28,31 @@ public class DetectionStatusTest {
         detectionStatus = new DetectionStatus((byte) 1);
         Assert.assertEquals(detectionStatus.getBytes(), new byte[]{(byte) 1});
         Assert.assertEquals(detectionStatus.getDisplayableValue(), "Active");
+        Assert.assertEquals(detectionStatus.getDisplayName(), "Detection Status");
+    }
+
+    @Test
+    public void testStaticValues() {
+        // Min
+        DetectionStatus detectionStatus = DetectionStatus.INACTIVE;
+        Assert.assertEquals(detectionStatus.getBytes(), new byte[]{(byte) 0});
+        Assert.assertEquals(detectionStatus.getDisplayableValue(), "Inactive");
+        Assert.assertEquals(detectionStatus.getDisplayName(), "Detection Status");
+
+        // Max
+        detectionStatus = DetectionStatus.STOPPED;
+        Assert.assertEquals(detectionStatus.getBytes(), new byte[]{(byte) 3});
+        Assert.assertEquals(detectionStatus.getDisplayableValue(), "Stopped");
+        Assert.assertEquals(detectionStatus.getDisplayName(), "Detection Status");
+
+        // Other values
+        detectionStatus = DetectionStatus.ACTIVE;
+        Assert.assertEquals(detectionStatus.getBytes(), new byte[]{(byte) 1});
+        Assert.assertEquals(detectionStatus.getDisplayableValue(), "Active");
+        Assert.assertEquals(detectionStatus.getDisplayName(), "Detection Status");
+        detectionStatus = DetectionStatus.DROPPED;
+        Assert.assertEquals(detectionStatus.getBytes(), new byte[]{(byte) 2});
+        Assert.assertEquals(detectionStatus.getDisplayableValue(), "Dropped");
         Assert.assertEquals(detectionStatus.getDisplayName(), "Detection Status");
     }
 
@@ -63,6 +90,7 @@ public class DetectionStatusTest {
         Assert.assertEquals(detectionStatus.getDetectionStatus(), (byte) 0);
         Assert.assertEquals(detectionStatus.getBytes(), new byte[]{(byte) 0x00});
         Assert.assertEquals(detectionStatus.getDisplayableValue(), "Inactive");
+        Assert.assertEquals(detectionStatus, DetectionStatus.INACTIVE);
 
         bytes = new byte[]{(byte) 0x01};
         v = VTrackerLS.createValue(VTrackerMetadataKey.detectionStatus, bytes);
@@ -72,6 +100,7 @@ public class DetectionStatusTest {
         Assert.assertEquals(detectionStatus.getDetectionStatus(), (byte) 1);
         Assert.assertEquals(detectionStatus.getBytes(), new byte[]{(byte) 0x01});
         Assert.assertEquals(detectionStatus.getDisplayableValue(), "Active");
+        Assert.assertEquals(detectionStatus, DetectionStatus.ACTIVE);
 
         bytes = new byte[]{(byte) 0x02};
         v = VTrackerLS.createValue(VTrackerMetadataKey.detectionStatus, bytes);
@@ -81,6 +110,7 @@ public class DetectionStatusTest {
         Assert.assertEquals(detectionStatus.getDetectionStatus(), (byte) 2);
         Assert.assertEquals(detectionStatus.getBytes(), new byte[]{(byte) 0x02});
         Assert.assertEquals(detectionStatus.getDisplayableValue(), "Dropped");
+        Assert.assertEquals(detectionStatus, DetectionStatus.DROPPED);
 
         bytes = new byte[]{(byte) 0x03};
         v = VTrackerLS.createValue(VTrackerMetadataKey.detectionStatus, bytes);
@@ -90,6 +120,7 @@ public class DetectionStatusTest {
         Assert.assertEquals(detectionStatus.getDetectionStatus(), (byte) 3);
         Assert.assertEquals(detectionStatus.getBytes(), new byte[]{(byte) 0x03});
         Assert.assertEquals(detectionStatus.getDisplayableValue(), "Stopped");
+        Assert.assertEquals(detectionStatus, DetectionStatus.STOPPED);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -105,5 +136,55 @@ public class DetectionStatusTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
         new DetectionStatus(new byte[]{0x00, 0x00});
+    }
+
+    @Test
+    public void hashTest()
+    {
+        DetectionStatus detectionStatus = DetectionStatus.ACTIVE;
+        assertEquals(detectionStatus.hashCode(), 0x70);
+        detectionStatus = DetectionStatus.STOPPED;
+        assertEquals(detectionStatus.hashCode(), 0x72);
+    }
+
+    @Test
+    public void equalsSameObject()
+    {
+        DetectionStatus detectionStatus = DetectionStatus.ACTIVE;
+        assertTrue(detectionStatus.equals(detectionStatus));
+    }
+
+    @Test
+    public void equalsSameValues()
+    {
+        DetectionStatus detectionStatus1 = new DetectionStatus((byte)0x02);
+        DetectionStatus detectionStatus2 = new DetectionStatus((byte)0x02);
+        assertTrue(detectionStatus1.equals(detectionStatus2));
+        assertTrue(detectionStatus2.equals(detectionStatus1));
+        assertTrue(detectionStatus1 != detectionStatus2);
+    }
+
+    @Test
+    public void equalsDifferentValues()
+    {
+        DetectionStatus detectionStatus1 = new DetectionStatus((byte)0x01);
+        DetectionStatus detectionStatus2 = new DetectionStatus((byte)0x02);
+        assertFalse(detectionStatus1.equals(detectionStatus2));
+        assertFalse(detectionStatus2.equals(detectionStatus1));
+        assertTrue(detectionStatus1 != detectionStatus2);
+    }
+
+    @Test
+    public void equalsNull()
+    {
+        DetectionStatus detectionStatus = new DetectionStatus((byte)0x03);
+        assertFalse(detectionStatus.equals(null));
+    }
+
+    @Test
+    public void equalsDifferentClass()
+    {
+        DetectionStatus detectionStatus = new DetectionStatus((byte)0x01);
+        assertFalse(detectionStatus.equals(new String("blah")));
     }
 }


### PR DESCRIPTION
## Motivation and Context
Tries to make DetectionStatus a bit easier to use. 
Resolves #123 

## Description
Adds static values to DetectionStatus. Also extends the parent VmtiEnumeration class to have a better equals() behaviour.
The implementation requires a static initializer block to ensure that things get constructed in the right order - it will fail without this.

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

