### PR TITLE
Implement ST0601 Event Start Time - UTC (tag 72)

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/EventStartTimeUtc.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/EventStartTimeUtc.java
@@ -1,0 +1,72 @@
+package org.jmisb.api.klv.st0601;
+
+import java.time.LocalDateTime;
+import org.jmisb.api.klv.st0603.ST0603TimeStamp;
+
+/**
+ * Event Start Time - UTC (ST 0601 tag 72).
+ * <p>
+ * From ST:
+ * <blockquote>
+ * Start time of scene, project, event, mission, editing event, license,
+ * publication, etc.
+ * <p>
+ * Represented in the number of microseconds elapsed since midnight (00:00:00),
+ * January 1, 1970.
+ * <p>
+ * The Event Start Time - UTC metadata item is used to represent the start time
+ * of a mission, or other event related to the Motion Imagery collection. Event
+ * Start Time – UTC is to be interpreted as an arbitrary time hack indicating
+ * the start of some event.
+ * </blockquote>
+ * Note: if you are looking to represent takeoff time, see TakeOffTime (Tag 131).
+ */
+public class EventStartTimeUtc extends ST0603TimeStamp implements IUasDatalinkValue
+{
+    /**
+     * Create from value
+     * @param microseconds Microseconds since the epoch.
+     */
+    public EventStartTimeUtc(long microseconds)
+    {
+        super(microseconds);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * @param bytes Encoded byte array
+     */
+    public EventStartTimeUtc(byte[] bytes)
+    {
+        super(bytes);
+    }
+
+    /**
+     * Create from {@code LocalDateTime}
+     * @param localDateTime The date and time
+     */
+    public EventStartTimeUtc(LocalDateTime localDateTime)
+    {
+        super(localDateTime);
+    }
+
+    @Override
+    public final String getDisplayName()
+    {
+        return "Event Start Time UTC";
+    }
+
+    @Override
+    public byte[] getBytes()
+    {
+        // Always 8 bytes.
+        return getBytesFull();
+    }
+
+    @Override
+    public String getDisplayableValue()
+    {
+        return getDisplayableValueDateTime();
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -170,8 +170,7 @@ public class UasDatalinkFactory
             case AlternatePlatformHeading:
                 return new AlternatePlatformHeading(bytes);
             case EventStartTimeUtc:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new EventStartTimeUtc(bytes);
             case RvtLocalDataSet:
                 // TODO Implement ST 0806
                 return new OpaqueValue(bytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -151,7 +151,7 @@ public enum UasDatalinkTag
     AlternatePlatformName(70),
     /** Tag 71; Heading angle of alternate platform connected to UAS; Value is an {@link AlternatePlatformHeading} */
     AlternatePlatformHeading(71),
-    /** Tag 72; Start time of scene, project, event, mission, editing event, license, publication, etc; Value is a {@link OpaqueValue} */
+    /** Tag 72; Start time of scene, project, event, mission, editing event, license, publication, etc; Value is a {@link EventStartTimeUtc} */
     EventStartTimeUtc(72),
     /** Tag 73; MISB ST 0806 RVT Local Set metadata items; Value is a {@link OpaqueValue} */
     RvtLocalDataSet(73),

--- a/api/src/test/java/org/jmisb/api/klv/st0601/EventStartTimeUtcTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/EventStartTimeUtcTest.java
@@ -1,0 +1,98 @@
+package org.jmisb.api.klv.st0601;
+
+import org.testng.annotations.Test;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import org.jmisb.api.common.KlvParseException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class EventStartTimeUtcTest
+{
+    // Example from MISB ST doc
+    @Test
+    public void testExample()
+    {
+        byte[] bytes = new byte[]{(byte)0x00, (byte)0x02, (byte)0xD5, (byte)0xCF, (byte)0x4D, (byte)0xDC, (byte)0x9A, (byte)0x35};
+        EventStartTimeUtc timestamp = new EventStartTimeUtc(bytes);
+        checkExampleValue(timestamp);
+    }
+
+    @Test
+    public void testContructFromValue()
+    {
+        EventStartTimeUtc timestamp = new EventStartTimeUtc(798036294670901L);
+        checkExampleValue(timestamp);
+    }
+
+    @Test
+    public void testContructFromDateTime()
+    {
+        LocalDateTime ldt = LocalDateTime.of(1995, Month.APRIL, 16, 12, 44, 54, 670901000);
+        EventStartTimeUtc timestamp = new EventStartTimeUtc(ldt);
+        checkExampleValue(timestamp);
+    }
+
+    protected void checkExampleValue(EventStartTimeUtc timestamp)
+    {
+        assertEquals(timestamp.getDisplayName(), "Event Start Time UTC");
+        // April 16, 1995. 13:44:54
+        assertEquals(timestamp.getDisplayableValue(), "1995-04-16T12:44:54.670901");
+        LocalDateTime dateTime = timestamp.getDateTime();
+        assertEquals(dateTime.getYear(), 1995);
+        assertEquals(dateTime.getMonth(), Month.APRIL);
+        assertEquals(dateTime.getDayOfMonth(), 16);
+        assertEquals(dateTime.getHour(), 12);
+        assertEquals(dateTime.getMinute(), 44);
+        assertEquals(dateTime.getSecond(), 54);
+        assertEquals(dateTime.getNano(), 670901000);
+        assertEquals(timestamp.getMicroseconds(), 798036294670901L);
+        assertEquals(timestamp.getBytes(), new byte[]{(byte)0x00, (byte)0x02, (byte)0xD5, (byte)0xCF, (byte)0x4D, (byte)0xDC, (byte)0x9A, (byte)0x35});
+    }
+
+    @Test
+    public void testFactoryExample() throws KlvParseException
+    {
+        byte[] bytes = new byte[]{(byte)0x00, (byte)0x02, (byte)0xD5, (byte)0xCF, (byte)0x4D, (byte)0xDC, (byte)0x9A, (byte)0x35};
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.EventStartTimeUtc, bytes);
+        assertTrue(v instanceof EventStartTimeUtc);
+        assertEquals(v.getDisplayName(), "Event Start Time UTC");
+        EventStartTimeUtc timestamp = (EventStartTimeUtc)v;
+        checkExampleValue(timestamp);
+    }
+
+    @Test
+    public void testMinAndMax()
+    {
+        EventStartTimeUtc pts = new EventStartTimeUtc(0L);
+        assertEquals(pts.getDisplayName(), "Event Start Time UTC");
+        assertEquals(pts.getDateTime().getYear(), 1970);
+        assertEquals(pts.getDateTime().getMonth(), Month.JANUARY);
+        assertEquals(pts.getDateTime().getDayOfMonth(), 1);
+        assertEquals(pts.getDisplayableValue(), "1970-01-01T00:00:00");
+
+        // Create max value and ensure no exception is thrown
+        pts = new EventStartTimeUtc(Long.MAX_VALUE);
+        assertEquals(pts.getDisplayName(), "Event Start Time UTC");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooSmall()
+    {
+        new EventStartTimeUtc(-1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooBig()
+    {
+        // Oct 12, 2263 at 08:30
+        new EventStartTimeUtc(LocalDateTime.of(2263, 10, 12, 8, 30));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLength()
+    {
+        new EventStartTimeUtc(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09});
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Implements a tag we didn't previously support. This one occurs in a reasonable number of the test files I have.

## Description
IUasDatalinkValue implementation. It makes use of the ST0603 changes that I brought in as part of Take Off Time implementation.
Includes documentation and tests.

## How Has This Been Tested?
Unit tests, plus viewer application. Note that the ESRI samples don't set this correctly - its all 0x00 bytes. We tolerate that, and render that as the start of the epoch (1970).

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

