### PR TITLE
Add support for ST0601 Tag 60 "Weapon Load" and Tag 61 "Weapon Fired"

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -147,8 +147,7 @@ public class UasDatalinkFactory
             case WeaponLoad:
                 return new WeaponLoad(bytes);
             case WeaponFired:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new WeaponFired(bytes);
             case LaserPrfCode:
                 return new LaserPrfCode(bytes);
             case SensorFovName:

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -145,8 +145,7 @@ public class UasDatalinkFactory
             case PlatformCallSign:
                 return new UasDatalinkString(UasDatalinkString.PLATFORM_CALL_SIGN, bytes);
             case WeaponLoad:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new WeaponLoad(bytes);
             case WeaponFired:
                 // TODO
                 return new OpaqueValue(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -127,7 +127,7 @@ public enum UasDatalinkTag
     PlatformFuelRemaining(58),
     /** Tag 59; Call sign of platform or operating unit; Value is a {@link UasDatalinkString} */
     PlatformCallSign(59),
-    /** Tag 60; Current weapons stored on aircraft; Value is a {@link OpaqueValue} */
+    /** Tag 60; Current weapons stored on aircraft; Value is a {@link WeaponLoad} */
     WeaponLoad(60),
     /** Tag 61; Indication when a particular weapon is released; Value is a {@link OpaqueValue} */
     WeaponFired(61),

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -129,7 +129,7 @@ public enum UasDatalinkTag
     PlatformCallSign(59),
     /** Tag 60; Current weapons stored on aircraft; Value is a {@link WeaponLoad} */
     WeaponLoad(60),
-    /** Tag 61; Indication when a particular weapon is released; Value is a {@link OpaqueValue} */
+    /** Tag 61; Indication when a particular weapon is released; Value is a {@link WeaponFired} */
     WeaponFired(61),
     /** Tag 62; A laser's Pulse Repetition Frequency (PRF) code used to mark a target; Value is a {@link LaserPrfCode} */
     LaserPrfCode(62),

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WeaponFired.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WeaponFired.java
@@ -1,0 +1,100 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Weapon Fired (ST 0601 tag 61).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Indication when a particular weapon is released.
+ * <p>
+ * Note: the Weapon Stores (Tag 140) replaces the Weapon Load (Tag 60) and
+ * Weapon Fired (Tag 61) for providing information about Weapons and their
+ * status.
+ * <p>
+ * The Weapon Fired metadata item has the same format as the first byte of the
+ * Weapon Load metadata item indicating station and substation location of a
+ * store. Byte 1 is composed of two nibbles with [nib1] being the most
+ * significant nibble with bit order [3210] where 3=msb.
+ * <p>
+ * When included in a KLV packet, correlate the Weapon Fired item with the
+ * mandatory timestamp to determine the release time of a weapon.
+ * </blockquote>
+ */
+public class WeaponFired implements IUasDatalinkValue
+{
+    private int stationNumber;
+    private int substationNumber;
+
+    /**
+     * Create from value.
+     *
+     * @param stationNumber the station number, in the range 1..15.
+     * @param substationNumber the substation number, in the range 0..15
+     */
+    public WeaponFired(int stationNumber, int substationNumber) {
+        if ((stationNumber < 1) || (stationNumber > 15))
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " station number must be in the range [1, 15]");
+        }
+        if ((substationNumber < 0) || (substationNumber > 15))
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " sub-station number must be in the range [0, 15]");
+        }
+        this.stationNumber = stationNumber;
+        this.substationNumber = substationNumber;
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * @param bytes The byte array of length 1
+     */
+    public WeaponFired(byte[] bytes)
+    {
+        if (bytes.length != 1)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " encoding is a 1-byte array");
+        }
+        byte b = bytes[0];
+        substationNumber = b & 0x0F;
+        stationNumber = (b & 0xF0) >> 4;;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        byte b = (byte)((stationNumber << 4) + substationNumber);
+        return new byte[]{b};
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return String.format("%d.%d", stationNumber, substationNumber);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Weapon Fired";
+    }
+
+    /**
+     * Get the store station number.
+     *
+     * @return integer value, where 1 is the left-most pylon.
+     */
+    public int getStationNumber()
+    {
+        return stationNumber;
+    }
+
+    /**
+     * Get the store substation number.
+     * @return integer value, in the range [0..15], where 0 means no-substation.
+     */
+    public int getSubstationNumber()
+    {
+        return substationNumber;
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WeaponLoad.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WeaponLoad.java
@@ -1,0 +1,145 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Weapon Load (ST 0601 tag 60).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Current weapons stored on aircraft.
+ * <p>
+ * Note: the Weapon Stores (Tag 140) replaces the Weapon Load (Tag 60) and
+ * Weapon Fired (Tag 61) for providing information about Weapons and their
+ * status.
+ * <p>
+ * The Weapon Load item is composed of two bytes: the first byte indicates the
+ * aircraft store location, and the second byte indicates the store type. Each
+ * byte is composed of two nibbles with [nib1] being the most significant nibble
+ * with bit order [3210] where 3=msb.
+ * <p>
+ * Aircraft store location is indicated by station number which starts its
+ * numbering at the outboard left wing as store location 1 and increases towards
+ * the outboard right wing. Each station can have a different
+ * weapon installed, or multiple weapons on the same station. For multiple
+ * weapons per station, the substation number begins at 1. A substation number
+ * of 0 indicates a single store located at the station. The aircraft store
+ * location byte has two nibbles: the first most significant nibble indicates
+ * Station Number; the second nibble the Substation Number.
+ * <p>
+ * The weapon type byte is also composed of two nibbles: the first most
+ * significant nibble indicates Weapon Type; the second nibble indicates Weapon
+ * Variant. A list of available weapons is undefined.
+ * </blockquote>
+ */
+public class WeaponLoad implements IUasDatalinkValue
+{
+    private int stationNumber;
+    private int substationNumber;
+    private int weaponType;
+    private int weaponVariant;
+    /**
+     * Create from value.
+     *
+     * @param stationNumber the station number, in the range 1..15.
+     * @param substationNumber the substation number, in the range 0..15
+     * @param weaponType the weapon type, in the range 0..15.
+     * @param weaponVariant the weapon variant, in the range 0..15
+     */
+    public WeaponLoad(int stationNumber, int substationNumber, int weaponType, int weaponVariant) {
+        if ((stationNumber < 1) || (stationNumber > 15))
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " station number must be in the range [1, 15]");
+        }
+        if ((substationNumber < 0) || (substationNumber > 15))
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " sub-station number must be in the range [0, 15]");
+        }
+        if ((weaponType < 0) || (weaponType > 15))
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " weapon type must be in the range [0, 15]");
+        }
+        if ((weaponVariant < 0) || (weaponVariant > 15))
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " weapon variant must be in the range [0, 15]");
+        }
+        this.stationNumber = stationNumber;
+        this.substationNumber = substationNumber;
+        this.weaponType = weaponType;
+        this.weaponVariant = weaponVariant;
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * @param bytes The byte array of length 2
+     */
+    public WeaponLoad(byte[] bytes)
+    {
+        if (bytes.length != 2)
+        {
+            throw new IllegalArgumentException(this.getDisplayName() + " encoding is a 2-byte array");
+        }
+        byte msb = bytes[0];
+        substationNumber = msb & 0x0F;
+        stationNumber = (msb & 0xF0) >> 4;
+        byte lsb = bytes[1];
+        weaponVariant = lsb & 0x0F;
+        weaponType = (lsb & 0xF0) >> 4;
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        byte msb = (byte)((stationNumber << 4) + substationNumber);
+        byte lsb = (byte)((weaponType << 4) + weaponVariant);
+        return new byte[]{msb, lsb};
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return String.format("%d.%d: %d/%d", stationNumber, substationNumber, weaponType, weaponVariant);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Weapon Load";
+    }
+
+    /**
+     * Get the store station number.
+     *
+     * @return integer value, where 1 is the left-most pylon.
+     */
+    public int getStationNumber()
+    {
+        return stationNumber;
+    }
+
+    /**
+     * Get the store substation number.
+     * @return integer value, in the range [0..15], where 0 means no-substation.
+     */
+    public int getSubstationNumber()
+    {
+        return substationNumber;
+    }
+
+    /**
+     * Get the weapon type number.
+     * @return weapon type number, in the range [0..15]
+     */
+    public int getWeaponType()
+    {
+        return weaponType;
+    }
+
+    /**
+     * Get the weapon variant number.
+     * @return weapon variant number, in the range [0..15]
+     */
+    public int getWeaponVariant()
+    {
+        return weaponVariant;
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/WeaponFiredTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/WeaponFiredTest.java
@@ -1,0 +1,74 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
+
+public class WeaponFiredTest
+{
+    private final byte[] ST_EXAMPLE_BYTES = new byte[]{(byte)0xBA};
+
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        WeaponFired weaponFired = new WeaponFired(11, 10);
+        checkValuesForExample(weaponFired);
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        WeaponFired weaponFired = new WeaponFired(ST_EXAMPLE_BYTES);
+        checkValuesForExample(weaponFired);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.WeaponFired, ST_EXAMPLE_BYTES);
+        assertTrue(v instanceof WeaponFired);
+        WeaponFired weaponFired = (WeaponFired)v;
+        checkValuesForExample(weaponFired);
+    }
+
+    private void checkValuesForExample(WeaponFired weaponFired)
+    {
+        assertEquals(weaponFired.getBytes(), ST_EXAMPLE_BYTES);
+        assertEquals(weaponFired.getStationNumber(), 11);
+        assertEquals(weaponFired.getSubstationNumber(), 10);
+        assertEquals(weaponFired.getDisplayableValue(), "11.10");
+        assertEquals(weaponFired.getDisplayName(), "Weapon Fired");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testStationTooSmall()
+    {
+        new WeaponFired(0, 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testStationTooBig()
+    {
+         new WeaponFired(16, 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSubStationTooSmall()
+    {
+        new WeaponFired(1, -1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSubStationTooBig()
+    {
+         new WeaponFired(1, 16);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new WeaponFired(new byte[]{0x00, 0x00});
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/WeaponLoadTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/WeaponLoadTest.java
@@ -1,0 +1,102 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
+
+public class WeaponLoadTest
+{
+    private final byte[] ST_EXAMPLE_BYTES = new byte[]{(byte)0xAF, (byte)0xD8};
+
+    @Test
+    public void testConstructFromValue()
+    {
+        // From ST:
+        WeaponLoad weaponLoad = new WeaponLoad(10, 15, 13, 8);
+        checkValuesForExample(weaponLoad);
+    }
+
+    @Test
+    public void testConstructFromEncoded()
+    {
+        WeaponLoad weaponLoad = new WeaponLoad(ST_EXAMPLE_BYTES);
+        checkValuesForExample(weaponLoad);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.WeaponLoad, ST_EXAMPLE_BYTES);
+        assertTrue(v instanceof WeaponLoad);
+        WeaponLoad weaponLoad = (WeaponLoad)v;
+        checkValuesForExample(weaponLoad);
+    }
+
+    private void checkValuesForExample(WeaponLoad weaponLoad)
+    {
+        assertEquals(weaponLoad.getBytes(), ST_EXAMPLE_BYTES);
+        assertEquals(weaponLoad.getStationNumber(), 10);
+        assertEquals(weaponLoad.getSubstationNumber(), 15);
+        assertEquals(weaponLoad.getWeaponType(), 13);
+        assertEquals(weaponLoad.getWeaponVariant(), 8);
+        assertEquals(weaponLoad.getDisplayableValue(), "10.15: 13/8");
+        assertEquals(weaponLoad.getDisplayName(), "Weapon Load");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testStationTooSmall()
+    {
+        new WeaponLoad(0, 1, 1, 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testStationTooBig()
+    {
+         new WeaponLoad(16, 1, 1, 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSubStationTooSmall()
+    {
+        new WeaponLoad(1, -1, 1, 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSubStationTooBig()
+    {
+         new WeaponLoad(1, 16, 1, 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testWeaponTypeTooSmall()
+    {
+        new WeaponLoad(1, 0, -1, 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testWeaponTypeTooBig()
+    {
+         new WeaponLoad(1, 1, 16, 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testWeaponVariantTooSmall()
+    {
+        new WeaponLoad(1, 0, 1, -1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testWeaponVariantTooBig()
+    {
+         new WeaponLoad(1, 1, 1, 16);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new WeaponLoad(new byte[]{0x00, 0x00, 0x00});
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Adds support for a couple of tags we don't yet support. Tag 60 and 61 are very similar.

## Description
Fairly standard IUasDatalinkValue implementations - some minor differences because of unpacking nibbles from byte array, but nothing special.
Includes tests.

## How Has This Been Tested?
Unit tests, plus some of the MISB FLI data has examples of Weapon Load (its all zero, which isn't actually valid, but it still works).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

