### PR TITLE
readme: update status, fix markdown lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-jMISB
-=============
+# jMISB
 
 ![Build Status](https://travis-ci.com/WestRidgeSystems/jmisb.svg?branch=develop)
 [![Coverage Status](https://coveralls.io/repos/github/WestRidgeSystems/jmisb/badge.svg?branch=develop)](https://coveralls.io/github/WestRidgeSystems/jmisb?branch=develop)
@@ -20,6 +19,7 @@ or would like to participate!
 The Motion Imagery Standards Board, or MISB's mission is to develop and
 maintain standards for interoperability between motion imagery systems in use
 within the Department of Defense (DoD) and Intelligence Community (IC).
+
 The goal of the jMISB project is to provide an open implementation of
 these standards and allow government and industry to leverage them more easily
 and effectively. The jMISB project is not affiliated with, nor endorsed by
@@ -35,14 +35,20 @@ in most widespread use. Usage is not easy to quantify, so we anticipate
 making course corrections based on feedback from the community. The initial
 set of standards to be supported are:
 
-* ST 0102: Security Metadata Universal and Local Sets for Digital Motion Imagery
-* ST 0601: UAS Datalink Local Set
-* ST 0805: KLV to Cursor-on-Target (CoT) Conversions
-* ST 0806: Remote Video Terminal Metadata Set
-* ST 0903: Video Moving Target Indicator and Track Metadata
-* ST 1201: Floating Point to Integer Mapping
-* ST 1204: Motion Imagery Identification System (MIIS) Core Identifier
-* ST 1402: MPEG-2 Transport Stream for Class 1/Class 2 Motion Imagery, Audio, and Metadata
+| Identifier | Name | Implementation Status | Known Issues |
+| ---------- | ---- | --------------------- | ------------ |
+| ST 0102 | Security Metadata Universal and Local Sets for Digital Motion Imagery | Implemented as of ST 0102.12. There is read-only support for some tags (not UMID) that were removed in ST 0102.12. | |
+| EG 0104 |	Predator UAV Basic Universal Metadata Set | Read only support for EG 0104.5. Writing is not planned, since this is deprecated. | |
+| ST 0601 | UAS Datalink Local Set | Mostly implemented as of ST 0102.16a. | #140 |
+| ST 0603 | MISP Time Systemand Timestamps | Partly implemented as of ST 0603.5. | #97 |
+| ST 0604 | Timestamps for Class 1 / Class 2 Motion Imagery | Partly implemented as of ST 0604.6. | #102 |
+| ST 0805 | KLV to Cursor-on-Target (CoT) Conversions | Partly implemented. Limited testing. | |
+| ST 0806 | Remote Video Terminal Metadata Set | Implemented as of ST 0806.5. Unit tests only, no interoperability testing. | |
+| ST 0903 | Video Moving Target Indicator and Track Metadata | Implemented as of ST 0903.5. No support for pre-0903.4 files. Unit testing only, no interoperability testing. | |
+| ST 1201 | Floating Point to Integer Mapping | Mostly implemented per ST1201.4. | #73 |
+| ST 1204 | Motion Imagery Identification System (MIIS) Core Identifier | Implemented as of ST 1204.3. | |
+| ST 1402 | MPEG-2 Transport Stream for Class 1/Class 2 Motion Imagery, Audio, and Metadata | Mostly implemented. | #103, #119 |
+| ST 1909 | Metadata Overlay for Visualization | Implementation in progress. Not yet merged. | #61 |
 
 jMISB aims to be cross-platform to run on any modern operating system. However,
 some OSes are more widely used than others, and we will prioritize those to
@@ -56,24 +62,28 @@ reach the widest audience possible. The OSes we are initially targeting are:
 ## Building
 
 To build the library from the command line, simply run the Maven command:
-<pre>
-$ mvn package
-</pre>
+
+```sh
+mvn package
+```
+
 This will compile the source code, run unit tests, and generate the JAR files.
 
-To get started, you may want to run <code>jmisb-viewer</code> and experiment
+To get started, you may want to run `jmisb-viewer` and experiment
 with some test data. This is a sample application intended mainly to aid in
 development. To run it from the command line, issue:
-<pre>
-$ cd viewer
-$ mvn exec:exec
-</pre>
+
+```sh
+cd viewer
+mvn exec:exec
+```
 
 ## Including in Your Project
 
 If you are using a dependency management tool such as Maven with access to the
 [Central Repository](https://search.maven.org/), you can configure it to use
-jMISB as a dependency. For Maven, add the following to your <code>pom.xml</code>:
+jMISB as a dependency. For Maven, add the following to your `pom.xml`:
+
 ```xml
     <dependency>
         <groupId>org.jmisb</groupId>
@@ -81,7 +91,9 @@ jMISB as a dependency. For Maven, add the following to your <code>pom.xml</code>
         <version>1.9.0</version>
     </dependency>
 ```
+
 For Gradle, include the following:
+
 ```groovy
 dependencies {
     compile group: 'org.jmisb', name: 'jmisb-api', version: '1.9.0'
@@ -111,8 +123,8 @@ catch (IOException e)
 }
 ```
 
-The <code>ExampleProcessor</code> class simply needs to implement the
-<code>IVideoListener</code> and <code>IMetadataListener</code> interfaces
+The `ExampleProcessor` class simply needs to implement the
+`IVideoListener` and `IMetadataListener` interfaces
 to receive video and metadata asynchronously as the data arrives.
 
 ```java
@@ -150,15 +162,15 @@ The result of `msg.getField(UasDatalinkTag.SensorLatitude)` will be an instance
 of the `SensorLatitude` class (`IUasDatalinkValue` is a superclass), and this
 relationship holds in general.
 
-More complete examples of usage may be found in the <code>viewer</code> demo
+More complete examples of usage may be found in the `viewer` demo
 application and in unit tests. Additional sample applications are a work in
 progress.
 
 ## Versioning
 
-jMISB adheres to <i>semantic versioning</i> to communicate to client
+jMISB adheres to *semantic versioning* to communicate to client
 developers about the scope of changes in any new release. Version numbers
-are formatted as <code>major.minor.patch</code>, where:
+are formatted as `major.minor.patch`, where:
 
 1. The major number is incremented to indicate incompatible API changes.
 2. The minor number is incremented to indicate new functionality has been
@@ -169,7 +181,7 @@ fix.
 In other words, users of the library should feel comfortable updating to use
 a new version unless the major number has changed. In general, users should
 keep up to date with the latest patch release for a given
-<code>major.minor</code> release branch.
+`major.minor` release branch.
 
 Use of -SNAPSHOT within the version number indicates that the version is
 for internal development only, i.e., the artifact is not to be used in a


### PR DESCRIPTION
## Motivation and Context
This provides a bit more detail (and currency) on the top level README.md file. It also fixes a few markdownlint complaints.

## Description
Changed the bulleted list to a table, added some links. The status is intentionally pretty conservative, and could be made more positive in the future.

## How Has This Been Tested?
Docs only, but I reviewed in in github.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

