### PR TITLE
Add end-of-file event listener

### DIFF
--- a/api/src/main/java/org/jmisb/api/video/DemuxReturnValue.java
+++ b/api/src/main/java/org/jmisb/api/video/DemuxReturnValue.java
@@ -1,0 +1,24 @@
+package org.jmisb.api.video;
+
+/**
+ * Return value enumeration for demux operation.
+ */
+enum DemuxReturnValue
+{
+    /**
+     * Operation succeeded.
+     */
+    SUCCESS,
+    /**
+     * End of file.
+     */
+    EOF,
+    /**
+     * Operation needs to be tried again
+     */
+    EAGAIN,
+    /**
+     * Some other failure.
+     */
+    ERROR
+}

--- a/api/src/main/java/org/jmisb/api/video/DemuxerUtils.java
+++ b/api/src/main/java/org/jmisb/api/video/DemuxerUtils.java
@@ -56,9 +56,9 @@ class DemuxerUtils
      *
      * @param avFormatContext The format context
      * @param packet The packet
-     * @return True if a packet was read, false otherwise
+     * @return return value corresponding to the read result
      */
-    static boolean readPacket(AVFormatContext avFormatContext, AVPacket packet)
+    static DemuxReturnValue readPacket(AVFormatContext avFormatContext, AVPacket packet)
     {
         int ret;
         if ((ret = av_read_frame(avFormatContext, packet)) < 0)
@@ -66,18 +66,18 @@ class DemuxerUtils
             if (ret == AVERROR_EOF)
             {
                 logger.debug("EOF packet received: " + FfmpegUtils.formatError(ret));
-                return false;
+                return DemuxReturnValue.EOF;
             } else if (ret != -11)
             {
                 logger.error("av_read_frame returned an error: " + FfmpegUtils.formatError(ret));
-                return false;
+                return DemuxReturnValue.ERROR;
             } else
             {
                 // AVERROR(EAGAIN) == -11, just need to wait a moment and try again
-                return false;
+                return DemuxReturnValue.EAGAIN;
             }
         }
-        return true;
+        return DemuxReturnValue.SUCCESS;
     }
 
     /**

--- a/api/src/main/java/org/jmisb/api/video/FileDemuxer.java
+++ b/api/src/main/java/org/jmisb/api/video/FileDemuxer.java
@@ -72,7 +72,13 @@ class FileDemuxer extends Demuxer
             }
 
             // Read a packet from the stream
-            if (!DemuxerUtils.readPacket(avFormatContext, packet))
+            DemuxReturnValue ret = DemuxerUtils.readPacket(avFormatContext, packet);
+            if (ret == DemuxReturnValue.EOF)
+            {
+                if (videoDecodeThread != null) videoDecodeThread.notifyEOF();
+                if (metadataDecodeThread != null) metadataDecodeThread.notifyEOF();
+            }
+            if (ret != DemuxReturnValue.SUCCESS)
             {
                 shortWait(10);
                 continue;

--- a/api/src/main/java/org/jmisb/api/video/IFileEventListener.java
+++ b/api/src/main/java/org/jmisb/api/video/IFileEventListener.java
@@ -1,0 +1,12 @@
+package org.jmisb.api.video;
+
+/**
+ * Interface for file event notifications.
+ */
+public interface IFileEventListener
+{
+    /**
+     * Notification that end-of-file has been reached.
+     */
+    void onEndOfFile();
+}

--- a/api/src/main/java/org/jmisb/api/video/IVideoFileInput.java
+++ b/api/src/main/java/org/jmisb/api/video/IVideoFileInput.java
@@ -63,4 +63,23 @@ public interface IVideoFileInput extends IVideoInput
      * @return The total number of video frames in the file
      */
     int getNumFrames();
+
+    /**
+     * Add a file event listener.
+     *
+     * @param listener Listener to add
+     */
+    void addFileEventListener(IFileEventListener listener);
+
+    /**
+     * Remove a file event listener.
+     *
+     * @param listener Listener to remove
+     */
+    void removeFileEventListener(IFileEventListener listener);
+
+    /**
+     * Notify consumers that end of file has been reached.
+     */
+    void notifyEOF();
 }

--- a/api/src/main/java/org/jmisb/api/video/MetadataDecodeThread.java
+++ b/api/src/main/java/org/jmisb/api/video/MetadataDecodeThread.java
@@ -140,4 +140,13 @@ class MetadataDecodeThread extends ProcessingThread
 
         avcodec_free_context(codecContext);
     }
+
+    public void notifyEOF()
+    {
+        if (inputStream instanceof IVideoFileInput)
+        {
+            IVideoFileInput fileInputStream = (IVideoFileInput)inputStream;
+            fileInputStream.notifyEOF();
+        }
+    }
 }

--- a/api/src/main/java/org/jmisb/api/video/StreamDemuxer.java
+++ b/api/src/main/java/org/jmisb/api/video/StreamDemuxer.java
@@ -34,7 +34,7 @@ class StreamDemuxer extends Demuxer
         while (!isShutdown())
         {
             // Read a packet from the stream
-            if (!DemuxerUtils.readPacket(avFormatContext, packet))
+            if (DemuxerUtils.readPacket(avFormatContext, packet) != DemuxReturnValue.SUCCESS)
             {
                 shortWait(10);
                 continue;

--- a/api/src/main/java/org/jmisb/api/video/VideoDecodeThread.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoDecodeThread.java
@@ -274,4 +274,13 @@ class VideoDecodeThread extends ProcessingThread
             nativeFrame = null;
         }
     }
+
+    public void notifyEOF()
+    {
+        if (inputStream instanceof IVideoFileInput)
+        {
+            IVideoFileInput fileInputStream = (IVideoFileInput)inputStream;
+            fileInputStream.notifyEOF();
+        }
+    }
 }

--- a/api/src/main/java/org/jmisb/api/video/VideoFileInput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoFileInput.java
@@ -9,6 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.bytedeco.ffmpeg.global.avcodec.avcodec_find_decoder;
 import static org.bytedeco.ffmpeg.global.avformat.AVSEEK_FLAG_BACKWARD;
@@ -29,6 +31,7 @@ public class VideoFileInput extends VideoInput implements IVideoFileInput
     private static final Logger logger = LoggerFactory.getLogger(VideoFileInput.class);
     private final VideoFileInputOptions options;
     private FileDemuxer demuxer;
+    private final Set<IFileEventListener> fileEventListeners = new HashSet<>();
     private boolean open = false;
     private boolean playing = false;
     private double position = 0.0;
@@ -340,4 +343,23 @@ public class VideoFileInput extends VideoInput implements IVideoFileInput
             logger.warn("Interrupted while joining demuxer thread", e);
         }
     }
+
+    @Override
+    public void addFileEventListener(IFileEventListener listener)
+    {
+        fileEventListeners.add(listener);
+    }
+
+    @Override
+    public void removeFileEventListener(IFileEventListener listener)
+    {
+        fileEventListeners.remove(listener);
+    }
+
+    @Override
+    public void notifyEOF()
+    {
+        fileEventListeners.forEach(listener -> listener.onEndOfFile());
+    }
+
 }

--- a/api/src/main/java/org/jmisb/api/video/VideoFileInput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoFileInput.java
@@ -359,7 +359,10 @@ public class VideoFileInput extends VideoInput implements IVideoFileInput
     @Override
     public void notifyEOF()
     {
-        fileEventListeners.forEach(listener -> listener.onEndOfFile());
+        if (queuesAreEmpty())
+        {
+            fileEventListeners.forEach(listener -> listener.onEndOfFile());
+        }
     }
 
 }

--- a/api/src/main/java/org/jmisb/api/video/VideoInput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoInput.java
@@ -359,4 +359,14 @@ public abstract class VideoInput extends VideoIO implements IVideoInput
             formatContext = null;
         }
     }
+
+    /**
+     * Check if our decoded data queues are empty.
+     *
+     * @return return true if all queues are empty, otherwise false.
+     */
+    protected boolean queuesAreEmpty()
+    {
+        return (decodedVideo.isEmpty()) && (decodedMetadata.isEmpty());
+    }
 }

--- a/api/src/test/java/org/jmisb/api/video/DemuxReturnValueTest.java
+++ b/api/src/test/java/org/jmisb/api/video/DemuxReturnValueTest.java
@@ -1,0 +1,28 @@
+package org.jmisb.api.video;
+
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+/**
+ * Simple tests for DemuxReturnValue.
+ */
+public class DemuxReturnValueTest
+{
+    public DemuxReturnValueTest()
+    {
+    }
+
+    @Test
+    public void checkValues()
+    {
+        DemuxReturnValue v1 = DemuxReturnValue.SUCCESS;
+        DemuxReturnValue v2 = DemuxReturnValue.ERROR;
+        DemuxReturnValue v3 = DemuxReturnValue.EOF;
+        DemuxReturnValue v4 = DemuxReturnValue.EAGAIN;
+        assertTrue(v1 == v1);
+        assertTrue(v1 != v2);
+        assertTrue(v2 != v3);
+        assertTrue(v3 != v4);
+        assertTrue(v4 != v1);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/video/IFileEventListenerTest.java
+++ b/api/src/test/java/org/jmisb/api/video/IFileEventListenerTest.java
@@ -1,0 +1,47 @@
+package org.jmisb.api.video;
+
+import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+/**
+ * IFileEventListener tests.
+ */
+public class IFileEventListenerTest
+{
+    class TestListener implements IFileEventListener {
+        boolean gotNotify = false;
+
+        @Override
+        public void onEndOfFile() {
+            gotNotify = true;
+        }
+    }
+
+    public IFileEventListenerTest()
+    {
+    }
+
+    @Test
+    public void checkListener()
+    {
+        TestListener testListener = new TestListener();
+        IVideoFileInput fileInput = new VideoFileInput();
+        fileInput.addFileEventListener(testListener);
+        assertFalse(testListener.gotNotify);
+        fileInput.notifyEOF();
+        assertTrue(testListener.gotNotify);
+        fileInput.removeFileEventListener(testListener);
+    }
+
+    @Test
+    public void checkListenerRemoval()
+    {
+        TestListener testListener = new TestListener();
+        IVideoFileInput fileInput = new VideoFileInput();
+        fileInput.addFileEventListener(testListener);
+        assertFalse(testListener.gotNotify);
+        fileInput.removeFileEventListener(testListener);
+        fileInput.notifyEOF();
+        assertFalse(testListener.gotNotify);
+    }
+}


### PR DESCRIPTION
## Motivation and Context
For processing purposes, I'd like to know when I'm able to close off my output files and drop the processing loop.

Resolves #149 

## Description
Adds event listener (peer to the existing metadata event and video frame event interfaces), and wires it up. Because frames can be queued, we also need to check the queue is empty first.

## How Has This Been Tested?
I modified the viewer application with debug statements. There is a little unit testing, but its not very comprehensive given the difficulty with mocking the native code.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

