### PR TITLE
Add support for RTSP streams

### DIFF
--- a/api/src/main/java/org/jmisb/api/video/VideoStreamInput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoStreamInput.java
@@ -55,7 +55,14 @@ public class VideoStreamInput extends VideoInput implements IVideoStreamInput
         // Open the input stream
         AVDictionary openOpts = new AVDictionary(null);
         String timeoutVal = "" + options.getOpenTimeout() * 1000;
-        av_dict_set(openOpts, "timeout", timeoutVal, 0);
+        if (url.startsWith("rtsp://"))
+        {
+            av_dict_set(openOpts, "stimeout", timeoutVal, 0);
+        }
+        else
+        {
+            av_dict_set(openOpts, "timeout", timeoutVal, 0);
+        }
         int ret = avformat_open_input(formatContext, url, null, openOpts);
         av_dict_free(openOpts);
         if (ret < 0)


### PR DESCRIPTION
## Motivation and Context
Implements RTSP as an input stream.

Resolves #118.

## Description
I don't fully understand the problem, but it appears that `timeout` is not a good thing for RTSP. There is such an option (https://ffmpeg.org/ffmpeg-protocols.html#rtsp) but its in seconds. By contrast, `stimeout` is in microseconds.

There is an RTSP example over at https://github.com/bytedeco/javacv/blob/master/samples/FFmpegStreamingTimeout.java that discusses the options in relation to RTSP. I'm not sure if that is meant to be a kind of bug report, or just a discussion of the workarounds. However it uses `stimeout` too.

## How Has This Been Tested?
Tested with the viewer application on a few RTSP examples I found on the internet. I tried traffic cameras, and also the "Big Buck Bunny" example.
 - rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
 - rtsp://170.93.143.139/rtplive/470011e600ef003a004ee33696235daa
 - rtsp://freja.hiof.no:1935/rtplive/definst/hessdalen03.stream

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/174642/84582117-312bc400-ae2b-11ea-9f7d-256f0136f1ea.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

