### PR TITLE
Simplify (and correct) VMTI parsing.

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/LdsParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/LdsParser.java
@@ -48,7 +48,6 @@ public class LdsParser
             // Get the Length (BER short or long form-encoded)
             int lengthFieldOffset = offset;
             BerField lengthField = BerDecoder.decode(bytes, lengthFieldOffset, false);
-
             // Get the Value
             int begin = lengthFieldOffset + lengthField.getLength();
             int end = begin + lengthField.getValue();

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WavelengthsList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WavelengthsList.java
@@ -79,7 +79,7 @@ public class WavelengthsList implements IUasDatalinkValue {
         int offset = 0;
         while (offset < bytes.length) {
             Wavelengths wavelengths = new Wavelengths();
-            BerField packLengthField = BerDecoder.decode(bytes, offset, true);
+            BerField packLengthField = BerDecoder.decode(bytes, offset, false);
             offset += packLengthField.getLength();
             int packLength = packLengthField.getValue();
             BerField idField = BerDecoder.decode(bytes, offset, true);

--- a/api/src/main/java/org/jmisb/api/klv/st0903/AlgorithmSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/AlgorithmSeries.java
@@ -55,10 +55,9 @@ public class AlgorithmSeries implements IVmtiMetadataValue
         int index = 0;
         while (index < bytes.length - 1)
         {
-            BerField lengthField = BerDecoder.decode(bytes, index, true);
+            BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
-            byte[] localSetBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            AlgorithmLS algorithmLS = new AlgorithmLS(localSetBytes);
+            AlgorithmLS algorithmLS = new AlgorithmLS(bytes, index, lengthField.getValue());
             localSets.add(algorithmLS);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/OntologySeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/OntologySeries.java
@@ -56,10 +56,9 @@ public class OntologySeries implements IVmtiMetadataValue
         int index = 0;
         while (index < bytes.length - 1)
         {
-            BerField lengthField = BerDecoder.decode(bytes, index, true);
+            BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
-            byte[] localSetBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            OntologyLS vobjectLS = new OntologyLS(localSetBytes);
+            OntologyLS vobjectLS = new OntologyLS(bytes, index, lengthField.getValue());
             localSets.add(vobjectLS);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/VTargetSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/VTargetSeries.java
@@ -46,10 +46,9 @@ public class VTargetSeries implements IVmtiMetadataValue
         int index = 0;
         while (index < bytes.length - 1)
         {
-            BerField lengthField = BerDecoder.decode(bytes, index, true);
+            BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
-            byte[] targetPackBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            VTargetPack targetPack = new VTargetPack(targetPackBytes);
+            VTargetPack targetPack = new VTargetPack(bytes, index, lengthField.getValue());
             targetPacks.add(targetPack);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLS.java
@@ -41,11 +41,9 @@ public class AlgorithmLS {
         map.putAll(values);
     }
 
-    // TODO consider refactoring to pass in the original array instead of a copy
-    public AlgorithmLS(byte[] bytes) throws KlvParseException
+    public AlgorithmLS(byte[] bytes, int offset, int length) throws KlvParseException
     {
-        int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, length);
         for (LdsField field : fields)
         {
             AlgorithmMetadataKey key = AlgorithmMetadataKey.getKey(field.getTag());

--- a/api/src/main/java/org/jmisb/api/klv/st0903/ontology/OntologyLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/ontology/OntologyLS.java
@@ -48,11 +48,9 @@ public class OntologyLS {
         map.putAll(values);
     }
 
-    // TODO consider refactoring to pass in the original array instead of a copy
-    public OntologyLS(byte[] bytes) throws KlvParseException
+    public OntologyLS(byte[] bytes, int offset, int length) throws KlvParseException
     {
-        int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, length);
         for (LdsField field : fields)
         {
             OntologyMetadataKey key = OntologyMetadataKey.getKey(field.getTag());

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vchip/VChipLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vchip/VChipLS.java
@@ -39,11 +39,9 @@ public class VChipLS
         map.putAll(values);
     }
 
-    // TODO consider refactoring to pass in the original array instead of a copy
-    public VChipLS(byte[] bytes) throws KlvParseException
+    public VChipLS(byte[] bytes, int offset, int length) throws KlvParseException
     {
-        int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, length);
         for (LdsField field : fields) {
             VChipMetadataKey key = VChipMetadataKey.getKey(field.getTag());
             if (key == VChipMetadataKey.Undefined) {

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vfeature/VFeatureLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vfeature/VFeatureLS.java
@@ -39,11 +39,9 @@ public class VFeatureLS
         map.putAll(values);
     }
 
-    // TODO consider refactoring to pass in the original array instead of a copy
     public VFeatureLS(byte[] bytes) throws KlvParseException
     {
-        int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, 0, bytes.length);
         for (LdsField field : fields) {
             VFeatureMetadataKey key = VFeatureMetadataKey.getKey(field.getTag());
             if (key == VFeatureMetadataKey.Undefined) {

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vmask/BitMaskSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vmask/BitMaskSeries.java
@@ -59,7 +59,7 @@ public class BitMaskSeries implements IVmtiMetadataValue
         int index = 0;
         while (index < bytes.length - 1)
         {
-            BerField lengthField = BerDecoder.decode(bytes, index, true);
+            BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
             byte[] valueBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
             PixelRunPair run = parsePixelRunPair(valueBytes);
@@ -117,7 +117,7 @@ public class BitMaskSeries implements IVmtiMetadataValue
     private PixelRunPair parsePixelRunPair(byte[] valueBytes)
     {
         int index = 0;
-        BerField lengthField = BerDecoder.decode(valueBytes, 0, true);
+        BerField lengthField = BerDecoder.decode(valueBytes, 0, false);
         index += lengthField.getLength();
         if (lengthField.getValue() > 6)
         {

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vmask/PixelPolygon.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vmask/PixelPolygon.java
@@ -62,7 +62,7 @@ public class PixelPolygon implements IVmtiMetadataValue
         int index = 0;
         while (index < bytes.length - 1)
         {
-            BerField lengthField = BerDecoder.decode(bytes, index, true);
+            BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
             byte[] polygonPointBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
             Long location = parseV6(polygonPointBytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vmask/VMaskLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vmask/VMaskLS.java
@@ -37,7 +37,6 @@ public class VMaskLS
         map.putAll(values);
     }
 
-    // TODO consider refactoring to pass in the original array instead of a copy
     public VMaskLS(byte[] bytes) throws KlvParseException
     {
         int offset = 0;

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vobject/VObjectLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vobject/VObjectLS.java
@@ -39,11 +39,9 @@ public class VObjectLS
         map.putAll(values);
     }
 
-    // TODO consider refactoring to pass in the original array instead of a copy
-    public VObjectLS(byte[] bytes) throws KlvParseException
+    public VObjectLS(byte[] bytes, int offset, int length) throws KlvParseException
     {
-        int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, length);
         for (LdsField field : fields) {
             VObjectMetadataKey key = VObjectMetadataKey.getKey(field.getTag());
             if (key == VObjectMetadataKey.Undefined) {

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetBoundarySeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetBoundarySeries.java
@@ -57,7 +57,7 @@ public class TargetBoundarySeries implements IVmtiMetadataValue
         int index = 0;
         while (index < bytes.length - 1)
         {
-            BerField lengthField = BerDecoder.decode(bytes, index, true);
+            BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
             byte[] packBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
             LocationPack location = TargetLocation.targetLocationPackFromBytes(packBytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetIntensity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetIntensity.java
@@ -31,7 +31,7 @@ public class TargetIntensity extends VmtiV3Value implements IVmtiMetadataValue
     /**
      * Create from encoded bytes.
      *
-     * @param bytes height, encoded as a variable length unsigned int (max 3 bytes)
+     * @param bytes intensity, encoded as a variable length unsigned int (max 3 bytes)
      */
     public TargetIntensity(byte[] bytes)
     {

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VChip.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VChip.java
@@ -40,7 +40,7 @@ public class VChip implements IVmtiMetadataValue
      */
     public VChip(byte[] bytes) throws KlvParseException
     {
-        value = new VChipLS(bytes);
+        value = new VChipLS(bytes, 0, bytes.length);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VChipSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VChipSeries.java
@@ -50,10 +50,9 @@ public class VChipSeries implements IVmtiMetadataValue
         int index = 0;
         while (index < bytes.length - 1)
         {
-            BerField lengthField = BerDecoder.decode(bytes, index, true);
+            BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
-            byte[] vChipBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            VChipLS chip = new VChipLS(vChipBytes);
+            VChipLS chip = new VChipLS(bytes, index, lengthField.getValue());
             chips.add(chip);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VMask.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VMask.java
@@ -66,7 +66,7 @@ public class VMask implements IVmtiMetadataValue
      *
      * @return the vmask local set.
      */
-    public VMaskLS getFeature()
+    public VMaskLS getMask()
     {
         return value;
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VObject.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VObject.java
@@ -38,7 +38,7 @@ public class VObject implements IVmtiMetadataValue
      */
     public VObject(byte[] bytes) throws KlvParseException
     {
-        value = new VObjectLS(bytes);
+        value = new VObjectLS(bytes, 0, bytes.length);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VObjectSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VObjectSeries.java
@@ -47,10 +47,9 @@ public class VObjectSeries implements IVmtiMetadataValue
         int index = 0;
         while (index < bytes.length - 1)
         {
-            BerField lengthField = BerDecoder.decode(bytes, index, true);
+            BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
-            byte[] vObjectBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            VObjectLS objectLocalSet = new VObjectLS(vObjectBytes);
+            VObjectLS objectLocalSet = new VObjectLS(bytes, index, lengthField.getValue());
             vobjects.add(objectLocalSet);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VTargetPack.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VTargetPack.java
@@ -35,14 +35,12 @@ public class VTargetPack {
         map.putAll(values);
     }
 
-    // TODO consider refactoring to pass in the original array instead of a copy
-    public VTargetPack(byte[] bytes) throws KlvParseException
+    public VTargetPack(byte[] bytes, int offset, int length) throws KlvParseException
     {
-        int offset = 0;
         BerField targetIdField = BerDecoder.decode(bytes, offset, true);
         offset += targetIdField.getLength();
         targetId = targetIdField.getValue();
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, offset, length - targetIdField.getLength());
         for (LdsField field : fields)
         {
             VTargetMetadataKey key = VTargetMetadataKey.getKey(field.getTag());

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/BoundarySeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/BoundarySeries.java
@@ -50,7 +50,7 @@ public class BoundarySeries implements IVmtiMetadataValue
         int index = 0;
         while (index < bytes.length - 1)
         {
-            BerField lengthField = BerDecoder.decode(bytes, index, true);
+            BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
             byte[] packBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
             LocationPack location = TargetLocation.targetLocationPackFromBytes(packBytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/TrackHistorySeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/TrackHistorySeries.java
@@ -50,7 +50,7 @@ public class TrackHistorySeries implements IVmtiMetadataValue
         int index = 0;
         while (index < bytes.length - 1)
         {
-            BerField lengthField = BerDecoder.decode(bytes, index, true);
+            BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
             byte[] packBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
             LocationPack location = TargetLocation.targetLocationPackFromBytes(packBytes);

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLS.java
@@ -39,11 +39,9 @@ public class VTrackerLS {
         map.putAll(values);
     }
 
-    // TODO consider refactoring to pass in the original array instead of a copy
     public VTrackerLS(byte[] bytes) throws KlvParseException
     {
-        int offset = 0;
-        List<LdsField> fields = LdsParser.parseFields(bytes, offset, bytes.length - offset);
+        List<LdsField> fields = LdsParser.parseFields(bytes, 0, bytes.length);
         for (LdsField field : fields) {
             VTrackerMetadataKey key = VTrackerMetadataKey.getKey(field.getTag());
             if (key == VTrackerMetadataKey.Undefined) {

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetOneWithTheLotTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetOneWithTheLotTest.java
@@ -1,0 +1,399 @@
+package org.jmisb.api.klv.st0903;
+
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.Ber;
+import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.IMisbMessage;
+import org.jmisb.api.klv.KlvConstants;
+import org.jmisb.api.klv.st0903.shared.VmtiTextString;
+import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.st0903.algorithm.AlgorithmLS;
+import org.jmisb.api.klv.st0903.algorithm.AlgorithmMetadataKey;
+import org.jmisb.api.klv.st0903.ontology.OntologyLS;
+import org.jmisb.api.klv.st0903.ontology.OntologyMetadataKey;
+import org.jmisb.api.klv.st0903.vchip.VChipLS;
+import org.jmisb.api.klv.st0903.vchip.VChipMetadataKey;
+import org.jmisb.api.klv.st0903.vfeature.VFeatureLSTest;
+import org.jmisb.api.klv.st0903.vmask.VMaskLSTest;
+import org.jmisb.api.klv.st0903.vmask.VMaskMetadataKey;
+import org.jmisb.api.klv.st0903.vobject.VObjectLS;
+import org.jmisb.api.klv.st0903.vobject.VObjectLSTest;
+import org.jmisb.api.klv.st0903.vobject.VObjectMetadataKey;
+import org.jmisb.api.klv.st0903.vtarget.TargetLocation;
+import org.jmisb.api.klv.st0903.vtarget.VChip;
+import org.jmisb.api.klv.st0903.vtarget.VChipSeries;
+import org.jmisb.api.klv.st0903.vtarget.VFeature;
+import org.jmisb.api.klv.st0903.vtarget.VMask;
+import org.jmisb.api.klv.st0903.vtarget.VObject;
+import org.jmisb.api.klv.st0903.vtarget.VObjectSeries;
+import org.jmisb.api.klv.st0903.vtarget.VTargetMetadataKey;
+import static org.jmisb.api.klv.st0903.vtarget.VTargetMetadataKey.VMask;
+import org.jmisb.api.klv.st0903.vtarget.VTargetPack;
+import org.jmisb.api.klv.st0903.vtarget.VTracker;
+import org.jmisb.api.klv.st0903.vtracker.VTrackerMetadataKey;
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for the ST0903 VMTI Local Set including nested parts
+ */
+public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks
+{
+    VmtiLocalSetOneWithTheLotTest()
+    {
+        super(VmtiLocalSet.class);
+    }
+
+    @Test
+    public void parseEverything() throws KlvParseException, URISyntaxException
+    {
+        final byte[] bytes = new byte[]{
+            0x02, 0x08, 0x00, 0x03, (byte)0x82, 0x44, 0x30, (byte)0xF6, (byte)0xCE, 0x40,
+            0x03, 0x0E, 0x44, 0x53, 0x54, 0x4F, 0x5F, 0x41, 0x44, 0x53, 0x53, 0x5F, 0x56, 0x4D, 0x54, 0x49,
+            0x04, 0x01, 0x05,
+            0x05, 0x01, 0x1C,
+            0x06, 0x01, 0x02,
+            0x07, 0x03, 0x01, 0x30, (byte)0xB0,
+            0x08, 0x02, 0x07, (byte)0x80,
+            0x09, 0x02, 0x04, 0x38,
+            0x0A, 0x07, 0x45, 0x4F, 0x20, 0x4E, 0x6F, 0x73, 0x65,
+            0x0B, 0x02, 0x06, 0x40,
+            0x0C, 0x02, 0x05, 0x00,
+            0x0D, 0x22, (byte)0x01, (byte)0x68, (byte)0xF3, (byte)0x54, (byte)0x66, (byte)0x6E, (byte)0xD5, (byte)0x52, (byte)0x4C, (byte)0x0D, (byte)0x91, (byte)0x68, (byte)0xA7, (byte)0x45, (byte)0x4C, (byte)0xEB, (byte)0xA0, (byte)0x73, (byte)0x84, (byte)0x0A, (byte)0x47, (byte)0x99, (byte)0xBB, (byte)0xC0, (byte)0x4B, (byte)0xD5, (byte)0x97, (byte)0xA7, (byte)0x56, (byte)0xF6, (byte)0x40, (byte)0x92, (byte)0xAF, (byte)0x7B,
+            0x65, (byte)0x82, (byte)0x03, (byte)0x86, // Key + length
+                (byte)0x82, (byte)0x02, (byte)0xE1, // Length of first VTarget LS
+                    0x01, // Target identifier
+                    0x01, 0x03, 0x06, 0x40, 0x00, // target centroid
+                    0x04, 0x01, 0x1B, // target priority
+                    0x05, 0x01, 0x50, // confidence
+                    0x06, 0x02, 0x0A, (byte)0xCD, // target history 
+                    0x07, 0x01, 0x32, // percentage target pixels
+                    0x08, 0x03, (byte)0xDA, (byte)0xA5, 0x20, // target colour
+                    0x0C, 0x02, 0x2A, (byte)0x94,
+                    0x11, 0x0A, (byte)0x27, (byte)0xba, (byte)0x93, (byte)0x02, (byte)0x34, (byte)0x4a, (byte)0x1a, (byte)0xdf, (byte)0x10, (byte)0x14, // Target location, basic form
+                    0x13, 0x02, 0x03, 0x68,
+                    0x14, 0x02, 0x04, 0x71,
+                    0x15, 0x02, 0x02, 0x03,
+                    0x16, 0x01, 0x2B,
+                    0x65, 25, // VMask tag + length
+                        0x01, 0x09, 0x02, 0x39, (byte)0xAA, 0x02, 0x39, (byte)0xBF, 0x02, 0x3B, 0x0B, // Tag 1
+                        0x02, 0x0C, 0x03, 0x01, 0x4A, 0x02, 0x03, 0x01, 0x59, 0x04, 0x03, 0x01, 0x6A, 0x02, // Tag 2
+                    0x66, 0x5B, // VObject tag + length
+                        0x01, 71, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3A, 0x2F, 0x2F,
+                          0x72, 0x61, 0x77, 0x2E, 0x67, 0x69, 0x74, 0x68,
+                          0x75, 0x62, 0x75, 0x73, 0x65, 0x72, 0x63, 0x6F,
+                          0x6E, 0x74, 0x65, 0x6E, 0x74, 0x2E, 0x63, 0x6F,
+                          0x6D, 0x2F, 0x6F, 0x77, 0x6C, 0x63, 0x73, 0x2F,
+                          0x70, 0x69, 0x7A, 0x7A, 0x61, 0x2D, 0x6F, 0x6E,
+                          0x74, 0x6F, 0x6C, 0x6F, 0x67, 0x79, 0x2F, 0x6D,
+                          0x61, 0x73, 0x74, 0x65, 0x72, 0x2F, 0x70, 0x69,
+                          0x7A, 0x7A, 0x61, 0x2E, 0x6F, 0x77, 0x6C,
+                        0x02, 8, 0x4D, 0x75, 0x73, 0x68, 0x72, 0x6F, 0x6F, 0x6D,
+                        0x03, 2, 0x01, 0x02,
+                        0x04, 2, 0x30, 0x00,
+                    0x67, (byte)0x82, 0x01, 0x76, // VFeature
+                        0x01, 45, // VFeature tag 1 - schema
+                            0x75, 0x72, 0x6e, 0x3a, 0x75, 0x75, 0x69, 0x64,
+                            0x3a, 0x66, 0x38, 0x31, 0x64, 0x34, 0x66, 0x61,
+                            0x65, 0x2d, 0x37, 0x64, 0x65, 0x63, 0x2d, 0x31,
+                            0x31, 0x64, 0x30, 0x2d, 0x61, 0x37, 0x36, 0x35,
+                            0x2d, 0x30, 0x30, 0x61, 0x30, 0x63, 0x39, 0x31,
+                            0x65, 0x36, 0x62, 0x66, 0x36,
+                        0x02, (byte)0x82, 0x01, 0x43, // VFeature tag 2 - schema feature
+                            0x3C, 0x67, 0x6D, 0x6C, 0x3A, 0x44, 0x61, 0x74,
+                            0x61, 0x42, 0x6C, 0x6F, 0x63, 0x6B, 0x3E, 0x3C,
+                            0x67, 0x6D, 0x6C, 0x3A, 0x72, 0x61, 0x6E, 0x67,
+                            0x65, 0x50, 0x61, 0x72, 0x61, 0x6D, 0x65, 0x74,
+                            0x65, 0x72, 0x73, 0x3E, 0x3C, 0x67, 0x6D, 0x6C,
+                            0x3A, 0x43, 0x6F, 0x6D, 0x70, 0x6F, 0x73, 0x69,
+                            0x74, 0x65, 0x56, 0x61, 0x6C, 0x75, 0x65, 0x3E,
+                            0x3C, 0x67, 0x6D, 0x6C, 0x3A, 0x76, 0x61, 0x6C,
+                            0x75, 0x65, 0x43, 0x6F, 0x6D, 0x70, 0x6F, 0x6E,
+                            0x65, 0x6E, 0x74, 0x73, 0x3E, 0x3C, 0x54, 0x65,
+                            0x6D, 0x70, 0x65, 0x72, 0x61, 0x74, 0x75, 0x72,
+                            0x65, 0x20, 0x75, 0x6F, 0x6D, 0x3D, 0x22, 0x75,
+                            0x72, 0x6E, 0x3A, 0x78, 0x2D, 0x73, 0x69, 0x3A,
+                            0x76, 0x31, 0x39, 0x39, 0x39, 0x3A, 0x75, 0x6F,
+                            0x6D, 0x3A, 0x64, 0x65, 0x67, 0x72, 0x65, 0x65,
+                            0x73, 0x43, 0x22, 0x3E, 0x74, 0x65, 0x6D, 0x70,
+                            0x6C, 0x61, 0x74, 0x65, 0x3C, 0x2F, 0x54, 0x65,
+                            0x6D, 0x70, 0x65, 0x72, 0x61, 0x74, 0x75, 0x72,
+                            0x65, 0x3E, 0x3C, 0x50, 0x72, 0x65, 0x73, 0x73,
+                            0x75, 0x72, 0x65, 0x20, 0x75, 0x6F, 0x6D, 0x3D,
+                            0x22, 0x75, 0x72, 0x6E, 0x3A, 0x78, 0x2D, 0x73,
+                            0x69, 0x3A, 0x76, 0x31, 0x39, 0x39, 0x39, 0x3A,
+                            0x75, 0x6F, 0x6D, 0x3A, 0x6B, 0x50, 0x61, 0x22,
+                            0x3E, 0x74, 0x65, 0x6D, 0x70, 0x6C, 0x61, 0x74,
+                            0x65, 0x3C, 0x2F, 0x50, 0x72, 0x65, 0x73, 0x73,
+                            0x75, 0x72, 0x65, 0x3E, 0x3C, 0x2F, 0x67, 0x6D,
+                            0x6C, 0x3A, 0x76, 0x61, 0x6C, 0x75, 0x65, 0x43,
+                            0x6F, 0x6D, 0x70, 0x6F, 0x6E, 0x65, 0x6E, 0x74,
+                            0x73, 0x3E, 0x3C, 0x2F, 0x67, 0x6D, 0x6C, 0x3A,
+                            0x43, 0x6F, 0x6D, 0x70, 0x6F, 0x73, 0x69, 0x74,
+                            0x65, 0x56, 0x61, 0x6C, 0x75, 0x65, 0x3E, 0x3C,
+                            0x2F, 0x67, 0x6D, 0x6C, 0x3A, 0x72, 0x61, 0x6E,
+                            0x67, 0x65, 0x50, 0x61, 0x72, 0x61, 0x6D, 0x65,
+                            0x74, 0x65, 0x72, 0x73, 0x3E, 0x3C, 0x67, 0x6D,
+                            0x6C, 0x3A, 0x74, 0x75, 0x70, 0x6C, 0x65, 0x4C,
+                            0x69, 0x73, 0x74, 0x3E, 0x33, 0x2C, 0x31, 0x30,
+                            0x31, 0x2E, 0x32, 0x3C, 0x2F, 0x67, 0x6D, 0x6C,
+                            0x3A, 0x74, 0x75, 0x70, 0x6C, 0x65, 0x4C, 0x69,
+                            0x73, 0x74, 0x3E, 0x3C, 0x2F, 0x67, 0x6D, 0x6C,
+                            0x3A, 0x44, 0x61, 0x74, 0x61, 0x42, 0x6C, 0x6F,
+                            0x63, 0x6B, 0x3E,
+                    0x68, 0x09, // VTracker Tag + length 
+                        0x02, 0x01, 0x01,
+                        0x07, 0x01, 0x32,
+                        0x0C, 0x01, 0x09, // Algorithm ID
+                    0x69, 0x4E, // VChip
+                        0x01, 0x04, 0x6A, 0x70, 0x65, 0x67, // Tag 1
+                        0x03, 70, 
+                        (byte) 0x89, (byte) 0x50, (byte) 0x4E, (byte) 0x47, (byte) 0x0D, (byte) 0x0A, (byte) 0x1A, (byte) 0x0A,
+                        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x0D, (byte) 0x49, (byte) 0x48, (byte) 0x44, (byte) 0x52,
+                        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01,
+                        (byte) 0x08, (byte) 0x06, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x1F, (byte) 0x15, (byte) 0xC4,
+                        (byte) 0x89, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x0D, (byte) 0x49, (byte) 0x44, (byte) 0x41,
+                        (byte) 0x54, (byte) 0x78, (byte) 0xDA, (byte) 0x63, (byte) 0x64, (byte) 0xD8, (byte) 0xF8, (byte) 0xFF,
+                        (byte) 0x3F, (byte) 0x00, (byte) 0x05, (byte) 0x1A, (byte) 0x02, (byte) 0xB1, (byte) 0x49, (byte) 0xC5,
+                        (byte) 0x4C, (byte) 0x37, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x49, (byte) 0x45,
+                        (byte) 0x4E, (byte) 0x44, (byte) 0xAE, (byte) 0x42, (byte) 0x60, (byte) 0x82,
+                    0x6B, 0x5B,
+                        0x53, // composite length for first ontology
+                            0x01, 71, // Tag 1 and length
+                                0x68, 0x74, 0x74, 0x70, 0x73, 0x3A, 0x2F, 0x2F,
+                                0x72, 0x61, 0x77, 0x2E, 0x67, 0x69, 0x74, 0x68,
+                                0x75, 0x62, 0x75, 0x73, 0x65, 0x72, 0x63, 0x6F,
+                                0x6E, 0x74, 0x65, 0x6E, 0x74, 0x2E, 0x63, 0x6F,
+                                0x6D, 0x2F, 0x6F, 0x77, 0x6C, 0x63, 0x73, 0x2F,
+                                0x70, 0x69, 0x7A, 0x7A, 0x61, 0x2D, 0x6F, 0x6E,
+                                0x74, 0x6F, 0x6C, 0x6F, 0x67, 0x79, 0x2F, 0x6D,
+                                0x61, 0x73, 0x74, 0x65, 0x72, 0x2F, 0x70, 0x69,
+                                0x7A, 0x7A, 0x61, 0x2E, 0x6F, 0x77, 0x6C,
+                            0x02, 0x08, 0x4D, 0x75, 0x73, 0x68, 0x72, 0x6F, 0x6F, 0x6D,
+                        0x06, // composite length for second ontology
+                            0x02, 0x04, 0x74, 0x65, 0x73, 0x74, // Tag 2 and length
+                (byte)0x81, (byte)0xA0, // Length of second vtarget local set
+                    0x03, // Target identifier
+                    0x02, 0x03, 0x06, 0x40, 0x00,
+                    0x03, 0x03, 0x06, (byte)0x8B, 0x0A,
+                    0x04, 0x01, 0x03, // target priority
+                    0x07, 0x01, 0x06, // percentage target pixels
+                    0x09, 0x02, 0x33, 0x54, // target intensity
+                    0x16, 0x01, 0x09, // algorithm ID
+                    0x6A, (byte)0x81, (byte)0x85, // VChipSeries tag and length
+                        78, // composite length for first chip
+                            0x01, 0x04, 0x6A, 0x70, 0x65, 0x67, // Tag 1
+                            (byte) 0x03, // Tag 3 key
+                            70, // Tag 3 length
+                            (byte) 0x89, (byte) 0x50, (byte) 0x4E, (byte) 0x47, (byte) 0x0D, (byte) 0x0A, (byte) 0x1A, (byte) 0x0A,
+                            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x0D, (byte) 0x49, (byte) 0x48, (byte) 0x44, (byte) 0x52,
+                            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01,
+                            (byte) 0x08, (byte) 0x06, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x1F, (byte) 0x15, (byte) 0xC4,
+                            (byte) 0x89, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x0D, (byte) 0x49, (byte) 0x44, (byte) 0x41,
+                            (byte) 0x54, (byte) 0x78, (byte) 0xDA, (byte) 0x63, (byte) 0x64, (byte) 0xD8, (byte) 0xF8, (byte) 0xFF,
+                            (byte) 0x3F, (byte) 0x00, (byte) 0x05, (byte) 0x1A, (byte) 0x02, (byte) 0xB1, (byte) 0x49, (byte) 0xC5,
+                            (byte) 0x4C, (byte) 0x37, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x49, (byte) 0x45,
+                            (byte) 0x4E, (byte) 0x44, (byte) 0xAE, (byte) 0x42, (byte) 0x60, (byte) 0x82,
+                        0x35, // composite length for second chip
+                            0x01, 0x03, 0x70, 0x6e, 0x67, // Tag 1 - image type
+                            0x02, 46, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3A, 0x2F, 0x2F, 0x77, 0x77, 0x77, 0x2E, 0x67, 0x77, 0x67, 0x2E, 0x6E, 0x67, 0x61, 0x2E, 0x6D, 0x69, 0x6C, 0x2F, 0x6D, 0x69, 0x73, 0x62, 0x2F, 0x69, 0x6D, 0x61, 0x67, 0x65, 0x73, 0x2F, 0x62, 0x61, 0x6E, 0x6E, 0x65, 0x72, 0x2E, 0x6A, 0x70, 0x67, // Tag 2 - URI
+            0x66, 0x39, // Algorithm Series key + length
+                ((1 + 1 + 1) + (1 + 1 + 0x14) + (1 + 1 + 4) + (1 + 1 + 7) + (1 + 1 + 1)), // Length of Algorithm entry 1
+                    0x01, 0x01, 0x09,
+                    0x02, 0x14, 0x6B, 0x36, 0x5F, 0x79, 0x6F, 0x6C, 0x6F, 0x5F, 0x39, 0x30, 0x30, 0x30, 0x5F, 0x74, 0x72, 0x61, 0x63, 0x6B, 0x65, 0x72,
+                    0x03, 0x04, 0x32, 0x2E, 0x36, 0x61,
+                    0x04, 0x07, 0x6B, 0x61, 0x6C, 0x6D, 0x61, 0x6E, 0x6E,
+                    0x05, 0x01, 0x0A,
+                0x0C, // Length of Algorithm entry 2
+                    0x01, 0x01, 0x2B,
+                    0x02, 0x07, 0x6f, 0x70, 0x65, 0x6e, 0x63, 0x76, 0x32,
+            0x67, 0x5F, 
+                83, // Length of Ontology entry 1
+                    0x03, 71,
+                        0x68, 0x74, 0x74, 0x70, 0x73, 0x3A, 0x2F, 0x2F,
+                        0x72, 0x61, 0x77, 0x2E, 0x67, 0x69, 0x74, 0x68,
+                        0x75, 0x62, 0x75, 0x73, 0x65, 0x72, 0x63, 0x6F,
+                        0x6E, 0x74, 0x65, 0x6E, 0x74, 0x2E, 0x63, 0x6F,
+                        0x6D, 0x2F, 0x6F, 0x77, 0x6C, 0x63, 0x73, 0x2F,
+                        0x70, 0x69, 0x7A, 0x7A, 0x61, 0x2D, 0x6F, 0x6E,
+                        0x74, 0x6F, 0x6C, 0x6F, 0x67, 0x79, 0x2F, 0x6D,
+                        0x61, 0x73, 0x74, 0x65, 0x72, 0x2F, 0x70, 0x69,
+                        0x7A, 0x7A, 0x61, 0x2E, 0x6F, 0x77, 0x6C,
+                    0x04, 0x08, 0x4D, 0x75, 0x73, 0x68, 0x72, 0x6F, 0x6F, 0x6D,
+                10, // Length of Ontology entry 2
+                    0x04, 0x08, 0x41, 0x6d, 0x65, 0x72, 0x69, 0x63, 0x61, 0x6e,
+            0x01, 0x02, (byte)0x1d, (byte)0xf5 // checksum
+        };
+        VmtiLocalSet localSet = new VmtiLocalSet(bytes);
+        assertNotNull(localSet);
+        assertEquals(localSet.getTags().size(), 15);
+        assertEquals(localSet.getField(VmtiMetadataKey.PrecisionTimeStamp).getDisplayName(), "Precision Time Stamp");
+        assertEquals(localSet.getField(VmtiMetadataKey.PrecisionTimeStamp).getDisplayableValue(), "987654321000000");
+        assertEquals(localSet.getField(VmtiMetadataKey.VersionNumber).getDisplayName(), "Version Number");
+        assertEquals(localSet.getField(VmtiMetadataKey.VersionNumber).getDisplayableValue(), "ST0903.5");
+        assertEquals(localSet.getField(VmtiMetadataKey.SystemName).getDisplayName(), "System Name/Description");
+        assertEquals(localSet.getField(VmtiMetadataKey.SystemName).getDisplayableValue(), "DSTO_ADSS_VMTI");
+        assertEquals(localSet.getField(VmtiMetadataKey.TotalTargetsInFrame).getDisplayName(), "Targets In Frame");
+        assertEquals(localSet.getField(VmtiMetadataKey.TotalTargetsInFrame).getDisplayableValue(), "28");
+        assertEquals(localSet.getField(VmtiMetadataKey.NumberOfReportedTargets).getDisplayName(), "Reported Targets");
+        assertEquals(localSet.getField(VmtiMetadataKey.NumberOfReportedTargets).getDisplayableValue(), "2");
+        assertEquals(localSet.getField(VmtiMetadataKey.FrameNumber).getDisplayName(), "Frame Number");
+        assertEquals(localSet.getField(VmtiMetadataKey.FrameNumber).getDisplayableValue(), "78000");
+        assertEquals(localSet.getField(VmtiMetadataKey.FrameWidth).getDisplayName(), "Frame Width");
+        assertEquals(localSet.getField(VmtiMetadataKey.FrameWidth).getDisplayableValue(), "1920px");
+        assertEquals(localSet.getField(VmtiMetadataKey.FrameHeight).getDisplayName(), "Frame Height");
+        assertEquals(localSet.getField(VmtiMetadataKey.FrameHeight).getDisplayableValue(), "1080px");
+        assertEquals(localSet.getField(VmtiMetadataKey.SourceSensor).getDisplayName(), "Source Sensor");
+        assertEquals(localSet.getField(VmtiMetadataKey.SourceSensor).getDisplayableValue(), "EO Nose");
+        assertEquals(localSet.getField(VmtiMetadataKey.HorizontalFieldOfView).getDisplayName(), "Horizontal Field of View");
+        assertEquals(localSet.getField(VmtiMetadataKey.HorizontalFieldOfView).getDisplayableValue(), "12.5\u00B0");
+        assertEquals(localSet.getField(VmtiMetadataKey.VerticalFieldOfView).getDisplayName(), "Vertical Field of View");
+        assertEquals(localSet.getField(VmtiMetadataKey.VerticalFieldOfView).getDisplayableValue(), "10.0\u00B0");
+        assertEquals(localSet.getField(VmtiMetadataKey.MiisId).getDisplayName(), "MIIS Core Identifier");
+        assertEquals(localSet.getField(VmtiMetadataKey.MiisId).getDisplayableValue(), "0168:F354-666E-D552-4C0D-9168-A745-4CEB-A073/840A-4799-BBC0-4BD5-97A7-56F6-4092-AF7B:AA");
+        assertEquals(localSet.getField(VmtiMetadataKey.VTargetSeries).getDisplayName(), "Target Series");
+        assertTrue(localSet.getField(VmtiMetadataKey.VTargetSeries) instanceof VTargetSeries);
+        VTargetSeries targetSeries = (VTargetSeries)localSet.getField(VmtiMetadataKey.VTargetSeries);
+        assertEquals(targetSeries.getVTargets().size(), 2);
+        VTargetPack targetPack1 = targetSeries.getVTargets().get(0);
+        assertEquals(targetPack1.getTargetIdentifier(), 1);
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetCentroid).getDisplayName(), "Target Centroid");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetCentroid).getDisplayableValue(), "409600");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetPriority).getDisplayName(), "Target Priority");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetPriority).getDisplayableValue(), "27");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetConfidenceLevel).getDisplayName(), "Target Confidence");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetConfidenceLevel).getDisplayableValue(), "80%");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetHistory).getDisplayName(), "Target History");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetHistory).getDisplayableValue(), "2765");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.PercentageOfTargetPixels).getDisplayName(), "Percentage Target Pixels");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.PercentageOfTargetPixels).getDisplayableValue(), "50%");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetColor).getDisplayName(), "Target Color");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetColor).getDisplayableValue(), "[218, 165, 32]");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetHAE).getDisplayName(), "Target HAE");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetHAE).getDisplayableValue(), "10000.0");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetLocation).getDisplayName(), "Target Location");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.TargetLocation).getDisplayableValue(), "[Location]");
+        assertTrue(targetPack1.getField(VTargetMetadataKey.TargetLocation) instanceof TargetLocation);
+        TargetLocation targetLocation = (TargetLocation)targetPack1.getField(VTargetMetadataKey.TargetLocation);
+        assertEquals(targetLocation.getDisplayableValue(), "[Location]");
+        assertEquals(targetLocation.getTargetLocation().getLat(), -10.5423886331461, 0.0001);
+        assertEquals(targetLocation.getTargetLocation().getLon(), 29.157890122923, 0.0001);
+        assertEquals(targetLocation.getTargetLocation().getHae(), 3216.0, 0.02);
+        assertEquals(targetPack1.getField(VTargetMetadataKey.CentroidPixRow).getDisplayName(), "Centroid Pixel Row");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.CentroidPixRow).getDisplayableValue(), "872");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.CentroidPixColumn).getDisplayName(), "Centroid Pixel Column");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.CentroidPixColumn).getDisplayableValue(), "1137");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.FPAIndex).getDisplayName(), "FPA Index");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.FPAIndex).getDisplayableValue(), "Row 2, Col 3");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.AlgorithmId).getDisplayName(), "Algorithm Id");
+        assertEquals(targetPack1.getField(VTargetMetadataKey.AlgorithmId).getDisplayableValue(), "43");
+        assertTrue(targetPack1.getField(VTargetMetadataKey.VMask) instanceof VMask);
+        VMask tp1mask = (VMask)targetPack1.getField(VTargetMetadataKey.VMask);
+        assertEquals(tp1mask.getMask().getTags().size(), 2);
+        VMaskLSTest.checkPolygonExample(tp1mask.getMask());
+        VMaskLSTest.checkBitmaskExample(tp1mask.getMask());
+        assertTrue(targetPack1.getField(VTargetMetadataKey.VObject) instanceof VObject);
+        VObject tp1object = (VObject)targetPack1.getField(VTargetMetadataKey.VObject);
+        assertEquals(tp1object.getVObject().getTags().size(), 4);
+        VObjectLSTest.checkOntologyExample(tp1object.getVObject());
+        VObjectLSTest.checkOntologyClassExample(tp1object.getVObject());
+        VObjectLSTest.checkOntologyIdExample(tp1object.getVObject());
+        VObjectLSTest.checkOntologyExample(tp1object.getVObject());
+        assertTrue(targetPack1.getField(VTargetMetadataKey.VFeature) instanceof VFeature);
+        VFeature tp1feature = (VFeature)targetPack1.getField(VTargetMetadataKey.VFeature);
+        VFeatureLSTest.checkSchemaExample(tp1feature.getFeature());
+        VFeatureLSTest.checkSchemaFeatureExample(tp1feature.getFeature());
+        assertTrue(targetPack1.getField(VTargetMetadataKey.VTracker) instanceof VTracker);
+        VTracker tp1tracker = (VTracker)targetPack1.getField(VTargetMetadataKey.VTracker);
+        assertEquals(tp1tracker.getTracker().getTags().size(), 3);
+        assertEquals(tp1tracker.getTracker().getField(VTrackerMetadataKey.detectionStatus).getDisplayName(), "Detection Status");
+        assertEquals(tp1tracker.getTracker().getField(VTrackerMetadataKey.detectionStatus).getDisplayableValue(), "Active");
+        assertEquals(tp1tracker.getTracker().getField(VTrackerMetadataKey.confidence).getDisplayName(), "Track Confidence");
+        assertEquals(tp1tracker.getTracker().getField(VTrackerMetadataKey.confidence).getDisplayableValue(), "50%");
+        assertEquals(tp1tracker.getTracker().getField(VTrackerMetadataKey.algorithmId).getDisplayName(), "Algorithm Id");
+        assertEquals(tp1tracker.getTracker().getField(VTrackerMetadataKey.algorithmId).getDisplayableValue(), "9");
+        assertTrue(targetPack1.getField(VTargetMetadataKey.VChip) instanceof VChip);
+        VChip targetPack1Chip = (VChip)targetPack1.getField(VTargetMetadataKey.VChip);
+        assertEquals(targetPack1Chip.getChip().getField(VChipMetadataKey.imageType).getDisplayName(), "Image Type");
+        assertEquals(targetPack1Chip.getChip().getField(VChipMetadataKey.imageType).getDisplayableValue(), "jpeg");
+        assertEquals(targetPack1Chip.getChip().getField(VChipMetadataKey.embeddedImage).getDisplayName(), "Embedded Image");
+        assertEquals(targetPack1Chip.getChip().getField(VChipMetadataKey.embeddedImage).getDisplayableValue(), "[Image]");
+        assertEquals(targetPack1Chip.getChip().getField(VChipMetadataKey.embeddedImage).getBytes().length, 70);
+        VTargetPack targetPack3 = targetSeries.getVTargets().get(1);
+        assertEquals(targetPack3.getTargetIdentifier(), 3);
+        assertEquals(targetPack3.getField(VTargetMetadataKey.BoundaryTopLeft).getDisplayName(), "Boundary Top Left");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.BoundaryTopLeft).getDisplayableValue(), "409600");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.BoundaryBottomRight).getDisplayName(), "Boundary Bottom Right");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.BoundaryBottomRight).getDisplayableValue(), "428810");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.TargetPriority).getDisplayName(), "Target Priority");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.TargetPriority).getDisplayableValue(), "3");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.PercentageOfTargetPixels).getDisplayName(), "Percentage Target Pixels");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.PercentageOfTargetPixels).getDisplayableValue(), "6%");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.TargetIntensity).getDisplayName(), "Target Intensity");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.TargetIntensity).getDisplayableValue(), "13140");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.AlgorithmId).getDisplayName(), "Algorithm Id");
+        assertEquals(targetPack3.getField(VTargetMetadataKey.AlgorithmId).getDisplayableValue(), "9");
+        assertTrue(targetPack3.getField(VTargetMetadataKey.VChipSeries) instanceof VChipSeries);
+        VChipSeries targetPack3ChipSeries = (VChipSeries)targetPack3.getField(VTargetMetadataKey.VChipSeries);
+        assertEquals(targetPack3ChipSeries.getChips().size(), 2);
+        VChipLS chip3_0 = targetPack3ChipSeries.getChips().get(0);
+        assertEquals(chip3_0.getField(VChipMetadataKey.imageType).getDisplayName(), "Image Type");
+        assertEquals(chip3_0.getField(VChipMetadataKey.imageType).getDisplayableValue(), "jpeg");
+        assertEquals(chip3_0.getField(VChipMetadataKey.embeddedImage).getDisplayName(), "Embedded Image");
+        assertEquals(chip3_0.getField(VChipMetadataKey.embeddedImage).getDisplayableValue(), "[Image]");
+        assertEquals(chip3_0.getField(VChipMetadataKey.embeddedImage).getBytes().length, 70);
+        VChipLS chip3_1 = targetPack3ChipSeries.getChips().get(1);
+        assertEquals(chip3_1.getField(VChipMetadataKey.imageType).getDisplayName(), "Image Type");
+        assertEquals(chip3_1.getField(VChipMetadataKey.imageType).getDisplayableValue(), "png");
+        assertEquals(chip3_1.getField(VChipMetadataKey.imageUri).getDisplayName(), "Image URI");
+        assertEquals(chip3_1.getField(VChipMetadataKey.imageUri).getDisplayableValue(), "https://www.gwg.nga.mil/misb/images/banner.jpg");
+
+        VObjectSeries vobjectSeries = (VObjectSeries)targetPack1.getField(VTargetMetadataKey.VObjectSeries);
+        assertEquals(vobjectSeries.getVObjects().size(), 2);
+        VObjectLS vobject1 = vobjectSeries.getVObjects().get(0);
+        assertEquals(vobject1.getField(VObjectMetadataKey.ontology).getDisplayName(), "Ontology");
+        assertEquals(vobject1.getField(VObjectMetadataKey.ontology).getDisplayableValue(), "https://raw.githubusercontent.com/owlcs/pizza-ontology/master/pizza.owl");
+        assertEquals(vobject1.getField(VObjectMetadataKey.ontologyClass).getDisplayName(), "Ontology Class");
+        assertEquals(vobject1.getField(VObjectMetadataKey.ontologyClass).getDisplayableValue(), "Mushroom");
+        VObjectLS vobject2 = vobjectSeries.getVObjects().get(1);
+        assertEquals(vobject2.getField(VObjectMetadataKey.ontologyClass).getDisplayName(), "Ontology Class");
+        assertEquals(vobject2.getField(VObjectMetadataKey.ontologyClass).getDisplayableValue(), "test");
+
+        AlgorithmSeries algorithmSeries = (AlgorithmSeries)localSet.getField(VmtiMetadataKey.AlgorithmSeries);
+        assertEquals(algorithmSeries.getAlgorithms().size(), 2);
+        AlgorithmLS algorithm1 = algorithmSeries.getAlgorithms().get(0);
+        assertEquals(algorithm1.getField(AlgorithmMetadataKey.id).getDisplayName(), "Algorithm Id");
+        assertEquals(algorithm1.getField(AlgorithmMetadataKey.id).getDisplayableValue(), "9");
+        assertEquals(algorithm1.getField(AlgorithmMetadataKey.name).getDisplayName(), "Algorithm Name");
+        assertEquals(algorithm1.getField(AlgorithmMetadataKey.name).getDisplayableValue(), "k6_yolo_9000_tracker");
+        assertEquals(algorithm1.getField(AlgorithmMetadataKey.version).getDisplayName(), "Algorithm Version");
+        assertEquals(algorithm1.getField(AlgorithmMetadataKey.version).getDisplayableValue(), "2.6a");
+        assertEquals(algorithm1.getField(AlgorithmMetadataKey.algorithmClass).getDisplayName(), "Algorithm Class");
+        assertEquals(algorithm1.getField(AlgorithmMetadataKey.algorithmClass).getDisplayableValue(), "kalmann");
+        assertEquals(algorithm1.getField(AlgorithmMetadataKey.nFrames).getDisplayName(), "Number of Frames");
+        assertEquals(algorithm1.getField(AlgorithmMetadataKey.nFrames).getDisplayableValue(), "10");
+        AlgorithmLS algorithm2 = algorithmSeries.getAlgorithms().get(1);
+        assertEquals(algorithm2.getField(AlgorithmMetadataKey.id).getDisplayName(), "Algorithm Id");
+        assertEquals(algorithm2.getField(AlgorithmMetadataKey.id).getDisplayableValue(), "43");
+        assertEquals(algorithm2.getField(AlgorithmMetadataKey.name).getDisplayName(), "Algorithm Name");
+        assertEquals(algorithm2.getField(AlgorithmMetadataKey.name).getDisplayableValue(), "opencv2");
+
+        OntologySeries ontologySeries = (OntologySeries)localSet.getField(VmtiMetadataKey.OntologySeries);
+        assertEquals(ontologySeries.getOntologies().size(), 2);
+        OntologyLS ontology1 = ontologySeries.getOntologies().get(0);
+        assertEquals(ontology1.getTags().size(), 2);
+        assertEquals(ontology1.getField(OntologyMetadataKey.ontology).getDisplayName(), "Ontology");
+        assertEquals(ontology1.getField(OntologyMetadataKey.ontology).getDisplayableValue(), "https://raw.githubusercontent.com/owlcs/pizza-ontology/master/pizza.owl");
+        assertEquals(ontology1.getField(OntologyMetadataKey.ontologyClass).getDisplayName(), "Ontology Class");
+        assertEquals(ontology1.getField(OntologyMetadataKey.ontologyClass).getDisplayableValue(), "Mushroom");
+
+        OntologyLS ontology2 = ontologySeries.getOntologies().get(1);
+        assertEquals(ontology2.getTags().size(), 1);
+        assertEquals(ontology2.getField(OntologyMetadataKey.ontologyClass).getDisplayName(), "Ontology Class");
+        assertEquals(ontology2.getField(OntologyMetadataKey.ontologyClass).getDisplayableValue(), "American");
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLSTest.java
@@ -24,7 +24,7 @@ public class AlgorithmLSTest extends LoggerChecks
     public void parseTag1() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x01, 0x03, 0x01, 0x03, (byte)0x98};
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, 0, bytes.length);
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 1);
         checkIdExample(algorithmLS);
@@ -34,7 +34,7 @@ public class AlgorithmLSTest extends LoggerChecks
     public void parseTag2() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x02, 0x14, 0x6B, 0x36, 0x5F, 0x79, 0x6F, 0x6C, 0x6F, 0x5F, 0x39, 0x30, 0x30, 0x30, 0x5F, 0x74, 0x72, 0x61, 0x63, 0x6B, 0x65, 0x72};
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, 0, bytes.length);
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 1);
         checkNameExample(algorithmLS);
@@ -44,7 +44,7 @@ public class AlgorithmLSTest extends LoggerChecks
     public void parseTag3() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x03, 0x04, 0x32, 0x2E, 0x36, 0x61};
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, 0, bytes.length);
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 1);
         checkVersionExample(algorithmLS);
@@ -54,7 +54,7 @@ public class AlgorithmLSTest extends LoggerChecks
     public void parseTag4() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x04, 0x07, 0x6B, 0x61, 0x6C, 0x6D, 0x61, 0x6E, 0x6E};
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, 0, bytes.length);
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 1);
         checkClassExample(algorithmLS);
@@ -64,7 +64,7 @@ public class AlgorithmLSTest extends LoggerChecks
     public void parseTag5() throws KlvParseException
     {
         final byte[] bytes = new byte[]{0x05, 0x01, 0x0A};
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, 0, bytes.length);
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 1);
         checkNumFramesExample(algorithmLS);
@@ -81,7 +81,7 @@ public class AlgorithmLSTest extends LoggerChecks
             0x04, 0x07, 0x6B, 0x61, 0x6C, 0x6D, 0x61, 0x6E, 0x6E,
             0x05, 0x01, 0x0A};
         verifyNoLoggerMessages();
-        AlgorithmLS algorithmLS = new AlgorithmLS(bytes);
+        AlgorithmLS algorithmLS = new AlgorithmLS(bytes, 0, bytes.length);
         this.verifySingleLoggerMessage("Unknown VMTI Algorithm Metadata tag: 6");
         assertNotNull(algorithmLS);
         assertEquals(algorithmLS.getTags().size(), 5);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/ontology/OntologyLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/ontology/OntologyLSTest.java
@@ -28,7 +28,7 @@ public class OntologyLSTest extends LoggerChecks
         final byte[] bytes = new byte[] {
             0x01, 0x02, 0x01, 0x02
         };
-        OntologyLS ontologyLS = new OntologyLS(bytes);
+        OntologyLS ontologyLS = new OntologyLS(bytes, 0, bytes.length);
         assertNotNull(ontologyLS);
         assertEquals(ontologyLS.getTags().size(), 1);
         checkIdExample(ontologyLS);
@@ -40,7 +40,7 @@ public class OntologyLSTest extends LoggerChecks
         final byte[] bytes = new byte[] {
             0x02, 0x01, 0x0a
         };
-        OntologyLS ontologyLS = new OntologyLS(bytes);
+        OntologyLS ontologyLS = new OntologyLS(bytes, 0, bytes.length);
         assertNotNull(ontologyLS);
         assertEquals(ontologyLS.getTags().size(), 1);
         checkParentIdExample(ontologyLS);
@@ -61,7 +61,7 @@ public class OntologyLSTest extends LoggerChecks
             0x61, 0x73, 0x74, 0x65, 0x72, 0x2F, 0x70, 0x69,
             0x7A, 0x7A, 0x61, 0x2E, 0x6F, 0x77, 0x6C
         };
-        OntologyLS ontologyLS = new OntologyLS(bytes);
+        OntologyLS ontologyLS = new OntologyLS(bytes, 0, bytes.length);
         assertNotNull(ontologyLS);
         assertEquals(ontologyLS.getTags().size(), 1);
         checkOntologyExample(ontologyLS);
@@ -71,7 +71,7 @@ public class OntologyLSTest extends LoggerChecks
     public void parseTag4() throws KlvParseException, URISyntaxException
     {
         final byte[] bytes = new byte[]{0x04, 0x08, 0x4D, 0x75, 0x73, 0x68, 0x72, 0x6F, 0x6F, 0x6D};
-        OntologyLS ontologyLS = new OntologyLS(bytes);
+        OntologyLS ontologyLS = new OntologyLS(bytes, 0, bytes.length);
         assertNotNull(ontologyLS);
         assertEquals(ontologyLS.getTags().size(), 1);
         checkOntologyClassExample(ontologyLS);
@@ -95,7 +95,7 @@ public class OntologyLSTest extends LoggerChecks
             0x04, 0x08,
             0x4D, 0x75, 0x73, 0x68, 0x72, 0x6F, 0x6F, 0x6D};
         verifyNoLoggerMessages();
-        OntologyLS ontologyLS = new OntologyLS(bytes);
+        OntologyLS ontologyLS = new OntologyLS(bytes, 0, bytes.length);
         this.verifySingleLoggerMessage("Unknown VMTI Ontology Metadata tag: 5");
         assertNotNull(ontologyLS);
         assertEquals(ontologyLS.getTags().size(), 2);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vchip/VChipLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vchip/VChipLSTest.java
@@ -25,7 +25,7 @@ public class VChipLSTest extends LoggerChecks
     public void parseTag1() throws KlvParseException
     {
         byte[] bytes = new byte[]{0x01, 0x04, 0x6A, 0x70, 0x65, 0x67};
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, 0, bytes.length);
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 1);
         checkImageTypeExample(vChipLS);
@@ -35,7 +35,7 @@ public class VChipLSTest extends LoggerChecks
     public void parseTag2() throws KlvParseException, URISyntaxException
     {
         final byte[] bytes = new byte[]{0x02, 46, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3A, 0x2F, 0x2F, 0x77, 0x77, 0x77, 0x2E, 0x67, 0x77, 0x67, 0x2E, 0x6E, 0x67, 0x61, 0x2E, 0x6D, 0x69, 0x6C, 0x2F, 0x6D, 0x69, 0x73, 0x62, 0x2F, 0x69, 0x6D, 0x61, 0x67, 0x65, 0x73, 0x2F, 0x62, 0x61, 0x6E, 0x6E, 0x65, 0x72, 0x2E, 0x6A, 0x70, 0x67};
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, 0, bytes.length);
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 1);
         checkImageUriExample(vChipLS);
@@ -56,7 +56,7 @@ public class VChipLSTest extends LoggerChecks
             (byte) 0x3F, (byte) 0x00, (byte) 0x05, (byte) 0x1A, (byte) 0x02, (byte) 0xB1, (byte) 0x49, (byte) 0xC5,
             (byte) 0x4C, (byte) 0x37, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x49, (byte) 0x45,
             (byte) 0x4E, (byte) 0x44, (byte) 0xAE, (byte) 0x42, (byte) 0x60, (byte) 0x82};
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, 0, bytes.length);
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 1);
         checkEmbeddedImageExample(vChipLS);
@@ -66,7 +66,7 @@ public class VChipLSTest extends LoggerChecks
     public void parseTag1andTag2() throws KlvParseException, URISyntaxException
     {
         final byte[] bytes = new byte[]{0x01, 0x04, 0x6A, 0x70, 0x65, 0x67, 0x02, 46, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3A, 0x2F, 0x2F, 0x77, 0x77, 0x77, 0x2E, 0x67, 0x77, 0x67, 0x2E, 0x6E, 0x67, 0x61, 0x2E, 0x6D, 0x69, 0x6C, 0x2F, 0x6D, 0x69, 0x73, 0x62, 0x2F, 0x69, 0x6D, 0x61, 0x67, 0x65, 0x73, 0x2F, 0x62, 0x61, 0x6E, 0x6E, 0x65, 0x72, 0x2E, 0x6A, 0x70, 0x67};
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, 0, bytes.length);
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 2);
         checkImageTypeExample(vChipLS);
@@ -89,7 +89,7 @@ public class VChipLSTest extends LoggerChecks
             (byte) 0x3F, (byte) 0x00, (byte) 0x05, (byte) 0x1A, (byte) 0x02, (byte) 0xB1, (byte) 0x49, (byte) 0xC5,
             (byte) 0x4C, (byte) 0x37, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x49, (byte) 0x45,
             (byte) 0x4E, (byte) 0x44, (byte) 0xAE, (byte) 0x42, (byte) 0x60, (byte) 0x82};
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, 0, bytes.length);
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 2);
         checkImageTypeExample(vChipLS);
@@ -114,7 +114,7 @@ public class VChipLSTest extends LoggerChecks
             (byte) 0x4C, (byte) 0x37, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x49, (byte) 0x45,
             (byte) 0x4E, (byte) 0x44, (byte) 0xAE, (byte) 0x42, (byte) 0x60, (byte) 0x82};
         verifyNoLoggerMessages();
-        VChipLS vChipLS = new VChipLS(bytes);
+        VChipLS vChipLS = new VChipLS(bytes, 0, bytes.length);
         verifySingleLoggerMessage("Unknown VMTI VChip Metadata tag: 4");
         assertNotNull(vChipLS);
         assertEquals(vChipLS.getTags().size(), 2);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vfeature/VFeatureLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vfeature/VFeatureLSTest.java
@@ -9,7 +9,6 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.shared.VmtiUri;
-import org.testng.Assert;
 import static org.testng.Assert.*;
 import org.testng.annotations.Test;
 
@@ -158,7 +157,7 @@ public class VFeatureLSTest extends LoggerChecks
         checkSchemaFeatureExample(localSet);
     }
 
-    public void checkSchemaExample(VFeatureLS localSet) throws URISyntaxException
+    public static void checkSchemaExample(VFeatureLS localSet) throws URISyntaxException
     {
         final String stringVal = "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
         assertTrue(localSet.getTags().contains(VFeatureMetadataKey.schema));
@@ -171,7 +170,7 @@ public class VFeatureLSTest extends LoggerChecks
         assertEquals(text.getUri().toString(), stringVal);
     }
 
-    public void checkSchemaFeatureExample(VFeatureLS localSet) throws URISyntaxException
+    public static void checkSchemaFeatureExample(VFeatureLS localSet) throws URISyntaxException
     {
         final String stringVal = "<gml:DataBlock><gml:rangeParameters><gml:CompositeValue><gml:valueComponents><Temperature uom=\"urn:x-si:v1999:uom:degreesC\">template</Temperature><Pressure uom=\"urn:x-si:v1999:uom:kPa\">template</Pressure></gml:valueComponents></gml:CompositeValue></gml:rangeParameters><gml:tupleList>3,101.2</gml:tupleList></gml:DataBlock>";
         assertTrue(localSet.getTags().contains(VFeatureMetadataKey.schemaFeature));

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vobject/VObjectLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vobject/VObjectLSTest.java
@@ -71,7 +71,7 @@ public class VObjectLSTest extends LoggerChecks
     @Test
     public void parseTag1() throws KlvParseException, URISyntaxException
     {
-        VObjectLS vObjectLS = new VObjectLS(ontologyBytes);
+        VObjectLS vObjectLS = new VObjectLS(ontologyBytes, 0, ontologyBytes.length);
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 1);
         checkOntologyExample(vObjectLS);
@@ -80,7 +80,7 @@ public class VObjectLSTest extends LoggerChecks
     @Test
     public void parseTag2() throws KlvParseException
     {
-        VObjectLS vObjectLS = new VObjectLS(ontologyClassBytes);
+        VObjectLS vObjectLS = new VObjectLS(ontologyClassBytes, 0, ontologyClassBytes.length);
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 1);
         checkOntologyClassExample(vObjectLS);
@@ -89,7 +89,7 @@ public class VObjectLSTest extends LoggerChecks
     @Test
     public void parseTag3() throws KlvParseException
     {
-        VObjectLS vObjectLS = new VObjectLS(ontologyIdBytes);
+        VObjectLS vObjectLS = new VObjectLS(ontologyIdBytes, 0, ontologyIdBytes.length);
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 1);
         checkOntologyIdExample(vObjectLS);
@@ -98,7 +98,7 @@ public class VObjectLSTest extends LoggerChecks
     @Test
     public void parseTag4() throws KlvParseException
     {
-        VObjectLS vObjectLS = new VObjectLS(confidenceBytes);
+        VObjectLS vObjectLS = new VObjectLS(confidenceBytes, 0, confidenceBytes.length);
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 1);
         checkConfidenceExample(vObjectLS);
@@ -107,7 +107,7 @@ public class VObjectLSTest extends LoggerChecks
     @Test
     public void parseMerged() throws KlvParseException, URISyntaxException
     {
-        VObjectLS vObjectLS = new VObjectLS(mergedBytes);
+        VObjectLS vObjectLS = new VObjectLS(mergedBytes, 0, mergedBytes.length);
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 4);
         checkOntologyExample(vObjectLS);
@@ -137,7 +137,7 @@ public class VObjectLSTest extends LoggerChecks
             0x01, 0x02
         };
         verifyNoLoggerMessages();
-        VObjectLS vObjectLS = new VObjectLS(bytes);
+        VObjectLS vObjectLS = new VObjectLS(bytes, 0, bytes.length);
         verifySingleLoggerMessage("Unknown VMTI VObject Metadata tag: 5");
         assertNotNull(vObjectLS);
         assertEquals(vObjectLS.getTags().size(), 3);
@@ -146,7 +146,7 @@ public class VObjectLSTest extends LoggerChecks
         checkOntologyIdExample(vObjectLS);
     }
 
-    private void checkOntologyExample(VObjectLS vObjectLS) throws URISyntaxException
+    public static void checkOntologyExample(VObjectLS vObjectLS) throws URISyntaxException
     {
         final String stringVal = "https://raw.githubusercontent.com/owlcs/pizza-ontology/master/pizza.owl";
         assertTrue(vObjectLS.getTags().contains(VObjectMetadataKey.ontology));
@@ -159,7 +159,7 @@ public class VObjectLSTest extends LoggerChecks
         assertEquals(uri.getUri().toString(), stringVal);
     }
 
-    private void checkOntologyClassExample(VObjectLS vObjectLS)
+    public static void checkOntologyClassExample(VObjectLS vObjectLS)
     {
         assertTrue(vObjectLS.getTags().contains(VObjectMetadataKey.ontologyClass));
         IVmtiMetadataValue v = vObjectLS.getField(VObjectMetadataKey.ontologyClass);
@@ -171,7 +171,7 @@ public class VObjectLSTest extends LoggerChecks
         assertEquals(textString.getValue(), "Mushroom");
     }
 
-    private void checkOntologyIdExample(VObjectLS vObjectLS)
+    public static void checkOntologyIdExample(VObjectLS vObjectLS)
     {
         assertTrue(vObjectLS.getTags().contains(VObjectMetadataKey.ontologyId));
         IVmtiMetadataValue v = vObjectLS.getField(VObjectMetadataKey.ontologyId);
@@ -182,7 +182,7 @@ public class VObjectLSTest extends LoggerChecks
         assertEquals(id.getValue(), 258);
     }
 
-    private void checkConfidenceExample(VObjectLS vObjectLS)
+    public static void checkConfidenceExample(VObjectLS vObjectLS)
     {
         assertTrue(vObjectLS.getTags().contains(VObjectMetadataKey.confidence));
         IVmtiMetadataValue v = vObjectLS.getField(VObjectMetadataKey.confidence);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VMaskTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VMaskTest.java
@@ -51,7 +51,7 @@ public class VMaskTest {
         });
         assertEquals(mask.getDisplayName(), "Target Pixel Mask");
         assertEquals(mask.getDisplayableValue(), "[VMask]");
-        VMaskLS feature = mask.getFeature();
+        VMaskLS feature = mask.getMask();
         VMaskLSTest.checkPolygonExample(feature);
         VMaskLSTest.checkBitmaskExample(feature);
     }
@@ -87,7 +87,7 @@ public class VMaskTest {
         assertEquals(mask.getDisplayableValue(), "[VMask]");
         assertEquals(mask.getDisplayName(), "Target Pixel Mask");
         assertEquals(mask.getDisplayableValue(), "[VMask]");
-        VMaskLS feature = mask.getFeature();
+        VMaskLS feature = mask.getMask();
         VMaskLSTest.checkPolygonExample(feature);
         VMaskLSTest.checkBitmaskExample(feature);
     }
@@ -125,7 +125,7 @@ public class VMaskTest {
         assertEquals(mask.getDisplayableValue(), "[VMask]");
         assertEquals(mask.getDisplayName(), "Target Pixel Mask");
         assertEquals(mask.getDisplayableValue(), "[VMask]");
-        VMaskLS feature = mask.getFeature();
+        VMaskLS feature = mask.getMask();
         VMaskLSTest.checkPolygonExample(feature);
         VMaskLSTest.checkBitmaskExample(feature);
     }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTargetPackTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTargetPackTest.java
@@ -33,7 +33,7 @@ public class VTargetPackTest extends LoggerChecks
             0x01, // Target Id
             0x16, 0x03, 0x01, 0x03, (byte)0x98 // Tag 22 - Algorithm Id.
         };
-        VTargetPack localSet = new VTargetPack(bytes);
+        VTargetPack localSet = new VTargetPack(bytes, 0, bytes.length);
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);
         assertTrue(localSet.getTags().contains(VTargetMetadataKey.AlgorithmId));
@@ -55,7 +55,7 @@ public class VTargetPackTest extends LoggerChecks
             0x16, 0x03, 0x01, 0x03, (byte)0x98 // Tag 22 - Algorithm Id.
         };
         verifyNoLoggerMessages();
-        VTargetPack localSet = new VTargetPack(bytes);
+        VTargetPack localSet = new VTargetPack(bytes, 0, bytes.length);
         verifySingleLoggerMessage("Unknown VMTI VTarget Metadata tag: 55");
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);


### PR DESCRIPTION
## Motivation and Context
The ST0903 implementation had some "TODO" items to avoid doing unnecessary array copies. This fixes those.
Along the way, I found a few bugs. In particular, I was treating the length as BER-OID encoded, which is wrong. That affected one place in ST0601 too, for the wavelength list. 

## Description
I hand-crafted a large VTMI byte array, and that is the main test I used. The arrays are no longer copied - we just take an offset and length. Some places didn't have any copies involved, so those just got the TODO comment removed.
Because the API changes, I had to update tests.

## How Has This Been Tested?
Just unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Coverage decreases slightly as a percentage, because there is less code to run.
