### PR TITLE
Add protection for bad MIIS core idents

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/MiisCoreIdentifier.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/MiisCoreIdentifier.java
@@ -41,7 +41,7 @@ public class MiisCoreIdentifier implements IUasDatalinkValue {
     /**
      * Get the identifier.
      *
-     * @return The identifier
+     * @return The identifier (which can be null if the parsing failed).
      */
     public CoreIdentifier getCoreIdentifier() {
         return coreIdentifier;
@@ -49,12 +49,20 @@ public class MiisCoreIdentifier implements IUasDatalinkValue {
 
     @Override
     public byte[] getBytes() {
-        return coreIdentifier.getRawBytesRepresentation();
+        if (coreIdentifier != null) {
+            return coreIdentifier.getRawBytesRepresentation();
+        } else {
+            return null;
+        }
     }
 
     @Override
     public String getDisplayableValue() {
-        return coreIdentifier.getTextRepresentation();
+        if (coreIdentifier != null) {
+            return coreIdentifier.getTextRepresentation();
+        } else {
+            return "[NULL]";
+        }
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st1204/CoreIdentifier.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1204/CoreIdentifier.java
@@ -164,9 +164,9 @@ public class CoreIdentifier
      */
     public static CoreIdentifier fromBytes(byte[] bytes)
     {
-        if (bytes.length < UUID_BYTE_LEN + 2)
+        if (bytes.length < 2)
         {
-            LOGGER.error("Insufficient bytes to read MIIS Core Identifer");
+            LOGGER.error("Insufficient bytes to read MIIS Core Identifer usage");
             return null;
         }
         int index = 0;

--- a/api/src/test/java/org/jmisb/api/klv/st0601/MiisCoreIdentifierTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/MiisCoreIdentifierTest.java
@@ -26,7 +26,7 @@ public class MiisCoreIdentifierTest {
         assertEquals(identifier.getCoreIdentifier().getVersion(), 1);
         assertTrue(identifier.getCoreIdentifier().hasValidCheckValue());
     }
-    
+
     @Test
     public void verifyFromBytes() {
         // ST0601 example
@@ -38,7 +38,7 @@ public class MiisCoreIdentifierTest {
         assertEquals(identifier.getCoreIdentifier().getVersion(), 1);
         assertTrue(identifier.getCoreIdentifier().hasValidCheckValue());
     }
-    
+
     @Test
     public void verifyFromFactory() throws KlvParseException {
         // ST0601 example
@@ -51,5 +51,17 @@ public class MiisCoreIdentifierTest {
         assertNotNull(identifier.getCoreIdentifier());
         assertEquals(identifier.getCoreIdentifier().getVersion(), 1);
         assertTrue(identifier.getCoreIdentifier().hasValidCheckValue());
+    }
+
+    @Test
+    public void verifyBadCoreIdentifierHandling() throws KlvParseException
+    {
+        IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.MiisCoreIdentifier, new byte[]{0x01, 0x10, 0x00});
+        Assert.assertTrue(v instanceof MiisCoreIdentifier);
+        MiisCoreIdentifier identifier = (MiisCoreIdentifier) v;
+        assertEquals(identifier.getDisplayableValue(), "[NULL]");
+        assertEquals(identifier.getDisplayName(), "MIIS Core Identifier");
+        assertNull(identifier.getBytes());
+        assertNull(identifier.getCoreIdentifier());
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st1204/CoreIdentifierTortureTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1204/CoreIdentifierTortureTest.java
@@ -88,4 +88,34 @@ public class CoreIdentifierTortureTest {
         CoreIdentifier coreIdentifier = CoreIdentifier.fromString("0154:C7D1-6253-98A2-41C2-BA6E-90F8-FCC7-3914/E047-AB3E-81BE-41ED-9664-09B0-2F44-5FAB:C8");
         assertNull(coreIdentifier);
     }
+
+    @Test
+    public void badByteLengthHeader() {
+        CoreIdentifier coreIdentifier = CoreIdentifier.fromBytes(new byte[] {0x01});
+        assertNull(coreIdentifier);
+    }
+
+    @Test
+    public void badByteLengthSensorId() {
+        CoreIdentifier coreIdentifier = CoreIdentifier.fromBytes(new byte[] {0x01, 0x40, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+        assertNull(coreIdentifier);
+    }
+
+    @Test
+    public void badByteLengthPlatformId() {
+        CoreIdentifier coreIdentifier = CoreIdentifier.fromBytes(new byte[] {0x01, 0x10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+        assertNull(coreIdentifier);
+    }
+
+    @Test
+    public void badByteLengthWindowId() {
+        CoreIdentifier coreIdentifier = CoreIdentifier.fromBytes(new byte[] {0x01, 0x04, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+        assertNull(coreIdentifier);
+    }
+
+    @Test
+    public void badByteLengthMinorId() {
+        CoreIdentifier coreIdentifier = CoreIdentifier.fromBytes(new byte[] {0x01, 0x02, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+        assertNull(coreIdentifier);
+    }
 }


### PR DESCRIPTION
## Motivation and Context
While testing some old Alticam data, I saw MIIS Core Identifiers that have inconsistent usage and lengths (e.g. bit flags that suggest window IDs, but not enough bytes to provide the window ID GUID). That causes parsing to fail.

## Description
Add length checks, and return null if it doesn't work out (which probably means its garbage). Also add null checks to users.

We already have protection on the framing code.


## How Has This Been Tested?
Re-ran unit tests. Tested against the problematic file.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

