### PR TITLE
st0601: update ST0601 documentation to reflect Items instead of Tags

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/ActivePayloads.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ActivePayloads.java
@@ -6,13 +6,13 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Active Payloads (Tag 139).
+ * Active Payloads (Item 139).
  *
  * <p>From ST0601:
  *
  * <blockquote>
  *
- * List of currently active payloads from the payload list (Tag 138).
+ * List of currently active payloads from the payload list (Item 138).
  *
  * <p>The Active Payloads item is a list of the subset of payloads from the Payload List which are
  * currently in use. The list is a series of Payload Identifiers which map into the Payload List
@@ -20,7 +20,7 @@ import java.util.List;
  *
  * <p>The list is a series of bits which represent which payloads are active. A bit value of one (1)
  * means the payload is active, a bit value of zero (0) means the payload is not active. Using the
- * example from the Payload List (Tag 138), if payloads 0, 1, and 3 are active, bits 0, 1, and 3
+ * example from the Payload List (Item 138), if payloads 0, 1, and 3 are active, bits 0, 1, and 3
  * will be set in the Active Payloads Value. The result for this example is a single byte with the
  * value of 0x0B.
  *
@@ -44,7 +44,7 @@ public class ActivePayloads implements IUasDatalinkValue {
     /**
      * Create from values.
      *
-     * @param values List of payload identifiers (per corresponding Tag 138).
+     * @param values List of payload identifiers (per corresponding Item 138).
      */
     public ActivePayloads(List<Integer> values) {
         payloads = BigInteger.valueOf(0);
@@ -78,7 +78,7 @@ public class ActivePayloads implements IUasDatalinkValue {
     /**
      * Get the list of identifiers for active payloads.
      *
-     * <p>The identifiers match the corresponding Tag 138 (PayloadList) identifiers.
+     * <p>The identifiers match the corresponding Item 138 (PayloadList) identifiers.
      *
      * @return list of integer identifiers.
      */
@@ -95,7 +95,7 @@ public class ActivePayloads implements IUasDatalinkValue {
     /**
      * Mark a payload as active.
      *
-     * @param identifier the payload identifier (per Tag 138 - PayloadList)
+     * @param identifier the payload identifier (per Item 138 - PayloadList)
      */
     public void setPayloadActive(final int identifier) {
         payloads = payloads.setBit(identifier);
@@ -104,7 +104,7 @@ public class ActivePayloads implements IUasDatalinkValue {
     /**
      * Mark a payload as inactive.
      *
-     * @param identifier the payload identifier (per Tag 138 - PayloadList)
+     * @param identifier the payload identifier (per Item 138 - PayloadList)
      */
     public void setPayloadInactive(final int identifier) {
         payloads = payloads.clearBit(identifier);
@@ -113,7 +113,7 @@ public class ActivePayloads implements IUasDatalinkValue {
     /**
      * Check if a payload is currently marked active.
      *
-     * @param identifier the payload identifier (per Tag 138 - PayloadList)
+     * @param identifier the payload identifier (per Item 138 - PayloadList)
      * @return true if the payload is active, otherwise false.
      */
     public boolean payloadIsActive(final int identifier) {

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ActiveWavelengthList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ActiveWavelengthList.java
@@ -8,7 +8,7 @@ import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
 
 /**
- * Active Wavelength List (Tag 121).
+ * Active Wavelength List (Item 121).
  *
  * <p>From ST0601:
  *
@@ -16,7 +16,7 @@ import org.jmisb.api.klv.BerField;
  *
  * List of wavelengths in Motion Imagery.
  *
- * <p>Used with Wavelengths List (Tag 128).
+ * <p>Used with Wavelengths List (Item 128).
  *
  * <p>The Active Wavelength List provides a list of wavelengths used by the sensor to generate the
  * Motion Imagery. This value updates when the sensor changes and the new sensor has a different
@@ -33,7 +33,7 @@ public class ActiveWavelengthList implements IUasDatalinkValue {
      * Create from value.
      *
      * <p>This valid identifiers should be from the defined set (1-7), or 21 and higher as defined
-     * by Tag 128.
+     * by Item 128.
      *
      * <p>
      *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AirbaseLocations.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AirbaseLocations.java
@@ -10,7 +10,7 @@ import org.jmisb.api.klv.st1201.FpEncoder;
 import org.jmisb.core.klv.ArrayUtils;
 
 /**
- * Airbase Locations (ST 0601 tag 130).
+ * Airbase Locations (ST 0601 Item 130).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AirfieldBarometricPressure.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AirfieldBarometricPressure.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Airfield Barometric Pressure (ST 0601 tag 53)
+ * Airfield Barometric Pressure (ST 0601 Item 53).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AirfieldElevation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AirfieldElevation.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Airfield Elevation (ST 0601 tag 54)
+ * Airfield Elevation (ST 0601 Item 54).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformAltitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformAltitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Alternative Platform Altitude (ST 0601 tag 69)
+ * Alternative Platform Altitude (ST 0601 Item 69).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformEllipsoidHeight.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformEllipsoidHeight.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Alternative Platform Ellipsoid Height (ST 0601 tag 76)
+ * Alternative Platform Ellipsoid Height (ST 0601 Item 76).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformEllipsoidHeightExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformEllipsoidHeightExtended.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Alternate Platform Ellipsoid Height Extended (ST 0601 tag 105)
+ * Alternate Platform Ellipsoid Height Extended (ST 0601 Item 105).
  *
  * <p>From ST:
  *
@@ -14,7 +14,7 @@ package org.jmisb.api.klv.st0601;
  * <p>Max Altitude: 40,000m for airborne systems
  *
  * <p>The purpose of Alternate Platform Ellipsoid Height Extended is to increase the range of
- * altitude values currently defined in Tag 76 Alternate Platform Ellipsoid Height to support all
+ * altitude values currently defined in Item 76 Alternate Platform Ellipsoid Height to support all
  * CONOPs for airborne systems.
  *
  * </blockquote>

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformHeading.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformHeading.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Alternate Platform Heading (ST 0601 tag 71)
+ * Alternate Platform Heading (ST 0601 Item 71).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformLatitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Alternate Platform Latitude (ST 0601 tag 67)
+ * Alternate Platform Latitude (ST 0601 Item 67).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AlternatePlatformLongitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Alternate Platform Longitude (ST 0601 tag 68)
+ * Alternate Platform Longitude (ST 0601 Item 68).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AltitudeAGL.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AltitudeAGL.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Altitude AGL (ST 0601 tag 113).
+ * Altitude AGL (ST 0601 Item 113).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommand.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommand.java
@@ -11,7 +11,7 @@ import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Control Command (ST 0601 tag 115).
+ * Control Command (ST 0601 Item 115).
  *
  * <p>From ST:
  *
@@ -21,16 +21,16 @@ import org.jmisb.core.klv.PrimitiveConverter;
  *
  * <p>A copy of the command and control values used to request platform/sensor to perform an action.
  *
- * <p>Tag 116 uses the Command ID to signal validation.
+ * <p>Item 116 uses the Command ID to signal validation.
  *
  * <p>Command is a "string" format defined by platform vendor.
  *
- * <p>Control Command Verification (Tag 116) shows acknowledgment of the command
+ * <p>Control Command Verification (Item 116) shows acknowledgment of the command
  *
- * <p>The purpose of the Control Command (Tag 115) and Command Acknowledgement (Tag 116) items are
+ * <p>The purpose of the Control Command (Item 115) and Command Acknowledgement (Item 116) items are
  * to report the commands issued to the platform/sensor and the acknowledgment of those commands.
  * The Control Command defines a command ID and the command string which describes the command or
- * action to perform. At some later time, the command is acknowledged by the platform and Tag 116
+ * action to perform. At some later time, the command is acknowledged by the platform and Item 116
  * records the acknowledgment, by just restating the Command ID.
  *
  * </blockquote>

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommandVerification.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommandVerification.java
@@ -9,7 +9,7 @@ import org.jmisb.api.klv.BerField;
 import org.jmisb.core.klv.ArrayUtils;
 
 /**
- * Control Command Verification List (ST 0601 tag 116).
+ * Control Command Verification List (ST 0601 Item 116).
  *
  * <p>From ST:
  *
@@ -19,7 +19,7 @@ import org.jmisb.core.klv.ArrayUtils;
  *
  * <p>The Control Command Verification List is a variable length pack of one or more BER-OID values.
  * Each value is a verification or acknowledgment of a Control Command sent to the platform – see
- * Tag 115 for more details.
+ * Item 115 for more details.
  *
  * </blockquote>
  */

--- a/api/src/main/java/org/jmisb/api/klv/st0601/CornerOffset.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/CornerOffset.java
@@ -4,11 +4,12 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Corner Offset (ST 0601 tags 26-33)
+ * Corner Offset (ST 0601 Items 26-33).
  *
- * <p>Tags 26-33 encode the corner locations of the sensor footprint as offsets from the frame
- * center (tag 23/24). These values use only two bytes each, so their resolution is limited (~0.25m
- * at equator). For higher precision, see tags 82-89, Corner Latitude/Longitude Points (Full).
+ * <p>Items 26-33 encode the corner locations of the sensor footprint as offsets from the frame
+ * center (Items 23 and 24). These values use only two bytes each, so their resolution is limited
+ * (~0.25m at equator). For higher precision, see Items 82-89, Corner Latitude/Longitude Points
+ * (Full).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/CorrectionOffset.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/CorrectionOffset.java
@@ -3,13 +3,13 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * CorrectionOffset (ST 0601 tag 137).
+ * CorrectionOffset (ST 0601 Item 137).
  *
  * <p>From ST:
  *
  * <blockquote>
  *
- * Post-flight time adjustment to correct Precision Time Stamp (Tag 2) as needed.
+ * Post-flight time adjustment to correct Precision Time Stamp (Item 2) as needed.
  *
  * <p>KLV format: int64, Min: -(2^63), Max: (2^63)-1.
  *
@@ -17,10 +17,10 @@ import org.jmisb.core.klv.PrimitiveConverter;
  *
  * <p>Resolution: 1 microsecond.
  *
- * <p>Add value to Precision Time Stamp (Tag 2) to correct time.
+ * <p>Add value to Precision Time Stamp (Item 2) to correct time.
  *
- * <p>This value DOES NOT INCLUDE leap seconds offset. See Leap Seconds (Tag 136) to add leap second
- * offset.
+ * <p>This value DOES NOT INCLUDE leap seconds offset. See Leap Seconds (Item 136) to add leap
+ * second offset.
  *
  * <p>See "Packet Timestamp" section for more information on the use of this item.
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/CountryCodes.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/CountryCodes.java
@@ -11,7 +11,7 @@ import org.jmisb.api.klv.st0102.CountryCodingMethodUtilities;
 import org.jmisb.core.klv.ArrayUtils;
 
 /**
- * Country Codes (ST 0601 tag 122).
+ * Country Codes (ST 0601 Item 122).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/DensityAltitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/DensityAltitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Density Altitude (ST 0601 tag 38)
+ * Density Altitude (ST 0601 Item 38).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/DensityAltitudeExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/DensityAltitudeExtended.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Density Altitude Extended (ST 0601 tag 103)
+ * Density Altitude Extended (ST 0601 Item 103).
  *
  * <p>From ST:
  *
@@ -15,7 +15,7 @@ package org.jmisb.api.klv.st0601;
  * <p>Max Altitude: 40,000m for airborne systems
  *
  * <p>The purpose of Density Altitude Extended is to increase the range of altitude values currently
- * defined in Tag 38 Density Altitude to support all CONOPs for airborne systems.
+ * defined in Item 38 Density Altitude to support all CONOPs for airborne systems.
  *
  * </blockquote>
  */

--- a/api/src/main/java/org/jmisb/api/klv/st0601/DifferentialPressure.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/DifferentialPressure.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Differential Pressure (ST 0601 tag 49)
+ * Differential Pressure (ST 0601 Item 49).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/EventStartTimeUtc.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/EventStartTimeUtc.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import org.jmisb.api.klv.st0603.ST0603TimeStamp;
 
 /**
- * Event Start Time - UTC (ST 0601 tag 72).
+ * Event Start Time - UTC (ST 0601 Item 72).
  *
  * <p>From ST:
  *
@@ -20,7 +20,7 @@ import org.jmisb.api.klv.st0603.ST0603TimeStamp;
  *
  * </blockquote>
  *
- * Note: if you are looking to represent takeoff time, see TakeOffTime (Tag 131).
+ * Note: if you are looking to represent takeoff time, see TakeOffTime (Item 131).
  */
 public class EventStartTimeUtc extends ST0603TimeStamp implements IUasDatalinkValue {
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterElevation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterElevation.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Frame Center Elevation (ST 0601 tag 25)
+ * Frame Center Elevation (ST 0601 Item 25).
  *
  * <p>From ST:
  *
@@ -19,9 +19,9 @@ package org.jmisb.api.klv.st0601;
  *
  * <blockquote>
  *
- * For legacy purposes, both MSL (Tag 25) and HAE (Tag 78) representations of Frame Center Elevation
- * MAY appear in the same ST 0601 packet. A single representation is preferred favoring the HAE
- * version (Tag 78).
+ * For legacy purposes, both MSL (Item 25) and HAE (Item 78) representations of Frame Center
+ * Elevation MAY appear in the same ST 0601 packet. A single representation is preferred favoring
+ * the HAE version (Item 78).
  *
  * </blockquote>
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterHae.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterHae.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Frame Center Height Above Ellipsoid (ST 0601 tag 78)
+ * Frame Center Height Above Ellipsoid (ST 0601 Item 78).
  *
  * <p>From ST:
  *
@@ -19,9 +19,9 @@ package org.jmisb.api.klv.st0601;
  *
  * <blockquote>
  *
- * For legacy purposes, both MSL (Tag 25) and HAE (Tag 78) representations of Frame Center Elevation
- * MAY appear in the same ST 0601 packet. A single representation is preferred favoring the HAE
- * version (Tag 78).
+ * For legacy purposes, both MSL (Item 25) and HAE (Item 78) representations of Frame Center
+ * Elevation MAY appear in the same ST 0601 packet. A single representation is preferred favoring
+ * the HAE version (Item 78).
  *
  * </blockquote>
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterLatitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Frame Center Latitude (ST 0601 tag 23)
+ * Frame Center Latitude (ST 0601 Item 23).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FrameCenterLongitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Frame Center Longitude (ST 0601 tag 24)
+ * Frame Center Longitude (ST 0601 Item 24).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FullCornerLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FullCornerLatitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Corner Latitude Point (ST 0601 tags 82/84/86/88)
+ * Corner Latitude Point (ST 0601 Items 82/84/86/88).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FullCornerLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FullCornerLongitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Corner Longitude Point (ST 0601 tags 83/85/87/89)
+ * Corner Longitude Point (ST 0601 Items 83/85/87/89).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/GroundRange.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/GroundRange.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Ground Range (ST 0601 tag 57)
+ * Ground Range (ST 0601 Item 57).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/HorizontalFov.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/HorizontalFov.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Sensor Horizontal field of view (ST 0601 tag 16)
+ * Sensor Horizontal field of view (ST 0601 Item 16).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/IcingDetected.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/IcingDetected.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Icing Detected (ST 0601 tag 34)
+ * Icing Detected (ST 0601 Item 34).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/LaserPrfCode.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/LaserPrfCode.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Laser PRF Code (ST0601 Tag 62)
+ * Laser PRF Code (ST0601 Item 62).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/LeapSeconds.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/LeapSeconds.java
@@ -3,13 +3,13 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Leap Seconds (ST 0601 tag 136).
+ * Leap Seconds (ST 0601 Item 136).
  *
  * <p>From ST:
  *
  * <blockquote>
  *
- * Number of leap seconds to adjust Precision Time Stamp (Tag 2) to UTC.
+ * Number of leap seconds to adjust Precision Time Stamp (Item 2) to UTC.
  *
  * <p>KLV format: int, Min: -(2^31), Max: (2^31)-1.
  *
@@ -17,7 +17,7 @@ import org.jmisb.core.klv.PrimitiveConverter;
  *
  * <p>Resolution: 1 second.
  *
- * <p>Add this value to Precision Time Stamp (Tag 2) to convert to UTC.
+ * <p>Add this value to Precision Time Stamp (Item 2) to convert to UTC.
  *
  * <p>When adjusting Precision Time Stamp to UTC multiply this leap second value by 1,000,000 to
  * convert it to microseconds.

--- a/api/src/main/java/org/jmisb/api/klv/st0601/MiisCoreIdentifier.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/MiisCoreIdentifier.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.api.klv.st1204.CoreIdentifier;
 
 /**
- * MIIS Core Identifier (Tag 94)
+ * MIIS Core Identifier (Item 94).
  *
  * <p>From ST:
  *
@@ -12,7 +12,7 @@ import org.jmisb.api.klv.st1204.CoreIdentifier;
  * Use according to the rules and requirements defined in ST 1204.
  *
  * <p>The MIIS Core Identifier allows users to include the MIIS Core Identifier (MISB ST 1204)
- * Binary Value (opposed to the text-based representation) within MISB ST 0601. Tag 94's value does
+ * Binary Value (opposed to the text-based representation) within MISB ST 0601. Item 94's value does
  * not include MISB ST 1204's 16-byte Key or length, only the value portion. See MISB ST 1204 for
  * generation and usage requirements.
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/NavsatsInView.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/NavsatsInView.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Number of NAVSATs in View (ST 0601 tag 123)
+ * Number of NAVSATs in View (ST 0601 Item 123).
  *
  * <p>From ST:
  *
@@ -13,7 +13,7 @@ import org.jmisb.core.klv.PrimitiveConverter;
  *
  * <p>Number of satellites used to determine position.
  *
- * <p>Used with Positioning Method Source (Tag 124) for NAVSAT Types
+ * <p>Used with Positioning Method Source (Item 124) for NAVSAT Types
  *
  * <p>Map 0..(2^8-1) to 0..255.
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/NestedRvtLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/NestedRvtLocalSet.java
@@ -4,7 +4,7 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0806.RvtLocalSet;
 
 /**
- * Remote Video Terminal Local Set (ST 0601 tag 73).
+ * Remote Video Terminal Local Set (ST 0601 Item 73).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/NestedSecurityMetadata.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/NestedSecurityMetadata.java
@@ -4,14 +4,14 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0102.localset.SecurityMetadataLocalSet;
 
 /**
- * Security Local Set (ST 0601 tag 48)
+ * Security Local Set (ST 0601 Item 48).
  *
  * <p>From ST:
  *
  * <blockquote>
  *
- * Local set tag to include the ST 0102 Local Set Security Metadata items within ST 0601. Use the
- * MISB ST 0102 Local Set tags within the MISB ST 0601 item 48.
+ * Local set Item to include the ST 0102 Local Set Security Metadata items within ST 0601. Use the
+ * MISB ST 0102 Local Set items within the MISB ST 0601 item 48.
  *
  * <p>The length field is the size of all MISB ST 0102 metadata items to be packaged within item 48.
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/NestedVmtiLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/NestedVmtiLocalSet.java
@@ -4,15 +4,15 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.VmtiLocalSet;
 
 /**
- * VMTI Local Set (ST 0601 tag 74)
+ * VMTI Local Set (ST 0601 Item 74).
  *
  * <p>From ST:
  *
  * <blockquote>
  *
- * Use the MISB ST 0903 Local Set within the MISB ST 0601 Tag 74.
+ * Use the MISB ST 0903 Local Set within the MISB ST 0601 Item 74.
  *
- * <p>The length field is the size of all VMTI LS metadata items to be packaged within Tag 74.
+ * <p>The length field is the size of all VMTI LS metadata items to be packaged within Item 74.
  *
  * <p>The VMTI Local Set allows users to include, or nest, VMTI LS (MISB ST 0903) metadata items
  * within MISB ST 0601.

--- a/api/src/main/java/org/jmisb/api/klv/st0601/OnBoardMiStorageCapacity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/OnBoardMiStorageCapacity.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * On-Board MI Storage Capacity (ST 0601 tag 133)
+ * On-Board MI Storage Capacity (ST 0601 Item 133).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/OnBoardMiStoragePercentFull.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/OnBoardMiStoragePercentFull.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.api.klv.st1201.FpEncoder;
 
 /**
- * On-board MI Storage Percent Full (Tag 120).
+ * On-board MI Storage Percent Full (Item 120).
  *
  * <p>From ST:
  *
@@ -11,7 +11,7 @@ import org.jmisb.api.klv.st1201.FpEncoder;
  *
  * Amount of on-board Motion Imagery storage used as a percentage of the total storage
  *
- * <p>Used with "On-board MI Storage Capacity" (Tag 133), if available, to determine remaining
+ * <p>Used with "On-board MI Storage Capacity" (Item 133), if available, to determine remaining
  * recording storage space.
  *
  * <p>Resolution: 2 bytes = 0.004 percent, 3 bytes = 1.5E-5 percent

--- a/api/src/main/java/org/jmisb/api/klv/st0601/OperationalMode.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/OperationalMode.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * OperationalMode (ST 0601 tag 77)
+ * OperationalMode (ST 0601 Item 77).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/OutsideAirTemperature.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/OutsideAirTemperature.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Outside Air Temperature (ST 0601 tag 39)
+ * Outside Air Temperature (ST 0601 Item 39).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PayloadList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PayloadList.java
@@ -11,7 +11,7 @@ import org.jmisb.api.klv.st0601.dto.Payload;
 import org.jmisb.core.klv.ArrayUtils;
 
 /**
- * Payload List (Tag 138).
+ * Payload List (Item 138).
  *
  * <p>From ST0601:
  *
@@ -20,11 +20,11 @@ import org.jmisb.core.klv.ArrayUtils;
  * The Payload List provides type and name of all relevant payloads on the platform. The Payload
  * List may contain optical sensors and non-optical payload packages such as SIGINT, LIDAR, or RADAR
  * systems. Some of the items in the Payload List will have further wavelength information provided
- * in the Wavelengths List when they become active. This list does not contain any weapons, see Tag
+ * in the Wavelengths List when they become active. This list does not contain any weapons, see Item
  * 140 for listing platform weapons. The Payload List is a Floating Length Pack (FLP) which contains
  * a Payload Record. A Payload Record consists of four elements: Payload Identifier, Payload Type,
  * Name Length and Payload Name. The Payload Identifier is a unique BER-OID integer sequentially
- * assigned starting with the number zero (0). The Active Payload (Tag 139) uses the Payload
+ * assigned starting with the number zero (0). The Active Payload (Item 139) uses the Payload
  * Identifier to specify which payloads are active. The Name Length encodes the length of the
  * Payload Name in BER short or long form. The Payload Name is a descriptive name of the payload
  * defined by the metadata encoder.

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttack.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttack.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Platform Angle of Attack (ST 0601 tag 50)
+ * Platform Angle of Attack (ST 0601 Item 50).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttackFull.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformAngleOfAttackFull.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Platform Angle of Attack (Full) (ST 0601 tag 92)
+ * Platform Angle of Attack (Full) (ST 0601 Item 92).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformCourseAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformCourseAngle.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.api.klv.st1201.FpEncoder;
 
 /**
- * Platform Course Angle (ST 0601 tag 112)
+ * Platform Course Angle (ST 0601 Item 112).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformFuelRemaining.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformFuelRemaining.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Platform Fuel Remaining (ST 0601 tag 58)
+ * Platform Fuel Remaining (ST 0601 Item 58).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformGroundSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformGroundSpeed.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Platform Ground Speed (ST 0601 tag 56)
+ * Platform Ground Speed (ST 0601 Item 56).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformHeadingAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformHeadingAngle.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Platform Heading Angle (ST 0601 tag 5)
+ * Platform Heading Angle (ST 0601 Item 5).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformIndicatedAirspeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformIndicatedAirspeed.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Platform Indicated Airspeed (ST 0601 tag 9)
+ * Platform Indicated Airspeed (ST 0601 Item 9).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformMagneticHeading.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformMagneticHeading.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Platform Magnetic Heading (ST 0601 tag 64)
+ * Platform Magnetic Heading (ST 0601 Item 64).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformPitchAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformPitchAngle.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Platform Pitch Angle (ST 0601 tag 6)
+ * Platform Pitch Angle (ST 0601 Item 6).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformPitchAngleFull.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformPitchAngleFull.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Platform Pitch Angle (Full) (ST 0601 tag 90)
+ * Platform Pitch Angle (Full) (ST 0601 Item 90).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformRollAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformRollAngle.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Platform Roll Angle (ST 0601 tag 7)
+ * Platform Roll Angle (ST 0601 Item 7).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformRollAngleFull.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformRollAngleFull.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Platform Roll Angle (Full) (ST 0601 tag 91)
+ * Platform Roll Angle (Full) (ST 0601 Item 91).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformSideslipAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformSideslipAngle.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Platform Sideslip Angle (ST 0601 tag 52)
+ * Platform Sideslip Angle (ST 0601 Item 52).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformSideslipAngleFull.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformSideslipAngleFull.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Platform Sideslip Angle (Full) (ST 0601 tag 93)
+ * Platform Sideslip Angle (Full) (ST 0601 Item 93).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformStatus.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformStatus.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Platform Status (ST 0601 tag 125)
+ * Platform Status (ST 0601 Item 125).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformTrueAirspeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformTrueAirspeed.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Platform True Airspeed (ST 0601 tag 8)
+ * Platform True Airspeed (ST 0601 Item 8).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PlatformVerticalSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PlatformVerticalSpeed.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Platform Vertical Speed (ST 0601 tag 51)
+ * Platform Vertical Speed (ST 0601 Item 51).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PositioningMethodSource.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PositioningMethodSource.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Positioning Method Source (ST 0601 tag 124)
+ * Positioning Method Source (ST 0601 Item 124).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PrecisionTimeStamp.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PrecisionTimeStamp.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import org.jmisb.api.klv.st0603.ST0603TimeStamp;
 
 /**
- * Precision Time Stamp (ST 0601 tag 2)
+ * Precision Time Stamp (ST 0601 Item 2).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PropulsionUnitSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PropulsionUnitSpeed.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Propulsion Unit Speed (ST 0601 tag 111).
+ * Propulsion Unit Speed (ST 0601 Item 111).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/RadarAltimeter.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/RadarAltimeter.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Radar Altimeter (ST 0601 tag 114).
+ * Radar Altimeter (ST 0601 Item 114).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/RangeToRecoveryLocation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/RangeToRecoveryLocation.java
@@ -3,7 +3,9 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.api.klv.st1201.FpEncoder;
 
 /**
- * Range To Recovery Location (Tag 109). From ST:
+ * Range To Recovery Location (Item 109).
+ *
+ * <p>From ST:
  *
  * <blockquote>
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/RelativeHumidity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/RelativeHumidity.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Relative Humidity (ST 0601 tag 55)
+ * Relative Humidity (ST 0601 Item 55).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ST0601Version.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ST0601Version.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * UAS Datalink LS Version Number (ST 0601 tag 65).
+ * UAS Datalink LS Version Number (ST 0601 Item 65).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorAngleRate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorAngleRate.java
@@ -5,8 +5,8 @@ import org.jmisb.api.klv.st1201.FpEncoder;
 /**
  * Shared implementation of Sensor Angle Rate.
  *
- * <p>This is used by Sensor Azimuth Rate, Sensor Elevation Rate, and Sensor Roll Rate (ST 0601 tag
- * 117, 118 and 119).
+ * <p>This is used by Sensor Azimuth Rate, Sensor Elevation Rate, and Sensor Roll Rate (ST 0601
+ * Items 117, 118 and 119).
  */
 public abstract class SensorAngleRate implements IUasDatalinkValue {
     private static double MIN_VAL = -1000.0;

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorAzimuthRate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorAzimuthRate.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Sensor Azimuth Rate (ST0601 Tag 117)
+ * Sensor Azimuth Rate (ST0601 Item 117).
  *
  * <p>From ST:
  *
@@ -11,9 +11,9 @@ package org.jmisb.api.klv.st0601;
  *
  * <p>Resolution: 2 bytes = 0.0625 degrees/second, 3 bytes = 0.000244 degrees/second
  *
- * <p>Uses the same orientation as Sensor Relative Azimuth Angle (Tag 18) Refer to Tag 18's diagram:
- * From above the aircraft looking down, when the sensor is moving clockwise the rate is positive
- * and negative when its moving counter-clockwise.
+ * <p>Uses the same orientation as Sensor Relative Azimuth Angle (Item 18) Refer to Item 18's
+ * diagram: From above the aircraft looking down, when the sensor is moving clockwise the rate is
+ * positive and negative when its moving counter-clockwise.
  *
  * </blockquote>
  */

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorControlMode.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorControlMode.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Sensor Control Mode (ST 0601 tag 126)
+ * Sensor Control Mode (ST 0601 Item 126).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorEastVelocity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorEastVelocity.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Sensor East Velocity (ST 0601 tag 80)
+ * Sensor East Velocity (ST 0601 Item 80).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorElevationRate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorElevationRate.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Sensor Elevation Rate (ST0601 Tag 118)
+ * Sensor Elevation Rate (ST0601 Item 118).
  *
  * <p>From ST:
  *
@@ -11,7 +11,7 @@ package org.jmisb.api.klv.st0601;
  *
  * <p>Resolution: 2 bytes = 0.0625 degrees/second, 3 bytes = 0.000244 degrees/second
  *
- * <p>Uses the same orientation as Sensor Relative Elevation Angle (Tag 19). Refer to Tag 19's
+ * <p>Uses the same orientation as Sensor Relative Elevation Angle (Item 19). Refer to Item 19's
  * diagram: From the side view of the aircraft shown, when the sensor is moving clockwise the rate
  * is positive and negative when its moving counter-clockwise.
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorEllipsoidHeight.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorEllipsoidHeight.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Sensor Ellipsoid Height (ST 0601 tag 75)
+ * Sensor Ellipsoid Height (ST 0601 Item 75).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorEllipsoidHeightExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorEllipsoidHeightExtended.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Sensor Ellipsoid Height Extended (ST 0601 tag 104)
+ * Sensor Ellipsoid Height Extended (ST 0601 Item 104).
  *
  * <p>From ST:
  *
@@ -14,7 +14,7 @@ package org.jmisb.api.klv.st0601;
  * <p>Resolution: 2 bytes = 2 meters, 3 bytes = 78.125 mm
  *
  * <p>The purpose of Sensor Ellipsoid Height Extended is to increase the range of altitude values
- * currently defined in Tag 75 Sensor Ellipsoid Height to support all CONOPs for airborne systems.
+ * currently defined in Item 75 Sensor Ellipsoid Height to support all CONOPs for airborne systems.
  *
  * </blockquote>
  */

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorFieldOfViewName.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorFieldOfViewName.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Sensor Field of View Name (ST 0601 tag 63)
+ * Sensor Field of View Name (ST 0601 Item 63).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorFrameRate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorFrameRate.java
@@ -9,7 +9,7 @@ import org.jmisb.api.klv.BerField;
 import org.jmisb.core.klv.ArrayUtils;
 
 /**
- * Sensor Frame Rate (ST 0601 tag 127).
+ * Sensor Frame Rate (ST 0601 Item 127).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorLatitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Sensor Latitude (ST 0601 tag 13)
+ * Sensor Latitude (ST 0601 Item 13).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorLongitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Sensor Longitude (ST 0601 tag 14)
+ * Sensor Longitude (ST 0601 Item 14).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorNorthVelocity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorNorthVelocity.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Sensor North Velocity (ST 0601 tag 79)
+ * Sensor North Velocity (ST 0601 Item 79).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeAzimuth.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeAzimuth.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Sensor Relative Azimuth (ST 0601 tag 18)
+ * Sensor Relative Azimuth (ST 0601 Item 18).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeElevation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeElevation.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Sensor Relative Elevation (ST 0601 tag 19)
+ * Sensor Relative Elevation (ST 0601 Item 19).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeRoll.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorRelativeRoll.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Sensor Relative Roll (ST 0601 tag 20)
+ * Sensor Relative Roll (ST 0601 Item 20).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorRollRate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorRollRate.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Sensor Roll Rate (ST0601 Tag 119)
+ * Sensor Roll Rate (ST0601 Item 119).
  *
  * <p>From ST:
  *
@@ -11,7 +11,7 @@ package org.jmisb.api.klv.st0601;
  *
  * <p>Resolution: 2 bytes = 0.0625 degrees/second, 3 bytes = 0.000244 degrees/second
  *
- * <p>Uses the same orientation as Sensor Relative Roll Angle (Tag 20). Refer to Tag 20's
+ * <p>Uses the same orientation as Sensor Relative Roll Angle (Item 20). Refer to Item 20's
  * description: From behind the sensor, when the sensor is moving clockwise the rate is positive and
  * negative when its moving counter-clockwise.
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SensorTrueAltitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SensorTrueAltitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Sensor True Altitude (ST 0601 tag 15)
+ * Sensor True Altitude (ST 0601 Item 15).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/SlantRange.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/SlantRange.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Slant Range (ST 0601 tag 21)
+ * Slant Range (ST 0601 Item 21).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/StaticPressure.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/StaticPressure.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Static Pressure (ST 0601 tag 37)
+ * Static Pressure (ST 0601 Item 37).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TakeOffTime.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TakeOffTime.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import org.jmisb.api.klv.st0603.ST0603TimeStamp;
 
 /**
- * Take Off Time (ST 0601 tag 131).
+ * Take Off Time (ST 0601 Item 131).
  *
  * <p>From ST:
  *
@@ -17,7 +17,7 @@ import org.jmisb.api.klv.st0603.ST0603TimeStamp;
  *
  * <p>See MISB ST 0603.
  *
- * <p>See details for Time Airborne (Tag 110) for description and usage.
+ * <p>See details for Time Airborne (Item 110) for description and usage.
  *
  * <p>Resolution: 1 microsecond.
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetErrorEstimateCe90.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetErrorEstimateCe90.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Target Error Estimate - CE90 (ST 0601 tag 45)
+ * Target Error Estimate - CE90 (ST 0601 Item 45).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetErrorEstimateLe90.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetErrorEstimateLe90.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Target Error Estimate - LE90 (ST 0601 tag 46)
+ * Target Error Estimate - LE90 (ST 0601 Item 46).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationElevation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationElevation.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Target Location Elevation (ST 0601 tag 42)
+ * Target Location Elevation (ST 0601 Item 42).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationLatitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Target Location Latitude (ST 0601 tag 40)
+ * Target Location Latitude (ST 0601 Item 40).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetLocationLongitude.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Target Location Longitude (ST 0601 tag 41)
+ * Target Location Longitude (ST 0601 Item 41).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetTrackGateHeight.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetTrackGateHeight.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Target Track Gate Height (ST 0601 tag 44)
+ * Target Track Gate Height (ST 0601 Item 44).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetTrackGateSize.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetTrackGateSize.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Target Track Gate Size (used by ST 0601 tag 43 and 44)
+ * Target Track Gate Size (used by ST 0601 Items 43 and 44).
  *
  * <p>Map 0..(2^8-1) to 0..510 pixels.
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetTrackGateWidth.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetTrackGateWidth.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Target Track Gate Width (ST 0601 tag 43)
+ * Target Track Gate Width (ST 0601 Item 43).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetWidth.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetWidth.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Target Width (ST 0601 tag 22)
+ * Target Width (ST 0601 Item 22).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetWidthExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetWidthExtended.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.api.klv.st1201.FpEncoder;
 
 /**
- * Target Width Extended (ST 0601 tag 96)
+ * Target Width Extended (ST 0601 Item 96).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TimeAirborne.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TimeAirborne.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Time Airborne (ST 0601 tag 110).
+ * Time Airborne (ST 0601 Item 110).
  *
  * <p>From ST:
  *
@@ -17,13 +17,13 @@ import org.jmisb.core.klv.PrimitiveConverter;
  *
  * <p>Resolution: 1 second.
  *
- * <p>This item is related to the "Take-Off Time" (Tag 131). Suggest using "Time airborne" (Tag 110)
- * or "Take-Off Time" (Tag 131) but not both in the same MISB ST 0601 Local Set.
+ * <p>This item is related to the "Take-Off Time" (Item 131). Suggest using "Time airborne" (Item
+ * 110) or "Take-Off Time" (Item 131) but not both in the same MISB ST 0601 Local Set.
  *
  * <p>Time Airborne is a continual count of the number of seconds since the aircraft took off from
- * the ground (or ship). The Take-Off time (Tag 131) is the timestamp indicating when the aircraft
+ * the ground (or ship). The Take-Off time (Item 131) is the timestamp indicating when the aircraft
  * became airborne. The Time Airborne and Take-Off Time are related mathematically using the
- * Precision Time Stamp (Tag 2), so the Local Set needs only one of these items to compute the
+ * Precision Time Stamp (Item 2), so the Local Set needs only one of these items to compute the
  * other.
  *
  * </blockquote>

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TransmissionFrequency.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TransmissionFrequency.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.api.klv.st1201.FpEncoder;
 
 /**
- * Transmission Frequency (Tag 132).
+ * Transmission Frequency (Item 132).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitude.java
@@ -5,8 +5,8 @@ import org.jmisb.core.klv.PrimitiveConverter;
 /**
  * Abstract base class for altitude values in ST 0601
  *
- * <p>Used by tags: 15, 25, 38, 42, 54, 69, 75, 76, 78. Note that some derived types use MSL, others
- * HAE.
+ * <p>Used by items: 15, 25, 38, 42, 54, 69, 75, 76, 78. Note that some derived types use MSL,
+ * others HAE.
  *
  * <blockquote>
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitudeExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitudeExtended.java
@@ -5,9 +5,9 @@ import org.jmisb.api.klv.st1201.FpEncoder;
 /**
  * Shared implementation of IMAPB encoded altitude.
  *
- * <p>Used by Alternate Platform Ellipsoid Height Extended (ST 0601 tag 105), Altitude AGL (ST 0601
- * tag 113), Density Altitude Extended (ST 0601 tag 103), Radar Altimeter (ST 0601 tag 114) and
- * Sensor Ellipsoid Height Extended (ST 0601 tag 104).
+ * <p>Used by Alternate Platform Ellipsoid Height Extended (ST 0601 Item 105), Altitude AGL (ST 0601
+ * Item 113), Density Altitude Extended (ST 0601 Item 103), Radar Altimeter (ST 0601 Item 114) and
+ * Sensor Ellipsoid Height Extended (ST 0601 Item 104).
  */
 public abstract class UasDatalinkAltitudeExtended implements IUasDatalinkValue {
     protected static final double MIN_VAL = -900.0;

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAngle.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Generic angle (used by ST 0601 tag 6, 50 and 52)
+ * Generic angle (used by ST 0601 items 6, 50 and 52).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAngle360.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAngle360.java
@@ -5,8 +5,8 @@ import org.jmisb.core.klv.PrimitiveConverter;
 /**
  * Heading-style Angle.
  *
- * <p>Used by ST 0601 tag 5 (Platform Heading Angle), tag 35 (Wind Direction), tag 64 (Platform
- * Magnetic Heading) and tag 71 (Alternate Platform Heading).
+ * <p>Used by ST 0601 Item 5 (Platform Heading Angle), Item 35 (Wind Direction), Item 64 (Platform
+ * Magnetic Heading) and Item 71 (Alternate Platform Heading).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLatitude.java
@@ -4,9 +4,9 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Abstract base class for latitude values in ST 0601
+ * Abstract base class for latitude values in ST 0601.
  *
- * <p>Used by tags: 13, 23, 40, 67, 82, 84, 86, 88
+ * <p>Used by items: 13, 23, 40, 67, 82, 84, 86, 88
  *
  * <blockquote>
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLongitude.java
@@ -4,9 +4,9 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Abstract base class for longitude values in ST 0601
+ * Abstract base class for longitude values in ST 0601.
  *
- * <p>Used by tags: 14, 24, 41, 68, 83, 85, 87, 89
+ * <p>Used by items: 14, 24, 41, 68, 83, 85, 87, 89.
  *
  * <blockquote>
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkSensorVelocity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkSensorVelocity.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Abstract base class for Sensor Velocity (used by ST 0601 tag 79 and 80)
+ * Abstract base class for Sensor Velocity (used by ST 0601 items 79 and 80).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkSpeed.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * UAS Datalink Speed (used by ST 0601 tag 8, 9 and 56)
+ * UAS Datalink Speed (used by ST 0601 items 8, 9 and 56).
  *
  * <p>Map 0..(2^8-1) to 0..255 meters/second.
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -464,20 +464,20 @@ public enum UasDatalinkTag {
     /** Tag 135; Type of communications used with platform; Value is a {@link UasDatalinkString} */
     CommunicationsMethod(135),
     /**
-     * Tag 136; Number of leap seconds to adjust Precision Time Stamp (Tag 2) to UTC; Value is a
+     * Tag 136; Number of leap seconds to adjust Precision Time Stamp (Item 2) to UTC; Value is a
      * {@link LeapSeconds}
      */
     LeapSeconds(136),
     /**
-     * Tag 137; Post-flight time adjustment to correct Precision Time Stamp (Tag 2) as needed; Value
-     * is a {@link CorrectionOffset}
+     * Tag 137; Post-flight time adjustment to correct Precision Time Stamp (Item 2) as needed;
+     * Value is a {@link CorrectionOffset}
      */
     CorrectionOffset(137),
     /** Tag 138; List of payloads available on the Platform; Value is a {@link PayloadList} */
     PayloadList(138),
     /**
-     * Tag 139; List of currently active payloads from the payload list (Tag 138); Value is a {@link
-     * ActivePayloads}
+     * Tag 139; List of currently active payloads from the payload list (Item 138); Value is a
+     * {@link ActivePayloads}
      */
     ActivePayloads(139),
     /** Tag 140; List of weapon stores and status; Value is a {@link WeaponsStores} */

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTargetErrorEstimate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTargetErrorEstimate.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Target Error Estimate (used by ST 0601 tag 45 and 46)
+ * Target Error Estimate (used by ST 0601 items 45 and 46).
  *
  * <blockquote>
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasPressureMillibars.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasPressureMillibars.java
@@ -3,9 +3,9 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Abstract base class for pressure values in ST 0601
+ * Abstract base class for pressure values in ST 0601.
  *
- * <p>Used by tags: 37, 49, 53.
+ * <p>Used by items: 37, 49, 53.
  *
  * <blockquote>
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasRange.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasRange.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Shared Range - used by ST 0601 tag 21 (Slant Range) and 57 (Ground Range)
+ * Shared Range - used by ST 0601 items 21 (Slant Range) and 57 (Ground Range).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/VerticalFov.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/VerticalFov.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Sensor Vertical field of view (ST 0601 tag 17)
+ * Sensor Vertical field of view (ST 0601 Item 17).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WavelengthsList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WavelengthsList.java
@@ -11,7 +11,7 @@ import org.jmisb.api.klv.st0601.dto.Wavelengths;
 import org.jmisb.api.klv.st1201.FpEncoder;
 
 /**
- * Wavelengths List (Tag 128).
+ * Wavelengths List (Item 128).
  *
  * <p>From ST0601:
  *
@@ -20,10 +20,10 @@ import org.jmisb.api.klv.st1201.FpEncoder;
  * List of wavelength bands provided by sensor(s).
  *
  * <p>The Wavelengths List is a list of information used by the on-board sensors which collect
- * Motion Imagery. This item is a companion to Active Wavelength List (Tag 121).
+ * Motion Imagery. This item is a companion to Active Wavelength List (Item 121).
  *
  * <p>Table 14 shows predefined sensor records which support a set of common wavelengths used by
- * sensors. The Active Wavelength List (Tag 121) can use these predefined wavelength bands if they
+ * sensors. The Active Wavelength List (Item 121) can use these predefined wavelength bands if they
  * are sufficient for the given platform’s sensors. If a platform/sensor requires more specific or
  * customized wavelength records, this item enables their definition. Any custom Wavelengths List
  * records are sent at a minimum of once every 30 seconds. If the predefined wavelengths are

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WaypointList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WaypointList.java
@@ -14,7 +14,7 @@ import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Waypoint List (ST 0601 tag 141).
+ * Waypoint List (ST 0601 Item 141).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WeaponFired.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WeaponFired.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Weapon Fired (ST 0601 tag 61).
+ * Weapon Fired (ST 0601 Item 61).
  *
  * <p>From ST:
  *
@@ -9,8 +9,8 @@ package org.jmisb.api.klv.st0601;
  *
  * Indication when a particular weapon is released.
  *
- * <p>Note: the Weapon Stores (Tag 140) replaces the Weapon Load (Tag 60) and Weapon Fired (Tag 61)
- * for providing information about Weapons and their status.
+ * <p>Note: the Weapon Stores (Item 140) replaces the Weapon Load (Item 60) and Weapon Fired (Item
+ * 61) for providing information about Weapons and their status.
  *
  * <p>The Weapon Fired metadata item has the same format as the first byte of the Weapon Load
  * metadata item indicating station and substation location of a store. Byte 1 is composed of two

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WeaponLoad.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WeaponLoad.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Weapon Load (ST 0601 tag 60).
+ * Weapon Load (ST 0601 Item 60).
  *
  * <p>From ST:
  *
@@ -9,8 +9,8 @@ package org.jmisb.api.klv.st0601;
  *
  * Current weapons stored on aircraft.
  *
- * <p>Note: the Weapon Stores (Tag 140) replaces the Weapon Load (Tag 60) and Weapon Fired (Tag 61)
- * for providing information about Weapons and their status.
+ * <p>Note: the Weapon Stores (Item 140) replaces the Weapon Load (Item 60) and Weapon Fired (Item
+ * 61) for providing information about Weapons and their status.
  *
  * <p>The Weapon Load item is composed of two bytes: the first byte indicates the aircraft store
  * location, and the second byte indicates the store type. Each byte is composed of two nibbles with

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WeaponsStores.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WeaponsStores.java
@@ -12,7 +12,7 @@ import org.jmisb.api.klv.st0601.dto.WeaponStoreStatus;
 import org.jmisb.core.klv.ArrayUtils;
 
 /**
- * Weapons Stores (ST 0601 tag 140).
+ * Weapons Stores (ST 0601 Item 140).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WindDirectionAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WindDirectionAngle.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0601;
 
 /**
- * Wind Direction (ST 0601 tag 35)
+ * Wind Direction (ST 0601 Item 35).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WindSpeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WindSpeed.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * Wind Speed (ST 0601 tag 36)
+ * Wind Speed (ST 0601 Item 36).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ZoomPercentage.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ZoomPercentage.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601;
 import org.jmisb.api.klv.st1201.FpEncoder;
 
 /**
- * Zoom Percentage (Tag 134).
+ * Zoom Percentage (Item 134).
  *
  * <p>From ST:
  *

--- a/api/src/main/java/org/jmisb/api/klv/st0601/dto/Location.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/dto/Location.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601.dto;
 /**
  * Data transfer object for Location.
  *
- * <p>This is used by Airbase Locations (ST0601 Tag 130) and Waypoint List (ST0601 Tag 141).
+ * <p>This is used by Airbase Locations (ST0601 Item 130) and Waypoint List (ST0601 Item 141).
  */
 public class Location {
     private double latitude;

--- a/api/src/main/java/org/jmisb/api/klv/st0601/dto/Payload.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/dto/Payload.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 /**
  * Data transfer object for Payload.
  *
- * <p>This is used by Payload List (ST0601 Tag 138).
+ * <p>This is used by Payload List (ST0601 Item 138).
  */
 public class Payload {
     private int identifier;
@@ -29,7 +29,7 @@ public class Payload {
      * The identifier for this payload.
      *
      * <p>The Payload Identifier is a unique BER-OID integer sequentially assigned starting with the
-     * number zero (0). The Active Payload (Tag 139) uses the Payload Identifier to specify which
+     * number zero (0). The Active Payload (Item 139) uses the Payload Identifier to specify which
      * payloads are active.
      *
      * @return the identifier.
@@ -42,7 +42,7 @@ public class Payload {
      * Set the identifier for this payload.
      *
      * <p>The Payload Identifier is a unique BER-OID integer sequentially assigned starting with the
-     * number zero (0). The Active Payload (Tag 139) uses the Payload Identifier to specify which
+     * number zero (0). The Active Payload (Item 139) uses the Payload Identifier to specify which
      * payloads are active.
      *
      * @param identifier the zero index payload identifier.

--- a/api/src/main/java/org/jmisb/api/klv/st0601/dto/Waypoint.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/dto/Waypoint.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0601.dto;
 /**
  * Data transfer object for Waypoint information.
  *
- * <p>This is used by Waypoint List (ST0601 Tag 141).
+ * <p>This is used by Waypoint List (ST0601 Item 141).
  */
 public class Waypoint {
     private int waypointID;

--- a/api/src/main/java/org/jmisb/api/klv/st0601/dto/WeaponStoreStatus.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/dto/WeaponStoreStatus.java
@@ -6,7 +6,7 @@ import java.util.Map;
 /**
  * Weapon / Store Status code.
  *
- * <p>This is the "General Status" from ST0601 Tag 140.
+ * <p>This is the "General Status" from ST0601 Item 140.
  */
 public enum WeaponStoreStatus {
     /** Off - No power operating power is available to the Store. */

--- a/api/src/test/java/org/jmisb/api/klv/st0601/CornerOffsetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/CornerOffsetTest.java
@@ -164,7 +164,7 @@ public class CornerOffsetTest {
     // ST0601.16 changed the test values.
     @Test
     public void testST0601_16() throws KlvParseException {
-        // Tag 26
+        // Item 26
         byte[] bytes = new byte[] {(byte) 0x17, (byte) 0x50};
         IUasDatalinkValue v =
                 UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLatitudePoint1, bytes);
@@ -175,7 +175,7 @@ public class CornerOffsetTest {
         Assert.assertEquals(offset.getDisplayableValue(), "0.0137\u00B0");
         Assert.assertEquals(offset.getDisplayName(), "Offset Corner Latitude Point 1");
 
-        // Tag 27
+        // Item 27
         bytes = new byte[] {(byte) 0x06, (byte) 0x3f};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLongitudePoint1, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
@@ -185,7 +185,7 @@ public class CornerOffsetTest {
         Assert.assertEquals(offset.getDisplayableValue(), "0.0037\u00B0");
         Assert.assertEquals(offset.getDisplayName(), "Offset Corner Longitude Point 1");
 
-        // Tag 28
+        // Item 28
         bytes = new byte[] {(byte) 0xF9, (byte) 0xC1};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLatitudePoint2, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
@@ -195,7 +195,7 @@ public class CornerOffsetTest {
         Assert.assertEquals(offset.getDisplayableValue(), "-0.0037\u00B0");
         Assert.assertEquals(offset.getDisplayName(), "Offset Corner Latitude Point 2");
 
-        // Tag 29
+        // Item 29
         bytes = new byte[] {(byte) 0x17, (byte) 0x50};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLongitudePoint2, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
@@ -205,7 +205,7 @@ public class CornerOffsetTest {
         Assert.assertEquals(offset.getDisplayableValue(), "0.0137\u00B0");
         Assert.assertEquals(offset.getDisplayName(), "Offset Corner Longitude Point 2");
 
-        // Tag 30
+        // Item 30
         bytes = new byte[] {(byte) 0xED, (byte) 0x1F};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLatitudePoint3, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
@@ -215,7 +215,7 @@ public class CornerOffsetTest {
         Assert.assertEquals(offset.getDisplayableValue(), "-0.0111\u00B0");
         Assert.assertEquals(offset.getDisplayName(), "Offset Corner Latitude Point 3");
 
-        // Tag 31
+        // Item 31
         bytes = new byte[] {(byte) 0xF7, (byte) 0x32};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLongitudePoint3, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
@@ -225,7 +225,7 @@ public class CornerOffsetTest {
         Assert.assertEquals(offset.getDisplayableValue(), "-0.0052\u00B0");
         Assert.assertEquals(offset.getDisplayName(), "Offset Corner Longitude Point 3");
 
-        // Tag 32
+        // Item 32
         bytes = new byte[] {(byte) 0x01, (byte) 0xD0};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLatitudePoint4, bytes);
         Assert.assertTrue(v instanceof CornerOffset);
@@ -235,7 +235,7 @@ public class CornerOffsetTest {
         Assert.assertEquals(offset.getDisplayableValue(), "0.0011\u00B0");
         Assert.assertEquals(offset.getDisplayName(), "Offset Corner Latitude Point 4");
 
-        // Tag 33
+        // Item 33
         bytes = new byte[] {(byte) 0xEB, (byte) 0x3F};
         v = UasDatalinkFactory.createValue(UasDatalinkTag.OffsetCornerLongitudePoint4, bytes);
         Assert.assertTrue(v instanceof CornerOffset);

--- a/api/src/test/java/org/jmisb/api/klv/st0601/SensorAngleRateTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/SensorAngleRateTest.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
 
 public class SensorAngleRateTest {
     @Test
-    public void testConstructFromValueTag117() {
+    public void testConstructFromValueItem117() {
         // From ST
         SensorAngleRate rate = new SensorAzimuthRate(1);
         Assert.assertEquals(rate.getBytes(), new byte[] {(byte) 0x3E, (byte) 0x90, (byte) 0x00});
@@ -15,7 +15,7 @@ public class SensorAngleRateTest {
     }
 
     @Test
-    public void testConstructFromEncodedTag117() {
+    public void testConstructFromEncodedItem117() {
         // From ST
         SensorAngleRate rate = new SensorAzimuthRate(new byte[] {(byte) 0x3E, (byte) 0x90});
         Assert.assertEquals(rate.getAngleRate(), 1.0, 0.01);
@@ -24,7 +24,7 @@ public class SensorAngleRateTest {
     }
 
     @Test
-    public void testFactoryTag117() throws KlvParseException {
+    public void testFactoryItem117() throws KlvParseException {
         byte[] bytes = new byte[] {(byte) 0x3E, (byte) 0x90};
         IUasDatalinkValue v =
                 UasDatalinkFactory.createValue(UasDatalinkTag.SensorAzimuthRate, bytes);
@@ -36,7 +36,7 @@ public class SensorAngleRateTest {
     }
 
     @Test
-    public void testConstructFromValueTag118() {
+    public void testConstructFromValueItem118() {
         // From ST
         SensorAngleRate rate = new SensorElevationRate(0.004176);
         Assert.assertEquals(rate.getBytes(), new byte[] {(byte) 0x3E, (byte) 0x80, (byte) 0x11});
@@ -45,7 +45,7 @@ public class SensorAngleRateTest {
     }
 
     @Test
-    public void testConstructFromEncodedTag118() {
+    public void testConstructFromEncodedItem118() {
         // From ST:
         SensorAngleRate rate =
                 new SensorElevationRate(new byte[] {(byte) 0x3E, (byte) 0x80, (byte) 0x11});
@@ -55,7 +55,7 @@ public class SensorAngleRateTest {
     }
 
     @Test
-    public void testFactoryTag118() throws KlvParseException {
+    public void testFactoryItem118() throws KlvParseException {
         byte[] bytes = new byte[] {(byte) 0x3E, (byte) 0x80, (byte) 0x11};
         IUasDatalinkValue v =
                 UasDatalinkFactory.createValue(UasDatalinkTag.SensorElevationRate, bytes);
@@ -67,7 +67,7 @@ public class SensorAngleRateTest {
     }
 
     @Test
-    public void testConstructFromValueTag119() {
+    public void testConstructFromValueItem119() {
         // From ST
         SensorAngleRate rate = new SensorRollRate(-50);
         Assert.assertEquals(rate.getBytes(), new byte[] {(byte) 0x3B, (byte) 0x60, (byte) 0x00});
@@ -76,7 +76,7 @@ public class SensorAngleRateTest {
     }
 
     @Test
-    public void testConstructFromEncodedTag119() {
+    public void testConstructFromEncodedItem119() {
         // From ST:
         SensorAngleRate rate = new SensorRollRate(new byte[] {(byte) 0x3B, (byte) 0x60});
         Assert.assertEquals(rate.getAngleRate(), -50.0, 0.001);
@@ -85,7 +85,7 @@ public class SensorAngleRateTest {
     }
 
     @Test
-    public void testFactoryTag119() throws KlvParseException {
+    public void testFactoryItem119() throws KlvParseException {
         byte[] bytes = new byte[] {(byte) 0x3B, (byte) 0x60};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.SensorRollRate, bytes);
         Assert.assertTrue(v instanceof SensorRollRate);

--- a/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkLongitudeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/UasDatalinkLongitudeTest.java
@@ -146,7 +146,7 @@ public class UasDatalinkLongitudeTest {
 
     // Test values changed in ST0601.16
     @Test
-    public void testST0601_16_Tag83() throws KlvParseException {
+    public void testST0601_16_Item83() throws KlvParseException {
         byte[] bytes = new byte[] {(byte) 0x14, (byte) 0xbc, (byte) 0xb2, (byte) 0xc0};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLonPt1, bytes);
         Assert.assertTrue(v instanceof FullCornerLongitude);
@@ -158,7 +158,7 @@ public class UasDatalinkLongitudeTest {
     }
 
     @Test
-    public void testST0601_16_Tag85() throws KlvParseException {
+    public void testST0601_16_Item85() throws KlvParseException {
         byte[] bytes = new byte[] {(byte) 0x14, (byte) 0xbe, (byte) 0x84, (byte) 0xc8};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLonPt2, bytes);
         Assert.assertTrue(v instanceof FullCornerLongitude);
@@ -170,7 +170,7 @@ public class UasDatalinkLongitudeTest {
     }
 
     @Test
-    public void testST0601_16_Tag87() throws KlvParseException {
+    public void testST0601_16_Item87() throws KlvParseException {
         byte[] bytes = new byte[] {(byte) 0x14, (byte) 0xBB, (byte) 0x17, (byte) 0xAF};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLonPt3, bytes);
         Assert.assertTrue(v instanceof FullCornerLongitude);
@@ -182,7 +182,7 @@ public class UasDatalinkLongitudeTest {
     }
 
     @Test
-    public void testST0601_16_Tag89() throws KlvParseException {
+    public void testST0601_16_Item89() throws KlvParseException {
         byte[] bytes = new byte[] {(byte) 0x14, (byte) 0xB9, (byte) 0xD1, (byte) 0x76};
         IUasDatalinkValue v = UasDatalinkFactory.createValue(UasDatalinkTag.CornerLonPt4, bytes);
         Assert.assertTrue(v instanceof FullCornerLongitude);


### PR DESCRIPTION
## Motivation and Context
This updates the documentation for the ST0601 implementation to reflect a change in terminology. It makes it easier to distinguish the item as a whole from just the tag part of the Tag/Length/Value item.

Resolves #173.

This doesn't change other implementations (e.g. VMTI or RVT), although I expect those to change at some stage.

## Description
Just update of javadoc. I added full stop (period) markers at the end of the javadoc where it was missing (and I was editing the line in any case).

## How Has This Been Tested?
Just rebuilt (including unit and integration tests).
Inspected the resulting javadoc.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

