### PR TITLE
st0601: switch version to be short.

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/ST0601Version.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ST0601Version.java
@@ -1,7 +1,9 @@
 package org.jmisb.api.klv.st0601;
 
+import org.jmisb.core.klv.PrimitiveConverter;
+
 /**
- * UAS Datalink LS Version Number (ST 0601 tag 65)
+ * UAS Datalink LS Version Number (ST 0601 tag 65).
  * <p>
  * From ST:
  * <blockquote>
@@ -11,19 +13,23 @@ package org.jmisb.api.klv.st0601;
  */
 public class ST0601Version implements IUasDatalinkValue
 {
-    private byte version;
+    private short version;
 
     /**
-     * Create from value
-     * @param version The version number
+     * Create from value.
+     * @param version The version number, in the range 0 to 255.
      */
-    public ST0601Version(byte version)
+    public ST0601Version(short version)
     {
+        if ((version < 0) || (version > 255))
+        {
+            throw new IllegalArgumentException("Version Number valid range is [0,255]");
+        }
         this.version = version;
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      * @param bytes Byte array of length 1
      */
     public ST0601Version(byte[] bytes)
@@ -32,14 +38,15 @@ public class ST0601Version implements IUasDatalinkValue
         {
             throw new IllegalArgumentException("Version Number encoding is a single unsigned byte");
         }
-        version = bytes[0];
+        version = (short)PrimitiveConverter.toUint8(bytes);
     }
 
     /**
-     * Get the version number
+     * Get the version number.
+     *
      * @return The version number
      */
-    public byte getVersion()
+    public short getVersion()
     {
         return version;
     }
@@ -47,13 +54,13 @@ public class ST0601Version implements IUasDatalinkValue
     @Override
     public byte[] getBytes()
     {
-        return new byte[]{version};
+        return PrimitiveConverter.uint8ToBytes(version);
     }
 
     @Override
     public String getDisplayableValue()
     {
-        return "" + (int)version;
+        return "" + version;
     }
 
     @Override

--- a/api/src/test/java/org/jmisb/api/klv/st0601/ST0601VersionTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/ST0601VersionTest.java
@@ -9,13 +9,19 @@ public class ST0601VersionTest {
     @Test
     public void testConstructFromValue() {
         // Min
-        ST0601Version version = new ST0601Version((byte) 0);
+        ST0601Version version = new ST0601Version((short) 0);
         Assert.assertEquals(version.getBytes(), new byte[]{(byte) 0x00});
-        Assert.assertEquals(version.getVersion(), (byte) 0);
+        Assert.assertEquals(version.getVersion(), 0);
         Assert.assertEquals(version.getDisplayableValue(), "0");
 
+        // Max
+        version = new ST0601Version((short)255);
+        Assert.assertEquals(version.getBytes(), new byte[]{(byte) 0xff});
+        Assert.assertEquals(version.getVersion(), 255);
+        Assert.assertEquals(version.getDisplayableValue(), "255");
+
         // ST example
-        version = new ST0601Version((byte) 13);
+        version = new ST0601Version((short)13);
         Assert.assertEquals(version.getBytes(), new byte[]{(byte) 0x0d});
         Assert.assertEquals(version.getVersion(), 13);
         Assert.assertEquals(version.getDisplayableValue(), "13");
@@ -26,7 +32,7 @@ public class ST0601VersionTest {
         // Min
         ST0601Version version = new ST0601Version(new byte[]{(byte) 0x00});
         Assert.assertEquals(version.getBytes(), new byte[]{(byte) 0x00});
-        Assert.assertEquals(version.getVersion(), (byte) 0);
+        Assert.assertEquals(version.getVersion(), 0);
         Assert.assertEquals(version.getDisplayableValue(), "0");
 
         byte[] bytes = new byte[]{0x00};
@@ -34,20 +40,19 @@ public class ST0601VersionTest {
         Assert.assertTrue(v instanceof ST0601Version);
         version = (ST0601Version)v;
         Assert.assertEquals(version.getBytes(), new byte[]{(byte) 0x00});
-        Assert.assertEquals(version.getVersion(), (byte) 0);
+        Assert.assertEquals(version.getVersion(), 0);
         Assert.assertEquals(version.getDisplayableValue(), "0");
-        
+
         // Max
         version = new ST0601Version(new byte[]{(byte) 0xff});
         Assert.assertEquals(version.getBytes(), new byte[]{(byte) 0xff});
-
 
         // ST example
         version = new ST0601Version(new byte[]{(byte) 0x0d});
         Assert.assertEquals(version.getBytes(), new byte[]{(byte) 0x0d});
         Assert.assertEquals(version.getVersion(), 13);
         Assert.assertEquals(version.getDisplayableValue(), "13");
-        
+
         bytes = new byte[]{0x0d};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.UasLdsVersionNumber, bytes);
         Assert.assertTrue(v instanceof ST0601Version);
@@ -62,5 +67,15 @@ public class ST0601VersionTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
         new ST0601Version(new byte[]{0x00, 0x00});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void tooSmall() {
+        new ST0601Version((short)-1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void tooLarge() {
+        new ST0601Version((short)256);
     }
 }


### PR DESCRIPTION
## Motivation and Context
Resolves #26.

## Description
Modifies the ST0601 LS Version (Tag 65) to be a short.

This is potentially an ABI break, but should be fine with a rebuild.


## How Has This Been Tested?
Ran unit tests. 
Also checked one of the MISB integration test examples in the viewer app.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

