### PR TITLE
Allow reuse of buffers in conversion to byte arrays

### DIFF
--- a/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
+++ b/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
@@ -191,7 +191,7 @@ public class PrimitiveConverter
     public static byte[] int16ToBytes(short val)
     {
         shortBuffer.get().putShort(0, val);
-        return shortBuffer.get().array();
+        return shortBuffer.get().array().clone();
     }
 
     /**
@@ -203,7 +203,7 @@ public class PrimitiveConverter
     public static byte[] int32ToBytes(int val)
     {
         intBuffer.get().putInt(0, val);
-        return intBuffer.get().array();
+        return intBuffer.get().array().clone();
     }
 
     /**
@@ -428,7 +428,7 @@ public class PrimitiveConverter
     public static byte[] int64ToBytes(long val)
     {
         longBuffer.get().putLong(0, val);
-        return longBuffer.get().array();
+        return longBuffer.get().array().clone();
     }
 
     /**
@@ -473,7 +473,7 @@ public class PrimitiveConverter
     public static byte[] float32ToBytes(float val)
     {
         floatBuffer.get().putFloat(0, val);
-        return floatBuffer.get().array();
+        return floatBuffer.get().array().clone();
     }
 
     /**
@@ -507,6 +507,6 @@ public class PrimitiveConverter
     public static byte[] float64ToBytes(double val)
     {
         doubleBuffer.get().putDouble(0, val);
-        return doubleBuffer.get().array();
+        return doubleBuffer.get().array().clone();
     }
 }

--- a/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
@@ -99,6 +99,19 @@ public class PrimitiveConverterTest
     }
 
     @Test
+    public void testSignedInt16ToBytesReuse()
+    {
+        byte[] bytes1 = PrimitiveConverter.int16ToBytes((short)1);
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x00, (byte)0x01});
+
+        byte[] bytes2 = PrimitiveConverter.int16ToBytes((short)2);
+        Assert.assertEquals(bytes2, new byte[]{(byte)0x00, (byte)0x02});
+
+        // Verify the original array is still OK
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x00, (byte)0x01});
+    }
+
+    @Test
     public void testSignedInt32ToBytes()
     {
         int intVal = -1;
@@ -108,6 +121,19 @@ public class PrimitiveConverterTest
         intVal = 10;
         bytes = PrimitiveConverter.int32ToBytes(intVal);
         Assert.assertEquals(bytes, new byte[]{0x00, 0x00, 0x00, 0x0a});
+    }
+
+    @Test
+    public void testSignedInt32ToBytesReuse()
+    {
+        byte[] bytes1 = PrimitiveConverter.int32ToBytes(1);
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x01});
+
+        byte[] bytes2 = PrimitiveConverter.int32ToBytes(2);
+        Assert.assertEquals(bytes2, new byte[]{0x00, 0x00, 0x00, 0x02});
+
+        // Verify the original array is still OK
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x01});
     }
 
     @Test
@@ -526,6 +552,18 @@ public class PrimitiveConverterTest
         Assert.assertEquals(bytes, new byte[]{(byte)0xff});
     }
 
+    @Test
+    public void testUnsignedInt8ToBytesReuse()
+    {
+        byte[] bytes1 = PrimitiveConverter.uint8ToBytes((short)1);
+        Assert.assertEquals(bytes1, new byte[]{0x01});
+
+        byte[] bytes2 = PrimitiveConverter.uint8ToBytes((short)255);
+        Assert.assertEquals(bytes2, new byte[]{(byte)0xff});
+
+        Assert.assertEquals(bytes1, new byte[]{0x01});
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testUnsignedInt8ToBytesTooSmall()
     {
@@ -795,5 +833,76 @@ public class PrimitiveConverterTest
         intVal = Long.MAX_VALUE;
         bytes = PrimitiveConverter.int64ToVariableBytes(intVal);
         Assert.assertEquals(bytes, new byte[]{(byte)0x7F, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff});
+    }
+
+    @Test
+    public void testSignedInt64ToBytesReuse()
+    {
+        byte[] bytes1 = PrimitiveConverter.int64ToBytes(1);
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x01});
+
+        byte[] bytes2 = PrimitiveConverter.int64ToBytes(2);
+        Assert.assertEquals(bytes2, new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x02});
+
+        // Verify the original array is still OK
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x01});
+    }
+
+    @Test
+    public void testSignedInt64ToVariableBytesReuse()
+    {
+        byte[] bytes1 = PrimitiveConverter.int64ToVariableBytes(1);
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x01});
+
+        byte[] bytes2 = PrimitiveConverter.int64ToVariableBytes(2);
+        Assert.assertEquals(bytes2, new byte[]{0x02});
+
+        // Verify the original array is still OK
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x01});
+    }
+
+    @Test
+    public void testFloat32ToBytes()
+    {
+        byte[] bytes = PrimitiveConverter.float32ToBytes(2.0f);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x40, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        bytes = PrimitiveConverter.float32ToBytes(-4.0f);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xC0, (byte)0x80, (byte)0x00, (byte)0x00});
+    }
+
+    @Test
+    public void testFloat32ToBytesReuse()
+    {
+        byte[] bytes1 = PrimitiveConverter.float32ToBytes(1.0f);
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x3f, (byte)0x80, (byte)0x00, (byte)0x00});
+
+        byte[] bytes2 = PrimitiveConverter.float32ToBytes(-3.0f);
+        Assert.assertEquals(bytes2, new byte[]{(byte)0xC0, (byte)0x40, (byte)0x00, (byte)0x00});
+
+        // Verify the original array is still OK
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x3f, (byte)0x80, (byte)0x00, (byte)0x00});
+    }
+
+    @Test
+    public void testFloat64ToBytes()
+    {
+        byte[] bytes = PrimitiveConverter.float64ToBytes(2.0f);
+        Assert.assertEquals(bytes, new byte[]{(byte)0x40, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        bytes = PrimitiveConverter.float64ToBytes(-4.0f);
+        Assert.assertEquals(bytes, new byte[]{(byte)0xC0, (byte)0x10, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+    }
+
+    @Test
+    public void testFloat64ToBytesReuse()
+    {
+        byte[] bytes1 = PrimitiveConverter.float64ToBytes(2.0f);
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x40, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        byte[] bytes2 = PrimitiveConverter.float64ToBytes(-4.0f);
+        Assert.assertEquals(bytes2, new byte[]{(byte)0xC0, (byte)0x10, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
+
+        Assert.assertEquals(bytes1, new byte[]{(byte)0x40, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00});
     }
 }


### PR DESCRIPTION
## Motivation and Context
Resolved #137 - see that for the background.

## Description
Modifies existing converters to `clone()` returned (mutable) buffers.

## How Has This Been Tested?
Unit tests in `core`, plus checked it works right in my ST0806 generation tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

