### PR TITLE
Add parse options to allow logging rather than throw

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/KlvParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/KlvParser.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -21,6 +22,25 @@ public class KlvParser
     private KlvParser() {}
 
     /**
+     * Parse a byte array containing one or more {@link IMisbMessage}s.
+     * <p>
+     * This is the main interface for parsing KLV metadata. It assumes that {@code bytes} contains one or more top-level
+     * messages, i.e., byte sequences starting with a Universal Label (UL). If a particular UL is unsupported it will be
+     * returned as a {@link RawMisbMessage}.
+     *
+     * This version assumes default parse options (no flags set).
+     *
+     * @param bytes The byte array
+     * @return List of {@link IMisbMessage}s
+     *
+     * @throws KlvParseException if a parsing exception occurs
+     */
+    public static java.util.List<org.jmisb.api.klv.IMisbMessage> parseBytes(byte[] bytes) throws org.jmisb.api.common.KlvParseException
+    {
+        return parseBytes(bytes, EnumSet.noneOf(ParseOptions.class));
+    }
+
+    /**
      * Parse a byte array containing one or more {@link IMisbMessage}s
      * <p>
      * This is the main interface for parsing KLV metadata. It assumes that {@code bytes} contains one or more top-level
@@ -28,14 +48,14 @@ public class KlvParser
      * returned as a {@link RawMisbMessage}.
      *
      * @param bytes The byte array
+     * @param parserOptions any special parsing options.
      * @return List of {@link IMisbMessage}s
      *
      * @throws KlvParseException if a parsing exception occurs
      */
-    public static List<IMisbMessage> parseBytes(byte[] bytes) throws KlvParseException
-    {
+    public static List<IMisbMessage> parseBytes(byte[] bytes, EnumSet<ParseOptions> parserOptions) throws KlvParseException {
         List<IMisbMessage> messages = new ArrayList<>();
-
+        
         if (logger.isDebugEnabled())
             logger.debug("len: " + bytes.length);
 
@@ -57,20 +77,19 @@ public class KlvParser
                 {
                     if (logger.isDebugEnabled())
                         logger.debug("UAS Datalink message");
-
-                    UasDatalinkMessage message = new UasDatalinkMessage(nextMessage);
+                    UasDatalinkMessage message = new UasDatalinkMessage(nextMessage, parserOptions);
                     messages.add(message);
                 } else if (ul.equals(KlvConstants.SecurityMetadataUniversalSetUl))
                 {
                     if (logger.isDebugEnabled())
                         logger.debug("Security Metadata Universal Set message");
-                    SecurityMetadataUniversalSet message = new SecurityMetadataUniversalSet(nextMessage);
+                    SecurityMetadataUniversalSet message = new SecurityMetadataUniversalSet(nextMessage, parserOptions);
                     messages.add(message);
                 } else if (ul.equals(KlvConstants.SecurityMetadataLocalSetUl))
                 {
                     if (logger.isDebugEnabled())
                         logger.debug("Security Metadata Local Set message");
-                    SecurityMetadataLocalSet message = new SecurityMetadataLocalSet(nextMessage, true);
+                    SecurityMetadataLocalSet message = new SecurityMetadataLocalSet(nextMessage, true, parserOptions);
                     messages.add(message);
                 } else
                 {

--- a/api/src/main/java/org/jmisb/api/klv/LdsParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/LdsParser.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 
 /**
@@ -18,17 +19,17 @@ public class LdsParser
     private LdsParser() {}
 
     /**
-     * Parse {@link LdsField}s from a byte array
+     * Parse {@link LdsField}s from a byte array.
      *
      * @param bytes Byte array to parse
      * @param start Index of the first byte to parse
      * @param length Number of bytes to parse
+     * @param parseOptions any special parsing options
      * @return List of parsed fields
      *
      * @throws KlvParseException If a parsing error occurs
      */
-    public static List<LdsField> parseFields(byte[] bytes, int start, int length) throws KlvParseException
-    {
+    public static List<LdsField> parseFields(byte[] bytes, int start, int length, EnumSet<ParseOptions> parseOptions) throws KlvParseException {
         StringBuilder debugMessageStringBuilder = new StringBuilder();
         if (logger.isDebugEnabled())
         {
@@ -54,8 +55,15 @@ public class LdsParser
             int end = begin + lengthField.getValue();
             if (end > bytes.length)
             {
-                // TODO: we will probably need a non-strict option to return the fields that were actually parsed
-                throw new KlvParseException("Overrun encountered while parsing LDS fields");
+                if (parseOptions.contains(ParseOptions.LOG_ON_OVERRUN))
+                {
+                    logger.warn("Overrun encountered while parsing LDS fields");
+                    break;
+                }
+                else
+                {
+                    throw new KlvParseException("Overrun encountered while parsing LDS fields");
+                }
             }
 
             byte[] value = Arrays.copyOfRange(bytes, begin, end);

--- a/api/src/main/java/org/jmisb/api/klv/ParseOptions.java
+++ b/api/src/main/java/org/jmisb/api/klv/ParseOptions.java
@@ -1,0 +1,42 @@
+package org.jmisb.api.klv;
+
+/**
+ * Flag options for parsing.
+ */
+public enum ParseOptions
+{
+    /**
+     * Whether to only log in the event of buffer overrun.
+     * 
+     * Not setting this flag means to throw in the event of buffer overrun.
+     */
+    LOG_ON_OVERRUN,
+    
+    /**
+     * Whether to only log if the checksum is present but incorrect.
+     * 
+     * Not setting this flag means to throw in the event of invalid checksum.
+     */
+    LOG_ON_CHECKSUM_FAIL,
+    
+    /**
+     * Whether to only log if the checksum is required but missing.
+     * 
+     * Not setting this flag means to throw if the checksum is required for
+     * whatever if being parsed.
+     * 
+     * This flag has no effect if the checksum is optional.
+     */
+    LOG_ON_CHECKSUM_MISSING,
+    
+    /**
+     * Whether to only log if an invalid field encoding is encountered.
+     * 
+     * This could be a field that has the wrong length, or has values that are
+     * out of range.
+     * 
+     * Not setting this means to throw in the event of invalid field, which will
+     * probably result in the whole message being ignored.
+     */
+    LOG_ON_INVALID_FIELD_ENCODING
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/NestedSecurityMetadata.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/NestedSecurityMetadata.java
@@ -1,6 +1,8 @@
 package org.jmisb.api.klv.st0601;
 
+import java.util.EnumSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0102.localset.SecurityMetadataLocalSet;
 
 /**
@@ -30,11 +32,12 @@ public class NestedSecurityMetadata implements IUasDatalinkValue
     /**
      * Create from encoded bytes
      * @param bytes Encoded bytes representing a nested ST 0102 local set
+     * @param parseOptions any special parse options
      * @throws KlvParseException if a parsing error occurs
      */
-    public NestedSecurityMetadata(byte[] bytes) throws KlvParseException
+    public NestedSecurityMetadata(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
-        this.localSet = new SecurityMetadataLocalSet(bytes, false);
+        this.localSet = new SecurityMetadataLocalSet(bytes, false, parseOptions);
     }
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/NestedVmtiLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/NestedVmtiLocalSet.java
@@ -1,6 +1,8 @@
 package org.jmisb.api.klv.st0601;
 
+import java.util.EnumSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.VmtiLocalSet;
 
 /**
@@ -39,11 +41,12 @@ public class NestedVmtiLocalSet implements IUasDatalinkValue
      * Create from encoded bytes.
      *
      * @param bytes The byte array
+     * @param parseOptions any special parsing options
      * @throws KlvParseException if the input is invalid
      */
-    public NestedVmtiLocalSet(byte[] bytes) throws KlvParseException
+    public NestedVmtiLocalSet(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
-        this.vmtiLocalSet = new VmtiLocalSet(bytes);
+        this.vmtiLocalSet = new VmtiLocalSet(bytes, parseOptions);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -1,6 +1,8 @@
 package org.jmisb.api.klv.st0601;
 
+import java.util.EnumSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 
 /**
  * Dynamically create {@link IUasDatalinkValue}s from {@link UasDatalinkTag}s.
@@ -19,8 +21,23 @@ public class UasDatalinkFactory
      * @throws IllegalArgumentException if input is invalid
      * @throws KlvParseException if a parsing error occurs
      */
-    public static IUasDatalinkValue createValue(UasDatalinkTag tag, byte[] bytes) throws KlvParseException
+    public static org.jmisb.api.klv.st0601.IUasDatalinkValue createValue(UasDatalinkTag tag, byte[] bytes) throws org.jmisb.api.common.KlvParseException
     {
+        return createValue(tag, bytes, EnumSet.noneOf(ParseOptions.class));
+    }
+
+    /**
+     * Create a {@link IUasDatalinkValue} instance from encoded bytes
+     *
+     * @param tag The tag defining the value type
+     * @param bytes Encoded bytes
+     * @param parseOptions any special parsing options
+     * @return The new instance
+     *
+     * @throws IllegalArgumentException if input is invalid
+     * @throws KlvParseException if a parsing error occurs
+     */
+    public static IUasDatalinkValue createValue(UasDatalinkTag tag, byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException {
         // Keep the case statements in enum ordinal order so we can keep track of what is implemented. Mark all
         // unimplemented tags with TODO.
         switch (tag)
@@ -121,7 +138,7 @@ public class UasDatalinkFactory
                 // TODO
                 return new OpaqueValue(bytes);
             case SecurityLocalMetadataSet:
-                return new NestedSecurityMetadata(bytes);
+                return new NestedSecurityMetadata(bytes, parseOptions);
             case DifferentialPressure:
                 return new DifferentialPressure(bytes);
             case PlatformAngleOfAttack:
@@ -176,7 +193,7 @@ public class UasDatalinkFactory
                 // TODO Implement ST 0806
                 return new OpaqueValue(bytes);
             case VmtiLocalDataSet:
-                return new NestedVmtiLocalSet(bytes);
+                return new NestedVmtiLocalSet(bytes, parseOptions);
             case SensorEllipsoidHeight:
                 return new SensorEllipsoidHeight(bytes);
             case AlternatePlatformEllipsoidHeight:

--- a/api/src/main/java/org/jmisb/api/klv/st0903/AlgorithmSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/AlgorithmSeries.java
@@ -2,11 +2,13 @@ package org.jmisb.api.klv.st0903;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.algorithm.AlgorithmLS;
 import org.jmisb.core.klv.ArrayUtils;
 
@@ -58,7 +60,7 @@ public class AlgorithmSeries implements IVmtiMetadataValue
             BerField lengthField = BerDecoder.decode(bytes, index, true);
             index += lengthField.getLength();
             byte[] localSetBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            AlgorithmLS algorithmLS = new AlgorithmLS(localSetBytes);
+            AlgorithmLS algorithmLS = new AlgorithmLS(localSetBytes, EnumSet.noneOf(ParseOptions.class));
             localSets.add(algorithmLS);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/OntologySeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/OntologySeries.java
@@ -2,11 +2,13 @@ package org.jmisb.api.klv.st0903;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.ontology.OntologyLS;
 import org.jmisb.core.klv.ArrayUtils;
 
@@ -49,9 +51,10 @@ public class OntologySeries implements IVmtiMetadataValue
      * Create from encoded bytes.
      *
      * @param bytes Encoded byte array
+     * @param parseOptions the parsing options to use in the event of error
      * @throws KlvParseException if there is a parsing error on the byte array.
      */
-    public OntologySeries(byte[] bytes) throws KlvParseException
+    public OntologySeries(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
         int index = 0;
         while (index < bytes.length - 1)
@@ -59,7 +62,7 @@ public class OntologySeries implements IVmtiMetadataValue
             BerField lengthField = BerDecoder.decode(bytes, index, true);
             index += lengthField.getLength();
             byte[] localSetBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            OntologyLS vobjectLS = new OntologyLS(localSetBytes);
+            OntologyLS vobjectLS = new OntologyLS(localSetBytes, parseOptions);
             localSets.add(vobjectLS);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLS.java
@@ -1,6 +1,7 @@
 package org.jmisb.api.klv.st0903.algorithm;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -10,6 +11,7 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.AlgorithmId;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
@@ -42,10 +44,10 @@ public class AlgorithmLS {
     }
 
     // TODO consider refactoring to pass in the original array instead of a copy
-    public AlgorithmLS(byte[] bytes) throws KlvParseException
+    public AlgorithmLS(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
         int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset, parseOptions);
         for (LdsField field : fields)
         {
             AlgorithmMetadataKey key = AlgorithmMetadataKey.getKey(field.getTag());
@@ -55,8 +57,22 @@ public class AlgorithmLS {
             }
             else
             {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try 
+                {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                }
+                catch (KlvParseException | IllegalArgumentException ex)
+                {
+                    if (parseOptions.contains(ParseOptions.LOG_ON_INVALID_FIELD_ENCODING))
+                    {
+                        LOGGER.warn(ex.getMessage());
+                    }
+                    else
+                    {
+                        throw ex;
+                    }
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/ontology/OntologyLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/ontology/OntologyLS.java
@@ -1,6 +1,7 @@
 package org.jmisb.api.klv.st0903.ontology;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -10,6 +11,7 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.shared.VmtiUri;
@@ -49,10 +51,10 @@ public class OntologyLS {
     }
 
     // TODO consider refactoring to pass in the original array instead of a copy
-    public OntologyLS(byte[] bytes) throws KlvParseException
+    public OntologyLS(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
         int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset, parseOptions);
         for (LdsField field : fields)
         {
             OntologyMetadataKey key = OntologyMetadataKey.getKey(field.getTag());
@@ -62,8 +64,22 @@ public class OntologyLS {
             }
             else
             {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try
+                {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                }
+                catch (KlvParseException | IllegalArgumentException ex)
+                {
+                    if (parseOptions.contains(ParseOptions.LOG_ON_INVALID_FIELD_ENCODING))
+                    {
+                        LOGGER.warn(ex.getMessage());
+                    }
+                    else
+                    {
+                        throw ex;
+                    }
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vchip/VChipLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vchip/VChipLS.java
@@ -1,6 +1,7 @@
 package org.jmisb.api.klv.st0903.vchip;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -10,6 +11,7 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.shared.VmtiUri;
@@ -40,17 +42,30 @@ public class VChipLS
     }
 
     // TODO consider refactoring to pass in the original array instead of a copy
-    public VChipLS(byte[] bytes) throws KlvParseException
-    {
+    public VChipLS(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException {
         int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset, parseOptions);
         for (LdsField field : fields) {
             VChipMetadataKey key = VChipMetadataKey.getKey(field.getTag());
             if (key == VChipMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI VChip Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try
+                {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                }
+                catch (KlvParseException | IllegalArgumentException ex)
+                {
+                    if (parseOptions.contains(ParseOptions.LOG_ON_INVALID_FIELD_ENCODING))
+                    {
+                        LOGGER.warn(ex.getMessage());
+                    }
+                    else
+                    {
+                        throw ex;
+                    }
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vmask/VMaskLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vmask/VMaskLS.java
@@ -1,6 +1,7 @@
 package org.jmisb.api.klv.st0903.vmask;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -10,6 +11,7 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.core.klv.ArrayUtils;
 import org.slf4j.Logger;
@@ -38,17 +40,31 @@ public class VMaskLS
     }
 
     // TODO consider refactoring to pass in the original array instead of a copy
-    public VMaskLS(byte[] bytes) throws KlvParseException
+    public VMaskLS(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
         int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset, parseOptions);
         for (LdsField field : fields) {
             VMaskMetadataKey key = VMaskMetadataKey.getKey(field.getTag());
             if (key == VMaskMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI VMask Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try
+                {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                }
+                catch (KlvParseException | IllegalArgumentException ex)
+                {
+                    if (parseOptions.contains(ParseOptions.LOG_ON_INVALID_FIELD_ENCODING))
+                    {
+                        LOGGER.warn(ex.getMessage());
+                    }
+                    else
+                    {
+                        throw ex;
+                    }
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vobject/VObjectLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vobject/VObjectLS.java
@@ -1,6 +1,7 @@
 package org.jmisb.api.klv.st0903.vobject;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -10,6 +11,7 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.shared.VmtiUri;
@@ -40,10 +42,10 @@ public class VObjectLS
     }
 
     // TODO consider refactoring to pass in the original array instead of a copy
-    public VObjectLS(byte[] bytes) throws KlvParseException
+    public VObjectLS(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
         int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset, parseOptions);
         for (LdsField field : fields) {
             VObjectMetadataKey key = VObjectMetadataKey.getKey(field.getTag());
             if (key == VObjectMetadataKey.Undefined) {

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VChip.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VChip.java
@@ -1,6 +1,8 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import java.util.EnumSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vchip.VChipLS;
 
@@ -36,11 +38,12 @@ public class VChip implements IVmtiMetadataValue
      * Create from encoded bytes.
      *
      * @param bytes Encoded byte array comprising the VChip LS
+     * @param parseOptions any special parse options
      * @throws KlvParseException if the byte array could not be parsed.
      */
-    public VChip(byte[] bytes) throws KlvParseException
+    public VChip(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
-        value = new VChipLS(bytes);
+        value = new VChipLS(bytes, parseOptions);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VChipSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VChipSeries.java
@@ -2,11 +2,13 @@ package org.jmisb.api.klv.st0903.vtarget;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vchip.VChipLS;
 import org.jmisb.core.klv.ArrayUtils;
@@ -43,9 +45,10 @@ public class VChipSeries implements IVmtiMetadataValue
      * Create from encoded bytes.
      *
      * @param bytes Encoded byte array comprising the VChipSeries
+     * @param parseOptions the parsing options to use in the event of error
      * @throws KlvParseException if the byte array could not be parsed.
      */
-    public VChipSeries(byte[] bytes) throws KlvParseException
+    public VChipSeries(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
         int index = 0;
         while (index < bytes.length - 1)
@@ -53,7 +56,7 @@ public class VChipSeries implements IVmtiMetadataValue
             BerField lengthField = BerDecoder.decode(bytes, index, true);
             index += lengthField.getLength();
             byte[] vChipBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            VChipLS chip = new VChipLS(vChipBytes);
+            VChipLS chip = new VChipLS(vChipBytes, parseOptions);
             chips.add(chip);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VFeature.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VFeature.java
@@ -1,6 +1,8 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import java.util.EnumSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vfeature.VFeatureLS;
 
@@ -52,11 +54,12 @@ public class VFeature implements IVmtiMetadataValue
      * Create from encoded bytes.
      *
      * @param bytes Encoded byte array comprising the VFeature LS
+     * @param parseOptions any special parse options
      * @throws KlvParseException if the byte array could not be parsed.
      */
-    public VFeature(byte[] bytes) throws KlvParseException
+    public VFeature(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
-        value = new VFeatureLS(bytes);
+        value = new VFeatureLS(bytes, parseOptions);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VMask.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VMask.java
@@ -1,6 +1,8 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import java.util.EnumSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vmask.VMaskLS;
 
@@ -36,11 +38,12 @@ public class VMask implements IVmtiMetadataValue
      * Create from encoded bytes.
      *
      * @param bytes Encoded byte array comprising the VMask LS
+     * @param parseOptions any special parse options
      * @throws KlvParseException if the byte array could not be parsed.
      */
-    public VMask(byte[] bytes) throws KlvParseException
+    public VMask(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
-        value = new VMaskLS(bytes);
+        value = new VMaskLS(bytes, parseOptions);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VObject.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VObject.java
@@ -1,6 +1,8 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import java.util.EnumSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vobject.VObjectLS;
 
@@ -34,11 +36,12 @@ public class VObject implements IVmtiMetadataValue
      * Create from encoded bytes.
      *
      * @param bytes Encoded byte array comprising the VObject LS
+     * @param parseOptions any special parse options
      * @throws KlvParseException if the byte array could not be parsed.
      */
-    public VObject(byte[] bytes) throws KlvParseException
+    public VObject(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
-        value = new VObjectLS(bytes);
+        value = new VObjectLS(bytes, parseOptions);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VObjectSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VObjectSeries.java
@@ -2,11 +2,13 @@ package org.jmisb.api.klv.st0903.vtarget;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vobject.VObjectLS;
 import org.jmisb.core.klv.ArrayUtils;
@@ -40,9 +42,10 @@ public class VObjectSeries implements IVmtiMetadataValue
      * Create from encoded bytes.
      *
      * @param bytes Encoded byte array comprising the VObjectSeries
+     * @param parseOptions any special parse options
      * @throws KlvParseException if the byte array could not be parsed.
      */
-    public VObjectSeries(byte[] bytes) throws KlvParseException
+    public VObjectSeries(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
         int index = 0;
         while (index < bytes.length - 1)
@@ -50,7 +53,7 @@ public class VObjectSeries implements IVmtiMetadataValue
             BerField lengthField = BerDecoder.decode(bytes, index, true);
             index += lengthField.getLength();
             byte[] vObjectBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            VObjectLS objectLocalSet = new VObjectLS(vObjectBytes);
+            VObjectLS objectLocalSet = new VObjectLS(vObjectBytes, parseOptions);
             vobjects.add(objectLocalSet);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VTracker.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VTracker.java
@@ -1,6 +1,8 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import java.util.EnumSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vtracker.VTrackerLS;
 
@@ -34,11 +36,12 @@ public class VTracker implements IVmtiMetadataValue
      * Create from encoded bytes.
      *
      * @param bytes Encoded byte array comprising the VTracker LS
+     * @param parseOptions any special parse options.
      * @throws KlvParseException if the byte array could not be parsed.
      */
-    public VTracker(byte[] bytes) throws KlvParseException
+    public VTracker(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
-        value = new VTrackerLS(bytes);
+        value = new VTrackerLS(bytes, parseOptions);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLS.java
@@ -1,6 +1,7 @@
 package org.jmisb.api.klv.st0903.vtracker;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -10,6 +11,7 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.AlgorithmId;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
@@ -40,17 +42,31 @@ public class VTrackerLS {
     }
 
     // TODO consider refactoring to pass in the original array instead of a copy
-    public VTrackerLS(byte[] bytes) throws KlvParseException
+    public VTrackerLS(byte[] bytes, EnumSet<ParseOptions> parseOptions) throws KlvParseException
     {
         int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset, parseOptions);
         for (LdsField field : fields) {
             VTrackerMetadataKey key = VTrackerMetadataKey.getKey(field.getTag());
             if (key == VTrackerMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI VTracker Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try
+                {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                }
+                catch (KlvParseException | IllegalArgumentException ex)
+                {
+                    if (parseOptions.contains(ParseOptions.LOG_ON_INVALID_FIELD_ENCODING))
+                    {
+                        LOGGER.warn(ex.getMessage());
+                    }
+                    else
+                    {
+                        throw ex;
+                    }
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/video/MetadataDecodeThread.java
+++ b/api/src/main/java/org/jmisb/api/video/MetadataDecodeThread.java
@@ -1,5 +1,6 @@
 package org.jmisb.api.video;
 
+import java.util.EnumSet;
 import org.bytedeco.ffmpeg.avcodec.AVCodecContext;
 import org.bytedeco.ffmpeg.avcodec.AVPacket;
 import org.bytedeco.ffmpeg.avformat.AVStream;
@@ -21,6 +22,7 @@ import static org.bytedeco.ffmpeg.global.avcodec.avcodec_alloc_context3;
 import static org.bytedeco.ffmpeg.global.avcodec.avcodec_free_context;
 import static org.bytedeco.ffmpeg.global.avcodec.avcodec_parameters_to_context;
 import static org.bytedeco.ffmpeg.global.avutil.av_q2d;
+import org.jmisb.api.klv.ParseOptions;
 
 /**
  * Metadata decoding thread
@@ -34,6 +36,7 @@ class MetadataDecodeThread extends ProcessingThread
     private final VideoInput inputStream;
     private final AVStream dataStream;
     private BlockingQueue<AVPacket> packetQueue = new LinkedBlockingDeque<>(INPUT_QUEUE_SIZE);
+    private EnumSet<ParseOptions> parseOptions = EnumSet.of(ParseOptions.LOG_ON_INVALID_FIELD_ENCODING);
 
     /**
      * Constructor
@@ -108,7 +111,7 @@ class MetadataDecodeThread extends ProcessingThread
 
                     try
                     {
-                        List<IMisbMessage> messages = KlvParser.parseBytes(data);
+                        List<IMisbMessage> messages = KlvParser.parseBytes(data, parseOptions);
                         for (IMisbMessage message : messages)
                         {
                             boolean queued = false;
@@ -140,4 +143,25 @@ class MetadataDecodeThread extends ProcessingThread
 
         avcodec_free_context(codecContext);
     }
+
+    /**
+     * Get the currently set parsing options.
+     *
+     * @return parsing options as an EnumSet.
+     */
+    public EnumSet<ParseOptions> getParseOptions()
+    {
+        return parseOptions;
+    }
+
+    /**
+     * Set the parsing options.
+     *
+     * @param options the parsing options.
+     */
+    public void setParseOptions(EnumSet<ParseOptions> options)
+    {
+        parseOptions = options;
+    }
+    
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetTest.java
@@ -8,10 +8,12 @@ import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.core.klv.ArrayUtils;
 
 public class SecurityMetadataLocalSetTest extends LoggerChecks
@@ -153,7 +155,7 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks
     @Test
     public void testParseConstructorMultipleFields() throws KlvParseException {
         byte[] bytes = new byte[]{1, 1, 1, 2, 1, 1, 3, 4, 47, 47, 67, 65, 4, 0, 5, 0, 6, 2, 67, 65, 21, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 22, 2, 0, 5};
-        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false);
+        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false, EnumSet.noneOf(ParseOptions.class));
         Assert.assertEquals(securityMetadataLocalSet.displayHeader(), "ST 0102 (local)");
         Assert.assertNotNull(securityMetadataLocalSet.getField(SecurityMetadataKey.ItemDesignatorId));
     }
@@ -161,7 +163,7 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks
     @Test
     public void testParseConstructor1() throws KlvParseException {
         byte[] bytes = new byte[]{1, 1, 1};
-        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false);
+        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false, EnumSet.noneOf(ParseOptions.class));
         Assert.assertEquals(securityMetadataLocalSet.displayHeader(), "ST 0102 (local)");
         Assert.assertNotNull(securityMetadataLocalSet.getField(SecurityMetadataKey.SecurityClassification));
         ISecurityMetadataValue val = securityMetadataLocalSet.getField(SecurityMetadataKey.SecurityClassification);
@@ -173,7 +175,7 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks
     @Test
     public void testParseConstructor21() throws KlvParseException {
         byte[] bytes = new byte[]{21, 16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
-        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false);
+        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false, EnumSet.noneOf(ParseOptions.class));
         Assert.assertEquals(securityMetadataLocalSet.displayHeader(), "ST 0102 (local)");
         Assert.assertNotNull(securityMetadataLocalSet.getField(SecurityMetadataKey.ItemDesignatorId));
         ISecurityMetadataValue val = securityMetadataLocalSet.getField(SecurityMetadataKey.ItemDesignatorId);
@@ -187,7 +189,7 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks
     {
         byte[] bytes = new byte[]{88, 1, 1};
         verifyNoLoggerMessages();
-        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false);
+        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false, EnumSet.noneOf(ParseOptions.class));
         verifySingleLoggerMessage("Unknown Security Metadata tag: 88");
         Assert.assertEquals(securityMetadataLocalSet.displayHeader(), "ST 0102 (local)");
         Assert.assertEquals(0, securityMetadataLocalSet.getKeys().size());
@@ -198,7 +200,7 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks
     {
         byte[] bytes = new byte[]{1, 1, 1, 2, 1, 1, 88, 1, 1, 3, 4, 47, 47, 67, 65, 4, 0, 5, 0, 6, 2, 67, 65, 22, 2, 0, 5};
         verifyNoLoggerMessages();
-        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false);
+        SecurityMetadataLocalSet securityMetadataLocalSet = new SecurityMetadataLocalSet(bytes, false, EnumSet.noneOf(ParseOptions.class));
         verifySingleLoggerMessage("Unknown Security Metadata tag: 88");
         Assert.assertEquals(securityMetadataLocalSet.displayHeader(), "ST 0102 (local)");
         Assert.assertEquals(7, securityMetadataLocalSet.getKeys().size());

--- a/api/src/test/java/org/jmisb/api/klv/st0601/NestedSecurityMetadataTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/NestedSecurityMetadataTest.java
@@ -1,8 +1,10 @@
 package org.jmisb.api.klv.st0601;
 
+import java.util.EnumSet;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0102.ISecurityMetadataValue;
 import org.jmisb.api.klv.st0102.SecurityMetadataKey;
 import org.jmisb.api.klv.st0102.SecurityMetadataString;
@@ -24,7 +26,7 @@ public class NestedSecurityMetadataTest
     @Test
     public void testConstructFromBytes() throws KlvParseException
     {
-        NestedSecurityMetadata nestedSecurityMetadata = new NestedSecurityMetadata(localSetAsBytes);
+        NestedSecurityMetadata nestedSecurityMetadata = new NestedSecurityMetadata(localSetAsBytes, EnumSet.noneOf(ParseOptions.class));
         checkResults(nestedSecurityMetadata);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st0601/NestedVmtiLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/NestedVmtiLocalSetTest.java
@@ -1,8 +1,10 @@
 package org.jmisb.api.klv.st0601;
 
+import java.util.EnumSet;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.VmtiLocalSet;
 import org.jmisb.api.klv.st0903.VmtiMetadataKey;
@@ -27,7 +29,7 @@ public class NestedVmtiLocalSetTest
     @Test
     public void testConstructFromBytes() throws KlvParseException
     {
-        NestedVmtiLocalSet localSetFromBytes = new NestedVmtiLocalSet(localSetAsByteArray);
+        NestedVmtiLocalSet localSetFromBytes = new NestedVmtiLocalSet(localSetAsByteArray, EnumSet.noneOf(ParseOptions.class));
         Assert.assertNotNull(localSetFromBytes);
         checkLocalSetValues(localSetFromBytes);
     }

--- a/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkMessageTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkMessageTest.java
@@ -9,6 +9,7 @@ import java.util.*;
 
 import static org.jmisb.api.klv.KlvConstants.UasDatalinkLocalUl;
 import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.ParseOptions;
 
 public class UasDatalinkMessageTest extends LoggerChecks
 {
@@ -110,7 +111,7 @@ public class UasDatalinkMessageTest extends LoggerChecks
         // ... and re-parse it
         try
         {
-            UasDatalinkMessage msg = new UasDatalinkMessage(bytes);
+            UasDatalinkMessage msg = new UasDatalinkMessage(bytes, EnumSet.noneOf(ParseOptions.class));
 
             // Verify the messages are the same
             SensorLatitude sensorLatitude = (SensorLatitude) msg.getField(UasDatalinkTag.SensorLatitude);
@@ -142,7 +143,7 @@ public class UasDatalinkMessageTest extends LoggerChecks
         // Parse
         try
         {
-            new UasDatalinkMessage(bytes);
+            new UasDatalinkMessage(bytes, EnumSet.noneOf(ParseOptions.class));
             Assert.fail("Parsing should have failed due to bad checksum");
         } catch (KlvParseException e)
         {
@@ -155,7 +156,7 @@ public class UasDatalinkMessageTest extends LoggerChecks
         missingChecksum[16] -= 4;
         try
         {
-            new UasDatalinkMessage(missingChecksum);
+            new UasDatalinkMessage(missingChecksum, EnumSet.noneOf(ParseOptions.class));
             Assert.fail("Parsing should have failed due to missing checksum");
         } catch (KlvParseException e)
         {

--- a/api/src/test/java/org/jmisb/api/klv/st0903/OntologySeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/OntologySeriesTest.java
@@ -1,10 +1,12 @@
 package org.jmisb.api.klv.st0903;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.ontology.OntologyLS;
 import org.jmisb.api.klv.st0903.ontology.OntologyMetadataKey;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
@@ -44,7 +46,7 @@ public class OntologySeriesTest
     @BeforeMethod
     public void setUpMethod() throws Exception
     {
-        ontologySeriesFromBytes = new OntologySeries(twoOntologysBytes);
+        ontologySeriesFromBytes = new OntologySeries(twoOntologysBytes, EnumSet.noneOf(ParseOptions.class));
 
         List<OntologyLS> ontologies = new ArrayList<>();
 

--- a/api/src/test/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLSTest.java
@@ -1,11 +1,13 @@
 package org.jmisb.api.klv.st0903.algorithm;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.AlgorithmId;
 import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import static org.testng.Assert.*;
 import org.testng.annotations.Test;
@@ -24,7 +26,7 @@ public class AlgorithmLSTest extends LoggerChecks
     public void parseTag1() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x01, 0x03, 0x01, 0x03, (byte)0x98};
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 1);
         checkIdExample(algorithmLS);
@@ -34,7 +36,7 @@ public class AlgorithmLSTest extends LoggerChecks
     public void parseTag2() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x02, 0x14, 0x6B, 0x36, 0x5F, 0x79, 0x6F, 0x6C, 0x6F, 0x5F, 0x39, 0x30, 0x30, 0x30, 0x5F, 0x74, 0x72, 0x61, 0x63, 0x6B, 0x65, 0x72};
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 1);
         checkNameExample(algorithmLS);
@@ -44,7 +46,7 @@ public class AlgorithmLSTest extends LoggerChecks
     public void parseTag3() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x03, 0x04, 0x32, 0x2E, 0x36, 0x61};
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 1);
         checkVersionExample(algorithmLS);
@@ -54,7 +56,7 @@ public class AlgorithmLSTest extends LoggerChecks
     public void parseTag4() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x04, 0x07, 0x6B, 0x61, 0x6C, 0x6D, 0x61, 0x6E, 0x6E};
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 1);
         checkClassExample(algorithmLS);
@@ -64,7 +66,7 @@ public class AlgorithmLSTest extends LoggerChecks
     public void parseTag5() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x05, 0x01, 0x0A};
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 1);
         checkNumFramesExample(algorithmLS);
@@ -81,7 +83,7 @@ public class AlgorithmLSTest extends LoggerChecks
             0x04, 0x07, 0x6B, 0x61, 0x6C, 0x6D, 0x61, 0x6E, 0x6E,
             0x05, 0x01, 0x0A};
         verifyNoLoggerMessages();
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, EnumSet.noneOf(ParseOptions.class));
         this.verifySingleLoggerMessage("Unknown VMTI Algorithm Metadata tag: 6");
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 5);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/ontology/OntologyLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/ontology/OntologyLSTest.java
@@ -2,11 +2,13 @@ package org.jmisb.api.klv.st0903.ontology;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.shared.VmtiUri;
 import static org.testng.Assert.*;
@@ -28,7 +30,7 @@ public class OntologyLSTest extends LoggerChecks
         final byte[] bytes = new byte[] {
             0x01, 0x02, 0x01, 0x02
         };
-        OntologyLS ontologyLS = new OntologyLS(bytes);
+        OntologyLS ontologyLS = new OntologyLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(ontologyLS);
         assertEquals(ontologyLS.getTags().size(), 1);
         checkIdExample(ontologyLS);
@@ -40,7 +42,7 @@ public class OntologyLSTest extends LoggerChecks
         final byte[] bytes = new byte[] {
             0x02, 0x01, 0x0a
         };
-        OntologyLS ontologyLS = new OntologyLS(bytes);
+        OntologyLS ontologyLS = new OntologyLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(ontologyLS);
         assertEquals(ontologyLS.getTags().size(), 1);
         checkParentIdExample(ontologyLS);
@@ -61,7 +63,7 @@ public class OntologyLSTest extends LoggerChecks
             0x61, 0x73, 0x74, 0x65, 0x72, 0x2F, 0x70, 0x69,
             0x7A, 0x7A, 0x61, 0x2E, 0x6F, 0x77, 0x6C
         };
-        OntologyLS ontologyLS = new OntologyLS(bytes);
+        OntologyLS ontologyLS = new OntologyLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(ontologyLS);
         assertEquals(ontologyLS.getTags().size(), 1);
         checkOntologyExample(ontologyLS);
@@ -71,7 +73,7 @@ public class OntologyLSTest extends LoggerChecks
     public void parseTag4() throws KlvParseException, URISyntaxException
     {
         final byte[] bytes = new byte[]{0x04, 0x08, 0x4D, 0x75, 0x73, 0x68, 0x72, 0x6F, 0x6F, 0x6D};
-        OntologyLS ontologyLS = new OntologyLS(bytes);
+        OntologyLS ontologyLS = new OntologyLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(ontologyLS);
         assertEquals(ontologyLS.getTags().size(), 1);
         checkOntologyClassExample(ontologyLS);
@@ -95,7 +97,7 @@ public class OntologyLSTest extends LoggerChecks
             0x04, 0x08,
             0x4D, 0x75, 0x73, 0x68, 0x72, 0x6F, 0x6F, 0x6D};
         verifyNoLoggerMessages();
-        OntologyLS ontologyLS = new OntologyLS(bytes);
+        OntologyLS ontologyLS = new OntologyLS(bytes, EnumSet.noneOf(ParseOptions.class));
         this.verifySingleLoggerMessage("Unknown VMTI Ontology Metadata tag: 5");
         assertNotNull(ontologyLS);
         assertEquals(ontologyLS.getTags().size(), 2);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vchip/VChipLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vchip/VChipLSTest.java
@@ -1,11 +1,13 @@
 package org.jmisb.api.klv.st0903.vchip;
 
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.shared.VmtiUri;
 import static org.testng.Assert.*;
@@ -25,7 +27,7 @@ public class VChipLSTest extends LoggerChecks
     public void parseTag1() throws KlvParseException
     {
         byte[] bytes = new byte[]{0x01, 0x04, 0x6A, 0x70, 0x65, 0x67};
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 1);
         checkImageTypeExample(vChipLS);
@@ -35,7 +37,7 @@ public class VChipLSTest extends LoggerChecks
     public void parseTag2() throws KlvParseException, URISyntaxException
     {
         final byte[] bytes = new byte[]{0x02, 46, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3A, 0x2F, 0x2F, 0x77, 0x77, 0x77, 0x2E, 0x67, 0x77, 0x67, 0x2E, 0x6E, 0x67, 0x61, 0x2E, 0x6D, 0x69, 0x6C, 0x2F, 0x6D, 0x69, 0x73, 0x62, 0x2F, 0x69, 0x6D, 0x61, 0x67, 0x65, 0x73, 0x2F, 0x62, 0x61, 0x6E, 0x6E, 0x65, 0x72, 0x2E, 0x6A, 0x70, 0x67};
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 1);
         checkImageUriExample(vChipLS);
@@ -56,7 +58,7 @@ public class VChipLSTest extends LoggerChecks
             (byte) 0x3F, (byte) 0x00, (byte) 0x05, (byte) 0x1A, (byte) 0x02, (byte) 0xB1, (byte) 0x49, (byte) 0xC5,
             (byte) 0x4C, (byte) 0x37, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x49, (byte) 0x45,
             (byte) 0x4E, (byte) 0x44, (byte) 0xAE, (byte) 0x42, (byte) 0x60, (byte) 0x82};
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 1);
         checkEmbeddedImageExample(vChipLS);
@@ -66,7 +68,7 @@ public class VChipLSTest extends LoggerChecks
     public void parseTag1andTag2() throws KlvParseException, URISyntaxException
     {
         final byte[] bytes = new byte[]{0x01, 0x04, 0x6A, 0x70, 0x65, 0x67, 0x02, 46, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3A, 0x2F, 0x2F, 0x77, 0x77, 0x77, 0x2E, 0x67, 0x77, 0x67, 0x2E, 0x6E, 0x67, 0x61, 0x2E, 0x6D, 0x69, 0x6C, 0x2F, 0x6D, 0x69, 0x73, 0x62, 0x2F, 0x69, 0x6D, 0x61, 0x67, 0x65, 0x73, 0x2F, 0x62, 0x61, 0x6E, 0x6E, 0x65, 0x72, 0x2E, 0x6A, 0x70, 0x67};
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 2);
         checkImageTypeExample(vChipLS);
@@ -89,7 +91,7 @@ public class VChipLSTest extends LoggerChecks
             (byte) 0x3F, (byte) 0x00, (byte) 0x05, (byte) 0x1A, (byte) 0x02, (byte) 0xB1, (byte) 0x49, (byte) 0xC5,
             (byte) 0x4C, (byte) 0x37, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x49, (byte) 0x45,
             (byte) 0x4E, (byte) 0x44, (byte) 0xAE, (byte) 0x42, (byte) 0x60, (byte) 0x82};
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 2);
         checkImageTypeExample(vChipLS);
@@ -114,7 +116,7 @@ public class VChipLSTest extends LoggerChecks
             (byte) 0x4C, (byte) 0x37, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x49, (byte) 0x45,
             (byte) 0x4E, (byte) 0x44, (byte) 0xAE, (byte) 0x42, (byte) 0x60, (byte) 0x82};
         verifyNoLoggerMessages();
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, EnumSet.noneOf(ParseOptions.class));
         verifySingleLoggerMessage("Unknown VMTI VChip Metadata tag: 4");
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 2);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vfeature/VFeatureLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vfeature/VFeatureLSTest.java
@@ -3,9 +3,11 @@ package org.jmisb.api.klv.st0903.vfeature;
 import org.jmisb.api.klv.LoggerChecks;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.shared.VmtiUri;
@@ -34,7 +36,7 @@ public class VFeatureLSTest extends LoggerChecks
             0x31, 0x64, 0x30, 0x2d, 0x61, 0x37, 0x36, 0x35,
             0x2d, 0x30, 0x30, 0x61, 0x30, 0x63, 0x39, 0x31,
             0x65, 0x36, 0x62, 0x66, 0x36 };
-        VFeatureLS localSet = new VFeatureLS(bytes);
+        VFeatureLS localSet = new VFeatureLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);
         checkSchemaExample(localSet);
@@ -88,7 +90,7 @@ public class VFeatureLSTest extends LoggerChecks
             0x3A, 0x44, 0x61, 0x74, 0x61, 0x42, 0x6C, 0x6F,
             0x63, 0x6B, 0x3E
         };
-        VFeatureLS localSet = new VFeatureLS(bytes);
+        VFeatureLS localSet = new VFeatureLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);
         checkSchemaFeatureExample(localSet);
@@ -150,7 +152,7 @@ public class VFeatureLSTest extends LoggerChecks
             0x3A, 0x44, 0x61, 0x74, 0x61, 0x42, 0x6C, 0x6F,
             0x63, 0x6B, 0x3E};
         verifyNoLoggerMessages();
-        VFeatureLS localSet = new VFeatureLS(bytes);
+        VFeatureLS localSet = new VFeatureLS(bytes, EnumSet.noneOf(ParseOptions.class));
         this.verifySingleLoggerMessage("Unknown VMTI VFeature Metadata tag: 3");
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 2);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vmask/VMaskLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vmask/VMaskLSTest.java
@@ -1,12 +1,14 @@
 package org.jmisb.api.klv.st0903.vmask;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.ParseOptions;
 import static org.testng.Assert.*;
 import org.testng.annotations.Test;
 
@@ -30,7 +32,7 @@ public class VMaskLSTest extends LoggerChecks
             0x02, 0x39, (byte)0xBF,
             0x02, 0x3B, 0x0B
         };
-        VMaskLS localSet = new VMaskLS(bytes);
+        VMaskLS localSet = new VMaskLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);
         checkPolygonExample(localSet);
@@ -46,7 +48,7 @@ public class VMaskLSTest extends LoggerChecks
             0x03, 0x01, 0x59, 0x04, // (89, 4)
             0x03, 0x01, 0x6A, 0x02  // (106, 2)
         };
-        VMaskLS localSet = new VMaskLS(bytes);
+        VMaskLS localSet = new VMaskLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);
         assertEquals(localSet.getBytes(), bytes);
@@ -70,7 +72,7 @@ public class VMaskLSTest extends LoggerChecks
             0x03, 0x01, 0x6A, 0x02  // (106, 2)
         };
         verifyNoLoggerMessages();
-        VMaskLS localSet = new VMaskLS(bytes);
+        VMaskLS localSet = new VMaskLS(bytes, EnumSet.noneOf(ParseOptions.class));
         this.verifySingleLoggerMessage("Unknown VMTI VMask Metadata tag: 3");
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 2);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vobject/VObjectLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vobject/VObjectLSTest.java
@@ -1,11 +1,13 @@
 package org.jmisb.api.klv.st0903.vobject;
 
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.shared.VmtiUri;
 import static org.testng.Assert.*;
@@ -71,7 +73,7 @@ public class VObjectLSTest extends LoggerChecks
     @Test
     public void parseTag1() throws KlvParseException, URISyntaxException
     {
-        VObjectLS vObjectLS = new VObjectLS(ontologyBytes);
+        VObjectLS vObjectLS = new VObjectLS(ontologyBytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 1);
         checkOntologyExample(vObjectLS);
@@ -80,7 +82,7 @@ public class VObjectLSTest extends LoggerChecks
     @Test
     public void parseTag2() throws KlvParseException
     {
-        VObjectLS vObjectLS = new VObjectLS(ontologyClassBytes);
+        VObjectLS vObjectLS = new VObjectLS(ontologyClassBytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 1);
         checkOntologyClassExample(vObjectLS);
@@ -89,7 +91,7 @@ public class VObjectLSTest extends LoggerChecks
     @Test
     public void parseTag3() throws KlvParseException
     {
-        VObjectLS vObjectLS = new VObjectLS(ontologyIdBytes);
+        VObjectLS vObjectLS = new VObjectLS(ontologyIdBytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 1);
         checkOntologyIdExample(vObjectLS);
@@ -98,7 +100,7 @@ public class VObjectLSTest extends LoggerChecks
     @Test
     public void parseTag4() throws KlvParseException
     {
-        VObjectLS vObjectLS = new VObjectLS(confidenceBytes);
+        VObjectLS vObjectLS = new VObjectLS(confidenceBytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 1);
         checkConfidenceExample(vObjectLS);
@@ -107,7 +109,7 @@ public class VObjectLSTest extends LoggerChecks
     @Test
     public void parseMerged() throws KlvParseException, URISyntaxException
     {
-        VObjectLS vObjectLS = new VObjectLS(mergedBytes);
+        VObjectLS vObjectLS = new VObjectLS(mergedBytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 4);
         checkOntologyExample(vObjectLS);
@@ -137,7 +139,7 @@ public class VObjectLSTest extends LoggerChecks
             0x01, 0x02
         };
         verifyNoLoggerMessages();
-        VObjectLS vObjectLS = new VObjectLS(bytes);
+        VObjectLS vObjectLS = new VObjectLS(bytes, EnumSet.noneOf(ParseOptions.class));
         verifySingleLoggerMessage("Unknown VMTI VObject Metadata tag: 5");
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 3);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftLatOffsetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftLatOffsetTest.java
@@ -1,5 +1,6 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import java.util.EnumSet;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import static org.testng.Assert.*;

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VChipSeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VChipSeriesTest.java
@@ -2,10 +2,12 @@ package org.jmisb.api.klv.st0903.vtarget;
 
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vchip.VChipLS;
 import org.jmisb.api.klv.st0903.vchip.VChipMetadataKey;
@@ -56,7 +58,7 @@ public class VChipSeriesTest
     @Test
     public void testConstructFromEncodedBytes() throws KlvParseException
     {
-        VChipSeries chipSeries = new VChipSeries(bytesOneChip);
+        VChipSeries chipSeries = new VChipSeries(bytesOneChip, EnumSet.noneOf(ParseOptions.class));
         assertEquals(chipSeries.getBytes().length, bytesOneChip.length);
         assertEquals(chipSeries.getDisplayName(), "Image Chips");
         assertEquals(chipSeries.getDisplayableValue(), "[Chip Series]");

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VChipTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VChipTest.java
@@ -1,9 +1,11 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vchip.VChipLS;
 import org.jmisb.api.klv.st0903.vchip.VChipMetadataKey;
@@ -32,7 +34,7 @@ public class VChipTest
     @Test
     public void testConstructFromEncodedBytes() throws KlvParseException
     {
-        VChip chip = new VChip(bytes);
+        VChip chip = new VChip(bytes, EnumSet.noneOf(ParseOptions.class));
         // Content can vary, but length should be OK.
         assertEquals(chip.getBytes().length, bytes.length);
         assertEquals(chip.getDisplayName(), "Image Chip");

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VFeatureTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VFeatureTest.java
@@ -1,9 +1,11 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vfeature.VFeatureLS;
 import org.jmisb.api.klv.st0903.vfeature.VFeatureMetadataKey;
@@ -28,7 +30,7 @@ public class VFeatureTest
     @Test
     public void testConstructFromEncodedBytes() throws KlvParseException
     {
-        VFeature vfeature = new VFeature(featureBytes);
+        VFeature vfeature = new VFeature(featureBytes, EnumSet.noneOf(ParseOptions.class));
         assertEquals(vfeature.getBytes(), featureBytes);
         assertEquals(vfeature.getDisplayName(), "Target Feature");
         assertEquals(vfeature.getDisplayableValue(), "[VFeature]");

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VMaskTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VMaskTest.java
@@ -1,10 +1,12 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vmask.BitMaskSeries;
 import org.jmisb.api.klv.st0903.vmask.PixelPolygon;
@@ -70,7 +72,7 @@ public class VMaskTest {
             0x03, 0x01, 0x4A, 0x02, // (74, 2)
             0x03, 0x01, 0x59, 0x04, // (89, 4)
             0x03, 0x01, 0x6A, 0x02  // (106, 2)
-        });
+        }, EnumSet.noneOf(ParseOptions.class));
         assertEquals(mask.getBytes(), new byte[]{
             0x01,
             0x09,

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VObjectSeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VObjectSeriesTest.java
@@ -2,10 +2,12 @@ package org.jmisb.api.klv.st0903.vtarget;
 
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vobject.VObjectLS;
 import org.jmisb.api.klv.st0903.vobject.VObjectMetadataKey;
@@ -56,7 +58,7 @@ public class VObjectSeriesTest
     @Test
     public void testConstructFromEncodedBytes() throws KlvParseException
     {
-        VObjectSeries objectSeries = new VObjectSeries(bytesOneObject);
+        VObjectSeries objectSeries = new VObjectSeries(bytesOneObject, EnumSet.noneOf(ParseOptions.class));
         assertEquals(objectSeries.getBytes().length, bytesOneObject.length);
         assertEquals(objectSeries.getDisplayName(), "Ontologies");
         assertEquals(objectSeries.getDisplayableValue(), "[VObject Series]");

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VObjectTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VObjectTest.java
@@ -1,9 +1,11 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.vobject.VObjectLS;
 import org.jmisb.api.klv.st0903.vobject.VObjectMetadataKey;
@@ -31,7 +33,7 @@ public class VObjectTest
     @Test
     public void testConstructFromEncodedBytes() throws KlvParseException
     {
-        VObject vobject = new VObject(ontologyBytes);
+        VObject vobject = new VObject(ontologyBytes, EnumSet.noneOf(ParseOptions.class));
         assertEquals(vobject.getBytes(), ontologyBytes);
         assertEquals(vobject.getDisplayName(), "VObject Ontology");
         assertEquals(vobject.getDisplayableValue(), "[VObject]");

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTrackerTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTrackerTest.java
@@ -1,8 +1,10 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ParseOptions;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.vtracker.DetectionStatus;
@@ -24,7 +26,7 @@ public class VTrackerTest
     @Test
     public void testConstructFromEncodedBytes() throws KlvParseException
     {
-        VTracker tracker = new VTracker(bytes);
+        VTracker tracker = new VTracker(bytes, EnumSet.noneOf(ParseOptions.class));
         assertEquals(tracker.getBytes(), bytes);
         assertEquals(tracker.getDisplayName(), "VTracker");
         assertEquals(tracker.getDisplayableValue(), "[VTracker]");

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLSTest.java
@@ -1,9 +1,11 @@
 package org.jmisb.api.klv.st0903.vtracker;
 
+import java.util.EnumSet;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.AlgorithmId;
 import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.ParseOptions;
 import static org.testng.Assert.*;
 import org.testng.annotations.Test;
 
@@ -31,7 +33,7 @@ public class VTrackerLSTest extends LoggerChecks
     public void parseAlgorithmId() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x0C, 0x01, 0x03};
-        VTrackerLS localSet = new VTrackerLS(bytes);
+        VTrackerLS localSet = new VTrackerLS(bytes, EnumSet.noneOf(ParseOptions.class));
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);
         assertTrue(localSet.getTags().contains(VTrackerMetadataKey.algorithmId));


### PR DESCRIPTION
## Motivation and Context
There is an existing TODO to allow less-strict parsing. This deals with that.

## Description
Adds a parse enum flag set that changes throws to logger entries. 

I'm not that happy with the implementation. It just doesn't feel right yet. Maybe there is a better way.

## How Has This Been Tested?
I ran it across some problematic files (e.g. the DayFlight and NightFlight sets from ffmpeg). We get more of the data, where previously we got none.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

