### PR TITLE
Implement ST0601 Take Off Time (Tag 131).

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/PrecisionTimeStamp.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PrecisionTimeStamp.java
@@ -32,6 +32,10 @@ public class PrecisionTimeStamp extends ST0603TimeStamp implements IUasDatalinkV
     public PrecisionTimeStamp(byte[] bytes)
     {
         super(bytes);
+        if (bytes.length < 8)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " encoding is an 8-byte unsigned int");
+        }
     }
 
     /**
@@ -44,8 +48,15 @@ public class PrecisionTimeStamp extends ST0603TimeStamp implements IUasDatalinkV
     }
 
     @Override
-    public String getDisplayName()
+    public final String getDisplayName()
     {
         return "Precision Time Stamp";
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        // On generation, we return the full 8 bytes for compliance.
+        return getBytesFull();
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TakeOffTime.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TakeOffTime.java
@@ -1,0 +1,70 @@
+package org.jmisb.api.klv.st0601;
+
+import java.time.LocalDateTime;
+import org.jmisb.api.klv.st0603.ST0603TimeStamp;
+
+/**
+ * Take Off Time (ST 0601 tag 131).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Time when aircraft became airborne.
+ * <p>
+ * Represented in the number of microseconds elapsed since midnight (00:00:00), January 1, 1970 not including leap seconds.
+ * <p>
+ * See MISB ST 0603.
+ * <p>
+ * See details for Time Airborne (Tag 110) for description and usage.
+ * <p>
+ * Resolution: 1 microsecond.
+ * </blockquote>
+ */
+public class TakeOffTime extends ST0603TimeStamp implements IUasDatalinkValue
+{
+    /**
+     * Create from value
+     * @param microseconds Microseconds since the epoch.
+     */
+    public TakeOffTime(long microseconds)
+    {
+        super(microseconds);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * @param bytes Encoded byte array
+     */
+    public TakeOffTime(byte[] bytes)
+    {
+        super(bytes);
+    }
+
+    /**
+     * Create from {@code LocalDateTime}
+     * @param localDateTime The date and time
+     */
+    public TakeOffTime(LocalDateTime localDateTime)
+    {
+        super(localDateTime);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Take Off Time";
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        // This doesn't need to be 8 bytes.
+        return getBytesVariable();
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return getDisplayableValueDateTime();
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -300,8 +300,7 @@ public class UasDatalinkFactory
             case AirbaseLocations:
                 return new AirbaseLocations(bytes);
             case TakeOffTime:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new TakeOffTime(bytes);
             case TransmissionFrequency:
                 return new TransmissionFrequency(bytes);
             case OnBoardMiStorageCapacity:

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -269,7 +269,7 @@ public enum UasDatalinkTag
     TargetId(129),
     /** Tag 130; Geographic location of the take-off site and recovery site; Value is a {@link AirbaseLocations} */
     AirbaseLocations(130),
-    /** Tag 131; Time when aircraft became airborne; Value is a {@link OpaqueValue} */
+    /** Tag 131; Time when aircraft became airborne; Value is a {@link TakeOffTime} */
     TakeOffTime(131),
     /** Tag 132; Radio frequency used to transmit the Motion Imagery; Value is a {@link TransmissionFrequency} */
     TransmissionFrequency(132),

--- a/api/src/main/java/org/jmisb/api/klv/st0903/PrecisionTimeStamp.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/PrecisionTimeStamp.java
@@ -45,7 +45,11 @@ public class PrecisionTimeStamp extends ST0603TimeStamp implements IVmtiMetadata
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
+     *
+     * In ST0903.4 and ST0903.5, this needs to be 8 bytes. However earlier
+     * versions allowed it to be up to 8 bytes, so we tolerate that.
+     *
      * @param bytes Encoded byte array
      */
     public PrecisionTimeStamp(byte[] bytes)
@@ -68,4 +72,10 @@ public class PrecisionTimeStamp extends ST0603TimeStamp implements IVmtiMetadata
         return "Precision Time Stamp";
     }
 
+    @Override
+    public byte[] getBytes()
+    {
+        // On generation, we return the full 8 bytes for compliance.
+        return getBytesFull();
+    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/EndTime.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/EndTime.java
@@ -28,7 +28,11 @@ public class EndTime extends ST0603TimeStamp implements IVmtiMetadataValue
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
+     *
+     * In ST0903.4 and ST0903.5, this needs to be 8 bytes. However earlier
+     * versions allowed it to be up to 8 bytes, so we tolerate that.
+     *
      * @param bytes Encoded byte array
      */
     public EndTime(byte[] bytes)
@@ -49,5 +53,12 @@ public class EndTime extends ST0603TimeStamp implements IVmtiMetadataValue
     public final String getDisplayName()
     {
         return "End Time";
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        // On generation, we return the full 8 bytes for compliance.
+        return getBytesFull();
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/StartTime.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/StartTime.java
@@ -27,7 +27,11 @@ public class StartTime extends ST0603TimeStamp implements IVmtiMetadataValue
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
+     *
+     * In ST0903.4 and ST0903.5, this needs to be 8 bytes. However earlier
+     * versions allowed it to be up to 8 bytes, so we tolerate that.
+     *
      * @param bytes Encoded byte array
      */
     public StartTime(byte[] bytes)
@@ -48,5 +52,12 @@ public class StartTime extends ST0603TimeStamp implements IVmtiMetadataValue
     public final String getDisplayName()
     {
         return "Start Time";
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        // On generation, we return the full 8 bytes for compliance.
+        return getBytesFull();
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/TakeOffTimeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/TakeOffTimeTest.java
@@ -1,0 +1,106 @@
+package org.jmisb.api.klv.st0601;
+
+import org.testng.annotations.Test;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import org.jmisb.api.common.KlvParseException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TakeOffTimeTest
+{
+    // Example from MISB ST doc
+    @Test
+    public void testExample()
+    {
+        byte[] bytes = new byte[]{(byte)0x00, (byte)0x05, (byte)0x6F, (byte)0x27, (byte)0x1B, (byte)0x5E, (byte)0x41, (byte)0xB7};
+        TakeOffTime timestamp = new TakeOffTime(bytes);
+        checkExampleValue(timestamp);
+    }
+
+    @Test
+    public void testContructFromValue()
+    {
+        TakeOffTime timestamp = new TakeOffTime(1529588637122999L);
+        checkExampleValue(timestamp);
+    }
+
+    @Test
+    public void testContructFromDateTime()
+    {
+        LocalDateTime ldt = LocalDateTime.of(2018, Month.JUNE, 21, 13, 43, 57, 122999000);
+        TakeOffTime timestamp = new TakeOffTime(ldt);
+        checkExampleValue(timestamp);
+    }
+
+    protected void checkExampleValue(TakeOffTime timestamp)
+    {
+        assertEquals(timestamp.getDisplayName(), "Take Off Time");
+        assertEquals(timestamp.getDisplayableValue(), "2018-06-21T13:43:57.122999");
+        LocalDateTime dateTime = timestamp.getDateTime();
+        assertEquals(dateTime.getYear(), 2018);
+        assertEquals(dateTime.getMonth(), Month.JUNE);
+        assertEquals(dateTime.getDayOfMonth(), 21);
+        assertEquals(dateTime.getHour(), 13);
+        assertEquals(dateTime.getMinute(), 43);
+        assertEquals(dateTime.getSecond(), 57);
+        assertEquals(dateTime.getNano(), 122999000);
+        assertEquals(timestamp.getMicroseconds(), 1529588637122999L);
+        assertEquals(timestamp.getBytes(), new byte[]{(byte)0x05, (byte)0x6F, (byte)0x27, (byte)0x1B, (byte)0x5E, (byte)0x41, (byte)0xB7});
+    }
+
+    @Test
+    public void testFactoryExample() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x00, (byte)0x05, (byte)0x6F, (byte)0x27, (byte)0x1B, (byte)0x5E, (byte)0x41, (byte)0xB7};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.TakeOffTime, bytes);
+        assertTrue(v instanceof TakeOffTime);
+        assertEquals(v.getDisplayName(), "Take Off Time");
+        TakeOffTime timestamp = (TakeOffTime)v;
+        checkExampleValue(timestamp);
+    }
+
+    @Test
+    public void testExampleWithShortArray()
+    {
+        // Convert byte[] -> value
+        byte[] bytes = new byte[]{(byte)0x05, (byte)0x6F, (byte)0x27, (byte)0x1B, (byte)0x5E, (byte)0x41, (byte)0xB7};
+        TakeOffTime timestamp = new TakeOffTime(bytes);
+        checkExampleValue(timestamp);
+    }
+
+    @Test
+    public void testMinAndMax()
+    {
+        TakeOffTime pts = new TakeOffTime(0L);
+        assertEquals(pts.getDisplayName(), "Take Off Time");
+        assertEquals(pts.getDateTime().getYear(), 1970);
+        assertEquals(pts.getDateTime().getMonth(), Month.JANUARY);
+        assertEquals(pts.getDateTime().getDayOfMonth(), 1);
+        assertEquals(pts.getDisplayableValue(), "1970-01-01T00:00:00");
+
+        // Create max value and ensure no exception is thrown
+        pts = new TakeOffTime(Long.MAX_VALUE);
+        assertEquals(pts.getDisplayName(), "Take Off Time");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new TakeOffTime(-1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        // Oct 12, 2263 at 08:30
+        new TakeOffTime(LocalDateTime.of(2263, 10, 12, 8, 30));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new TakeOffTime(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0603/ST0603TimeStampTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0603/ST0603TimeStampTest.java
@@ -6,11 +6,8 @@ import org.testng.annotations.Test;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import org.jmisb.api.common.KlvParseException;
 
 public class ST0603TimeStampTest
 {
@@ -32,11 +29,12 @@ public class ST0603TimeStampTest
         Assert.assertEquals(dateTime.getSecond(), 21);
         Assert.assertEquals(dateTime.getNano(), 0);
 
+        Assert.assertEquals(pts.getDisplayableValueDateTime(), "2001-04-19T04:25:21");
         // Convert value -> byte[]
         long microseconds = dateTime.toInstant(ZoneOffset.UTC).toEpochMilli() * 1000;
         ST0603TimeStamp pts2 = new ST0603TimeStamp(microseconds);
-        Assert.assertEquals(pts2.getBytes(), new byte[]{(byte)0x00, (byte)0x03, (byte)0x82, (byte)0x44, (byte)0x30, (byte)0xF6, (byte)0xCE, (byte)0x40});
-
+        Assert.assertEquals(pts2.getBytesFull(), new byte[]{(byte)0x00, (byte)0x03, (byte)0x82, (byte)0x44, (byte)0x30, (byte)0xF6, (byte)0xCE, (byte)0x40});
+        Assert.assertEquals(pts2.getBytesVariable(), new byte[]{(byte)0x03, (byte)0x82, (byte)0x44, (byte)0x30, (byte)0xF6, (byte)0xCE, (byte)0x40});
         Assert.assertEquals(microseconds, 987654321000000L);
         Assert.assertEquals(pts2.getDisplayableValue(), "987654321000000");
     }
@@ -61,6 +59,7 @@ public class ST0603TimeStampTest
         Assert.assertEquals(pts.getDateTime().getMonth(), Month.JANUARY);
         Assert.assertEquals(pts.getDateTime().getDayOfMonth(), 1);
         Assert.assertEquals(pts.getDisplayableValue(), "0");
+        Assert.assertEquals(pts.getDisplayableValueDateTime(), "1970-01-01T00:00:00");
 
         // Create max value and ensure no exception is thrown
         pts = new ST0603TimeStamp(Long.MAX_VALUE);
@@ -82,6 +81,6 @@ public class ST0603TimeStampTest
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength()
     {
-        new ST0603TimeStamp(new byte[]{0x00, 0x00, 0x00, 0x00});
+        new ST0603TimeStamp(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/PrecisionTimeStampTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/PrecisionTimeStampTest.java
@@ -107,6 +107,6 @@ public class PrecisionTimeStampTest
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength()
     {
-        new PrecisionTimeStamp(new byte[]{0x00, 0x00, 0x00, 0x00});
+        new PrecisionTimeStamp(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/EndTimeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/EndTimeTest.java
@@ -108,6 +108,6 @@ public class EndTimeTest
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength()
     {
-        new EndTime(new byte[]{0x00, 0x00, 0x00, 0x00});
+        new EndTime(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/StartTimeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/StartTimeTest.java
@@ -108,6 +108,6 @@ public class StartTimeTest
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength()
     {
-        new StartTime(new byte[]{0x00, 0x00, 0x00, 0x00});
+        new StartTime(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
     }
 }

--- a/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
+++ b/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
@@ -92,6 +92,33 @@ public class PrimitiveConverter
         }
     }
 
+    /**
+     * Convert an unsigned 8 byte unsigned integer (long with range of uint64) to a byte array.
+     * <p>
+     * This only uses the minimum required number of bytes to represent the
+     * value. So if the value will fit into two bytes, the results will be only
+     * two bytes.
+     *
+     * @param longValue The unsigned integer as long
+     * @return The array of length 1-8 bytes.
+     */
+    public static byte[] uintToVariableBytes(long longValue)
+    {
+        if (Long.compareUnsigned(longValue, 72057594037927935L) > 0)
+        {
+            return PrimitiveConverter.int64ToBytes(longValue);
+        }
+        else if (Long.compareUnsigned(longValue, 281474976710655L) > 0)
+        {
+            byte[] bytes = PrimitiveConverter.int64ToBytes(longValue);
+            return new byte[]{bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]};
+        }
+        else
+        {
+            return uintToVariableBytesV6(longValue);
+        }
+    }
+
     private PrimitiveConverter() {}
 
     /**
@@ -360,6 +387,36 @@ public class PrimitiveConverter
     public static long variableBytesToInt64(byte[] bytes)
     {
         return new BigInteger(bytes).longValue();
+    }
+
+    /**
+     * Convert a variable length byte array to an unsigned 64-bit integer (long with range of uint64)
+     *
+     * @param bytes The array of length 1-8
+     * @return The unsigned 64-bit integer as a long
+     */
+    public static long variableBytesToUint64(byte[] bytes)
+    {
+        switch (bytes.length) {
+            case 8:
+                return ByteBuffer.wrap(bytes, 0, Long.BYTES).getLong();
+            case 7:
+                return arrayToUnsignedLongInternal(bytes);
+            case 6:
+                return arrayToUnsignedLongInternal(bytes);
+            case 5:
+                return arrayToUnsignedLongInternal(bytes);
+            case 4:
+                return PrimitiveConverter.toUint32(bytes);
+            case 3:
+                return arrayToUnsignedLongInternal(bytes);
+            case 2:
+                return PrimitiveConverter.toUint16(bytes);
+            case 1:
+                return PrimitiveConverter.toUint8(bytes);
+            default:
+                throw new IllegalArgumentException("Invalid buffer length");
+        }
     }
 
     /**

--- a/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
@@ -351,7 +351,7 @@ public class PrimitiveConverterTest
     }
 
     @Test
-    public void testUnsignedInt32ToVariableBytesV6()
+    public void testUnsignedIntToVariableBytesV6()
     {
         long longVal = 1L;
         byte[] bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
@@ -400,6 +400,118 @@ public class PrimitiveConverterTest
         longVal = 281474976710655L;
         bytes = PrimitiveConverter.uintToVariableBytesV6(longVal);
         Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+    }
+
+    @Test
+    public void testUnsignedIntToVariableBytes()
+    {
+        long longVal = 1L;
+        byte[] bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{0x01});
+
+        longVal = 255L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff});
+
+        longVal = 256L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00});
+
+        longVal = 65535L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff});
+
+        longVal = 65536L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00});
+
+        longVal = 16777215L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
+
+        longVal = 16777216L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        longVal = 4294967295L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        longVal = 4294967296L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        longVal = 1099511627775L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        longVal = 1099511627776L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        longVal = 281474976710655L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        longVal = 72057594037927935L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+
+        longVal = 72057594037927936L;
+        bytes = PrimitiveConverter.uintToVariableBytes(longVal);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testVariableBytesToUintBadLength()
+    {
+        PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0x01, (byte)0x02, (byte)0x03, (byte)0x04, (byte)0x05, (byte)0x06, (byte)0x07, (byte)0x08, (byte)0x09});
+    }
+
+    @Test
+    public void testVariableBytesToUint()
+    {
+        long val = PrimitiveConverter.variableBytesToUint64(new byte[]{0x01});
+        Assert.assertEquals(val, 1L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0xFF});
+        Assert.assertEquals(val, 255L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0x01, (byte)0x00});
+        Assert.assertEquals(val, 256L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0xFF, (byte)0xFF});
+        Assert.assertEquals(val, 65535L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0x01, (byte)0x00, (byte)0x00});
+        Assert.assertEquals(val, 65536L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(val, 16777215L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00});
+        Assert.assertEquals(val, 16777216L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(val, 4294967295L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+        Assert.assertEquals(val, 4294967296L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(val, 1099511627775L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+        Assert.assertEquals(val, 1099511627776L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(val, 281474976710655L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+        Assert.assertEquals(val, 72057594037927935L);
+
+        val = PrimitiveConverter.variableBytesToUint64(new byte[]{(byte)0x01, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+        Assert.assertEquals(val,72057594037927936L );
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
Adds support for a tag we don't currently support.

## Description
IUasDatalinkValue implementation, with support via the ST0603 timestamp code we already had, extended to handle the "variable up to 8 bytes" encoding. 
That is also useful in ST0903 timestamps, which are now required to be 8 bytes, but previously supported variable length encoding (typically 7 bytes). 
There was a knock-effect to other users of the ST0603 code, but its mostly in the tests.
The variable-length encoding/decoding required extension to the PrimitiveConverter.

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

