### PR TITLE
Implement ST1204.3 UUID combination approach

### DIFF
--- a/api/src/test/java/org/jmisb/api/klv/st1204/CoreIdentifierTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1204/CoreIdentifierTest.java
@@ -27,9 +27,35 @@ public class CoreIdentifierTest
         CoreIdentifier coreIdentifier = new CoreIdentifier();
         assertNull(coreIdentifier.getPlatformUUID());
         assertEquals(coreIdentifier.getPlatformIdType(), IdType.None);
-        UUID sensorid = UUID.randomUUID();
-        coreIdentifier.setPlatformUUID(IdType.Managed, sensorid);
+        UUID platformId = UUID.randomUUID();
+        coreIdentifier.setPlatformUUID(IdType.Managed, platformId);
         assertEquals(coreIdentifier.getPlatformIdType(), IdType.Managed);
-        assertEquals(coreIdentifier.getPlatformUUID(), sensorid);
+        assertEquals(coreIdentifier.getPlatformUUID(), platformId);
+    }
+
+    @Test
+    public void windowSetter() {
+        CoreIdentifier coreIdentifier = new CoreIdentifier();
+        assertNull(coreIdentifier.getWindowUUID());
+        assertEquals(coreIdentifier.getWindowUUID(), null);
+        UUID windowId = UUID.randomUUID();
+        coreIdentifier.setWindowUUID(windowId);
+        assertEquals(coreIdentifier.getWindowUUID(), windowId);
+        coreIdentifier.setWindowUUID(null);
+        assertNull(coreIdentifier.getWindowUUID());
+        assertEquals(coreIdentifier.getWindowUUID(), null);
+    }
+
+    @Test
+    public void MinorSetter() {
+        CoreIdentifier coreIdentifier = new CoreIdentifier();
+        assertNull(coreIdentifier.getMinorUUID());
+        assertEquals(coreIdentifier.getMinorUUID(), null);
+        UUID minorId = UUID.randomUUID();
+        coreIdentifier.setMinorUUID(minorId);
+        assertEquals(coreIdentifier.getMinorUUID(), minorId);
+        coreIdentifier.setMinorUUID(null);
+        assertNull(coreIdentifier.getMinorUUID());
+        assertEquals(coreIdentifier.getMinorUUID(), null);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st1204/UUIDCombinationTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1204/UUIDCombinationTest.java
@@ -1,0 +1,55 @@
+package org.jmisb.api.klv.st1204;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+public class UUIDCombinationTest {
+
+    public UUIDCombinationTest() {
+    }
+
+    @Test
+    public void checkExample()
+    {
+        List<String> uuids = new ArrayList<>();
+        uuids.add("f81d4fae-7dec-11d0-a765-00a0c91e6bf6");
+        uuids.add("1ea5de30-e1d3-40fa-b501-2ca5cb58ca25");
+        UUID result = CoreIdentifier.combineMultipleUUID(uuids);
+        assertEquals(result.toString(), "cd9a0ef2-24a6-5343-aa21-3cd6be881b52");
+    }
+
+    @Test
+    public void checkExampleUppercase()
+    {
+        List<String> uuids = new ArrayList<>();
+        uuids.add("F81D4FAE-7DEC-11D0-A765-00A0C91E6BF6");
+        uuids.add("1EA5DE30-E1D3-40FA-B501-2CA5CB58CA25");
+        UUID result = CoreIdentifier.combineMultipleUUID(uuids);
+        assertEquals(result.toString(), "cd9a0ef2-24a6-5343-aa21-3cd6be881b52");
+    }
+
+    @Test
+    public void checkExampleMixedCase()
+    {
+        List<String> uuids = new ArrayList<>();
+        uuids.add("f81D4FAE-7dEC-11D0-a765-00A0C91e6Bf6");
+        uuids.add("1Ea5de30-e1d3-40FA-b501-2CA5CB58cA25");
+        UUID result = CoreIdentifier.combineMultipleUUID(uuids);
+        assertEquals(result.toString(), "cd9a0ef2-24a6-5343-aa21-3cd6be881b52");
+    }
+
+    @Test
+    public void checkFourUUID()
+    {
+        List<String> uuids = new ArrayList<>();
+        uuids.add("4e0f8130-7ed2-4f38-8278-21c9c3922ef6");
+        uuids.add("73eb8d66-4b90-46a3-b107-93678992e240");
+        uuids.add("53678ad0-f5a5-41b6-a379-8fb142794c15");
+        uuids.add("bbb3a8b5-def0-467a-9292-a40fd980a0bc");
+        UUID result = CoreIdentifier.combineMultipleUUID(uuids);
+        assertEquals(result.toString(), "74762af1-0c7b-56ff-b4f2-06209381b93a");
+    }
+}

--- a/core/src/main/java/org/jmisb/core/klv/UuidUtils.java
+++ b/core/src/main/java/org/jmisb/core/klv/UuidUtils.java
@@ -1,6 +1,8 @@
 package org.jmisb.core.klv;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.UUID;
 
 /**
@@ -66,10 +68,33 @@ public class UuidUtils {
      * @param uuid the UUID to format as text
      * @return text equivalent to the UUID
      */
-    public static String formatUUID(UUID uuid) {
+    public static String formatUUID(UUID uuid)
+    {
         String standardFormatUUID = uuid.toString().toUpperCase();
         String misbFormatUUID = standardFormatUUID.substring(0, 4) + "-" + standardFormatUUID.substring(4, 28) + "-" + standardFormatUUID.substring(28, 32) + "-" + standardFormatUUID.substring(32);
         return misbFormatUUID;
+    }
+
+    public static UUID convertHashOutputToVersion5UUID(byte[] uuidBytes)
+    {
+        byte[] truncatedBytes = Arrays.copyOf(uuidBytes, 16);
+        truncatedBytes[6] &= 15; // clear version
+        truncatedBytes[6] |= 80; // set to version 5
+        truncatedBytes[8] &= 63; // clear variant bits
+        truncatedBytes[8] |= 128; // set to variant 2
+        return UuidUtils.arrayToUuid(truncatedBytes, 0);
+    }
+
+    /**
+     * Convert a hex String (in UUID format) to a byte array.
+     * <p>
+     * Per ST1204 algorithm, the separators are ignored.
+     * @param uuidString the string to convert
+     * @return corresponding byte array.
+     */
+    public static byte[] uuidStringToByteArray(String uuidString)
+    {
+        return uuidString.replaceAll("-", "").toUpperCase().getBytes(Charset.forName("US-ASCII"));
     }
 
 }

--- a/core/src/test/java/org/jmisb/core/klv/UuidUtilsTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/UuidUtilsTest.java
@@ -49,4 +49,33 @@ public class UuidUtilsTest
         UUID expectedUuid = UUID.fromString("C2A7D724-96F7-47DB-A23D-A29730075876");
         assertEquals(uuid, expectedUuid);
     }
+
+    @Test
+    public void checkUUIDStringtoByteArray()
+    {
+        byte[] ba = UuidUtils.uuidStringToByteArray("C2A7D724-96F7-47DB-A23D-A29730075876");
+        byte[] expectedBytes = new byte[] {(byte)0x43, (byte)0x32, (byte)0x41, (byte)0x37, (byte)0x44, (byte)0x37, (byte)0x32, (byte)0x34, (byte)0x39, (byte)0x36, (byte)0x46, (byte)0x37, (byte)0x34, (byte)0x37, (byte)0x44, (byte)0x42, (byte)0x41, (byte)0x32, (byte)0x33, (byte)0x44, (byte)0x41, (byte)0x32, (byte)0x39, (byte)0x37, (byte)0x33, (byte)0x30, (byte)0x30, (byte)0x37, (byte)0x35, (byte)0x38, (byte)0x37, (byte)0x36};
+        assertEquals(ba, expectedBytes);
+    }
+
+    @Test
+    public void checkUUIDlowerCaseStringtoByteArray()
+    {
+        byte[] ba = UuidUtils.uuidStringToByteArray("c2a7d724-96f7-47db-a23d-a29730075876");
+        // for (int i = 0; i < ba.length; i++)
+        // {
+        //    System.out.print(String.format("(byte)0x%02x, ", ba[i]));
+        //}
+        byte[] expectedBytes = new byte[] {(byte)0x43, (byte)0x32, (byte)0x41, (byte)0x37, (byte)0x44, (byte)0x37, (byte)0x32, (byte)0x34, (byte)0x39, (byte)0x36, (byte)0x46, (byte)0x37, (byte)0x34, (byte)0x37, (byte)0x44, (byte)0x42, (byte)0x41, (byte)0x32, (byte)0x33, (byte)0x44, (byte)0x41, (byte)0x32, (byte)0x39, (byte)0x37, (byte)0x33, (byte)0x30, (byte)0x30, (byte)0x37, (byte)0x35, (byte)0x38, (byte)0x37, (byte)0x36};
+        assertEquals(ba, expectedBytes);
+    }
+
+    @Test
+    public void checkByteArrayToUUID5()
+    {
+        byte[] bytes = new byte[] {(byte)0xc2, (byte)0xa7, (byte)0xd7, (byte)0x24, (byte)0x96, (byte)0xf7, (byte)0x47, (byte)0xdb, (byte)0xa2, (byte)0x3d, (byte)0xa2, (byte)0x97, (byte)0x30, (byte)0x07, (byte)0x58, (byte)0x76};
+        UUID uuid = UuidUtils.convertHashOutputToVersion5UUID(bytes);
+        UUID expectedUuid = UUID.fromString("C2A7D724-96F7-57DB-A23D-A29730075876");
+        assertEquals(uuid, expectedUuid);
+    }
 }


### PR DESCRIPTION
## Motivation and Context
Adds the ST1204.3 UUID combination approach.

Resolves #84 

This PR replaces #86 which was too badly conflicted.

## Description
Implements new algorithm for UUID combination (e.g. for sensors in a LVMI scenario).
Also adds a bit more javadoc.

## How Has This Been Tested?
Unit tests to match to the example in ST1204.3 scenario.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.