### PR TITLE
Implement ST0601 Correction Offset

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/CorrectionOffset.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/CorrectionOffset.java
@@ -1,0 +1,81 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.core.klv.PrimitiveConverter;
+
+/**
+ * CorrectionOffset (ST 0601 tag 137).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Post-flight time adjustment to correct Precision Time Stamp (Tag 2) as
+ * needed.
+ * <p>
+ * KLV format: int64, Min: -(2^63), Max: (2^63)-1.
+ * <p>
+ * Length: variable, Max Length: 8, Required Length: N/A.
+ * <p>
+ * Resolution: 1 microsecond.
+ * <p>
+ * Add value to Precision Time Stamp (Tag 2) to correct time.
+ * <p>
+ * This value DOES NOT INCLUDE leap seconds offset. See Leap Seconds (Tag 136)
+ * to add leap second offset.
+ * <p>
+ * See "Packet Timestamp" section for more information on the use of this item.
+ * </blockquote>
+ */
+public class CorrectionOffset implements IUasDatalinkValue
+{
+    private long microseconds;
+    private static int MAX_BYTES = 8;
+
+    /**
+     * Create from value
+     * @param microseconds time in microseconds. Legal values are in [-2^63,2^63-1].
+     */
+    public CorrectionOffset(long microseconds)
+    {
+        this.microseconds = microseconds;
+    }
+
+    /**
+     * Create from encoded bytes
+     * @param bytes Byte array, maximum eight bytes
+     */
+    public CorrectionOffset(byte[] bytes)
+    {
+        if (bytes.length > MAX_BYTES)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " field length must be 1 - 8 bytes");
+        }
+        this.microseconds = PrimitiveConverter.variableBytesToInt64(bytes);
+    }
+
+    /**
+     * Get the correction offset.
+     *
+     * @return The correction offset, in microseconds.
+     */
+    public long getOffset()
+    {
+        return microseconds;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        return PrimitiveConverter.int64ToVariableBytes(microseconds);
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return microseconds + "\u00B5s";
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Correction Offset";
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -313,8 +313,7 @@ public class UasDatalinkFactory
             case LeapSeconds:
                 return new LeapSeconds(bytes);
             case CorrectionOffset:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new CorrectionOffset(bytes);
             case PayloadList:
                 return new PayloadList(bytes);
             case ActivePayloads:

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -281,7 +281,7 @@ public enum UasDatalinkTag
     CommunicationsMethod(135),
     /** Tag 136; Number of leap seconds to adjust Precision Time Stamp (Tag 2) to UTC; Value is a {@link LeapSeconds} */
     LeapSeconds(136),
-    /** Tag 137; Post-flight time adjustment to correct Precision Time Stamp (Tag 2) as needed; Value is a {@link OpaqueValue} */
+    /** Tag 137; Post-flight time adjustment to correct Precision Time Stamp (Tag 2) as needed; Value is a {@link CorrectionOffset} */
     CorrectionOffset(137),
     /** Tag 138; List of payloads available on the Platform; Value is a {@link PayloadList} */
     PayloadList(138),

--- a/api/src/test/java/org/jmisb/api/klv/st0601/CorrectionOffsetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/CorrectionOffsetTest.java
@@ -1,0 +1,52 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
+
+public class CorrectionOffsetTest
+{
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadLength()
+    {
+        byte[] nineByteArray = new byte[]{(byte)0x01, (byte)0x02, (byte)0x03, (byte)0x04, (byte)0x05, (byte)0x06, (byte)0x07, (byte)0x08, (byte)0x09};
+        new CorrectionOffset(nineByteArray);
+    }
+
+    @Test
+    public void stExample()
+    {
+        long value = 5025678901L;
+        byte[] origBytes = new byte[]{(byte)0x01, (byte)0x2B, (byte)0x8D, (byte)0xC6, (byte)0x35};
+
+        CorrectionOffset time = new CorrectionOffset(origBytes);
+        assertEquals(time.getDisplayName(), "Correction Offset");
+        assertEquals(time.getOffset(), value);
+        assertEquals(time.getBytes(), origBytes);
+        assertEquals(time.getDisplayableValue(), "5025678901\u00B5s");
+
+        time = new CorrectionOffset(value);
+        assertEquals(time.getDisplayName(), "Correction Offset");
+        assertEquals(time.getOffset(), value);
+        assertEquals(time.getBytes(), origBytes);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException {
+        long value = 5025678901L;
+        byte[] origBytes = new byte[]{(byte)0x01, (byte)0x2B, (byte)0x8D, (byte)0xC6, (byte)0x35};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.CorrectionOffset, origBytes);
+        assertTrue(v instanceof CorrectionOffset);
+        CorrectionOffset time = (CorrectionOffset)v;
+        assertEquals(time.getDisplayName(), "Correction Offset");
+        assertEquals(time.getOffset(), value);
+        assertEquals(time.getBytes(), origBytes);
+        assertEquals(time.getDisplayableValue(), "5025678901\u00B5s");
+
+        time = new CorrectionOffset(value);
+        assertEquals(time.getDisplayName(), "Correction Offset");
+        assertEquals(time.getOffset(), value);
+        assertEquals(time.getBytes(), origBytes);
+    }
+}

--- a/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
+++ b/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
@@ -1,5 +1,6 @@
 package org.jmisb.core.klv;
 
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -351,6 +352,17 @@ public class PrimitiveConverter
     }
 
     /**
+     * Convert a variable length byte array to an signed 64-bit integer (long)
+     *
+     * @param bytes The array of length 1-8
+     * @return The signed 64-bit integer as a long
+     */
+    public static long variableBytesToInt64(byte[] bytes)
+    {
+        return new BigInteger(bytes).longValue();
+    }
+
+    /**
      * Convert a signed 64-byte integer to a byte array
      *
      * @param val The long value
@@ -360,6 +372,21 @@ public class PrimitiveConverter
     {
         longBuffer.get().putLong(0, val);
         return longBuffer.get().array();
+    }
+
+    /**
+     * Convert an signed 64-bit integer to a byte array.
+     * <p>
+     * This is similar to int64ToBytes, except that it only uses the minimum
+     * required number of bytes to represent the value. So if the value will
+     * fit into two bytes, the results will be only two bytes.
+     *
+     * @param val The signed 64-bit integer
+     * @return The array of length 1-8 bytes.
+     */
+    public static byte[] int64ToVariableBytes(long val)
+    {
+        return BigInteger.valueOf(val).toByteArray();
     }
 
     /**

--- a/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
@@ -476,4 +476,212 @@ public class PrimitiveConverterTest
     {
         PrimitiveConverter.toInt64(new byte[]{(byte)0x12, (byte)0x34, (byte)0x00, (byte)0x04, (byte)0x59, (byte)0xF4, (byte)0xA6, (byte)0xAA, (byte)0x4A}, 2);
     }
+
+    @Test
+    public void testVariableBytesToSignedInt64()
+    {
+        byte[] bytes = new byte[]{(byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -1);
+
+        bytes = new byte[]{(byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 0);
+
+        bytes = new byte[]{(byte)0x80};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -128);
+
+        bytes = new byte[]{(byte)0x7F};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 127);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -1);
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 0);
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -32768);
+
+        bytes = new byte[]{(byte)0x7F, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 32767);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -1);
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 0);
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -8388608);
+
+        bytes = new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 8388607);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -1);
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 0);
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -2147483648);
+
+        bytes = new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 2147483647);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -1);
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 0);
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -549755813888L);
+
+        bytes = new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 549755813887L);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -1);
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 0);
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -140737488355328L);
+
+        bytes = new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 140737488355327L);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -1);
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 0);
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -36028797018963968L);
+
+        bytes = new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 36028797018963967L);
+
+        bytes = new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), -1);
+
+        bytes = new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), 0);
+
+        bytes = new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), Long.MIN_VALUE);
+
+        bytes = new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
+        Assert.assertEquals(PrimitiveConverter.variableBytesToInt64(bytes), Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testSignedInt64ToVariableBytes()
+    {
+        long intVal = -1;
+        byte[] bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff});
+
+        intVal = 0;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{0x00});
+
+        intVal = 10;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{0x0a});
+
+        intVal = 127;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{0x7f});
+
+        intVal = -127;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x81});
+
+        intVal = -128;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80});
+
+        intVal = 128;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x00, (byte)0x80});
+
+        intVal = -129;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xFF, (byte)0x7F});
+
+        intVal = 32767;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x7F, (byte)0xFF});
+
+        intVal = -32767;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x01});
+
+        intVal = -32768;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x00});
+
+        intVal = 32768;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x00, (byte)0x80, (byte)0x00});
+
+        intVal = -32769;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xFF, (byte)0x7F, (byte)0xFF});
+
+        intVal = 32768;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x00, (byte)0x80, (byte)0x00});
+
+        intVal = -8388608;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x00, (byte)0x00});
+
+        intVal = 8388607;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff});
+
+        intVal = -2147483648;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        intVal = 2147483647;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        intVal = -549755813888L;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        intVal = 549755813887L;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        intVal = -140737488355328L;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        intVal = 140737488355327L;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        intVal = -36028797018963968L;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        intVal = 36028797018963967L;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        intVal = Long.MIN_VALUE;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x80, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        intVal = Long.MAX_VALUE;
+        bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+    }
 }


### PR DESCRIPTION
## Motivation and Context
Adds support for an ST0601 Tag (137 - Correction Offset) that we don't currently support.

## Description
Fairly standard IUasDatalinkValue implementation. Adds some extra functionality to the PrimitiveConverter for signed 64 bit values with variable length representation - that is described in the Motion Imagery Handbook 2020.1, section 7.3.10 "Integer".

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

