### PR TITLE
st0601: implement GenericFlagData01 (item 47)

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/FlagDataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FlagDataKey.java
@@ -1,0 +1,29 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.klv.IKlvKey;
+
+/**
+ * Enumeration of the various flags used in GenericFlagData01.
+ *
+ * <p>Each of these corresponds to a single bit in the GenericFlagData01 data. The tag value matches
+ * the bit (where 0 is the least significant bit).
+ */
+public enum FlagDataKey implements IKlvKey {
+    LaserRange(0),
+    AutoTrack(1),
+    IR_Polarity(2),
+    IcingStatus(3),
+    SlantRange(4),
+    ImageInvalid(5);
+
+    FlagDataKey(int key) {
+        this.tag = key;
+    }
+
+    private final int tag;
+
+    @Override
+    public int getTag() {
+        return tag;
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/GenericFlagData01.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/GenericFlagData01.java
@@ -1,0 +1,245 @@
+package org.jmisb.api.klv.st0601;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.jmisb.api.klv.IKlvKey;
+
+/**
+ * Generic Flag Data (ST 0601 Item 47).
+ *
+ * <p>From ST:
+ *
+ * <blockquote>
+ *
+ * Generic metadata flags.
+ *
+ * <p>The Generic Data Flags are miscellaneous boolean (yes / no) aircraft and image related data
+ * settings which are individual bits in a single byte value.
+ *
+ * </blockquote>
+ *
+ * Initial versions of ST0601.13, ST0601.14, ST0601.15 and ST0601.16 inadvertently reversed the
+ * meaning of these bits. We use the original (intended) meaning as published in the updated
+ * (ST0601.13a, ST0601.14a, ST0601.15a and ST0601.16a) versions, not the interpretation published in
+ * the initial versions.
+ */
+public class GenericFlagData01 implements IUasDatalinkValue {
+
+    protected static final String LASER_RANGE_STRING_KEY = "Laser Range";
+    protected static final String LASER_OFF = "Laser off";
+    protected static final String LASER_ON = "Laser on";
+
+    protected static final String AUTO_TRACK_STRING_KEY = "Auto-Track";
+    protected static final String AUTO_TRACK_OFF = "Auto-Track off";
+    protected static final String AUTO_TRACK_ON = "Auto-Track on";
+
+    protected static final String IR_POLARITY_STRING_KEY = "IR Polarity";
+    protected static final String WHITE_HOT = "White Hot";
+    protected static final String BLACK_HOT = "Black Hot";
+
+    protected static final String ICING_STATUS_STRING_KEY = "Icing Status";
+    protected static final String NO_ICING_DETECTED = "No Icing Detected";
+    protected static final String ICING_DETECTED = "Icing Detected";
+
+    protected static final String SLANT_RANGE_STRING_KEY = "Slant Range";
+    protected static final String CALCULATED = "Calculated";
+    protected static final String MEASURED = "Measured";
+
+    protected static final String IMAGE_INVALID_STRING_KEY = "Image Invalid";
+    protected static final String IMAGE_INVALID = "Image Invalid";
+    protected static final String IMAGE_VALID = "Image Valid";
+
+    private final SortedMap<FlagDataKey, UasDatalinkString> map = new TreeMap<>();
+
+    /**
+     * Create from value.
+     *
+     * <p>Each of the keys that is set in the parameter list will be set (1). The meaning of set is:
+     *
+     * <ul>
+     *   <li>LaserRange: Laser is on.
+     *   <li>AutoTrack: Auto-track is on.
+     *   <li>IR_Polarity: Black hot.
+     *   <li>IcingStatus: Icing detected.
+     *   <li>SlantRange: Measured.
+     * </ul>
+     *
+     * @param values the values to set on this flagged data instance.
+     */
+    public GenericFlagData01(List<FlagDataKey> values) {
+        if (values.contains(FlagDataKey.LaserRange)) {
+            map.put(
+                    FlagDataKey.LaserRange,
+                    new UasDatalinkString(LASER_RANGE_STRING_KEY, LASER_ON));
+        } else {
+            map.put(
+                    FlagDataKey.LaserRange,
+                    new UasDatalinkString(LASER_RANGE_STRING_KEY, LASER_OFF));
+        }
+
+        if (values.contains(FlagDataKey.AutoTrack)) {
+            map.put(
+                    FlagDataKey.AutoTrack,
+                    new UasDatalinkString(AUTO_TRACK_STRING_KEY, AUTO_TRACK_ON));
+        } else {
+            map.put(
+                    FlagDataKey.AutoTrack,
+                    new UasDatalinkString(AUTO_TRACK_STRING_KEY, AUTO_TRACK_OFF));
+        }
+
+        if (values.contains(FlagDataKey.IR_Polarity)) {
+            map.put(
+                    FlagDataKey.IR_Polarity,
+                    new UasDatalinkString(IR_POLARITY_STRING_KEY, BLACK_HOT));
+        } else {
+            map.put(
+                    FlagDataKey.IR_Polarity,
+                    new UasDatalinkString(IR_POLARITY_STRING_KEY, WHITE_HOT));
+        }
+
+        if (values.contains(FlagDataKey.IcingStatus)) {
+            map.put(
+                    FlagDataKey.IcingStatus,
+                    new UasDatalinkString(ICING_STATUS_STRING_KEY, ICING_DETECTED));
+        } else {
+            map.put(
+                    FlagDataKey.IcingStatus,
+                    new UasDatalinkString(ICING_STATUS_STRING_KEY, NO_ICING_DETECTED));
+        }
+
+        if (values.contains(FlagDataKey.SlantRange)) {
+            map.put(
+                    FlagDataKey.SlantRange,
+                    new UasDatalinkString(SLANT_RANGE_STRING_KEY, MEASURED));
+        } else {
+            map.put(
+                    FlagDataKey.SlantRange,
+                    new UasDatalinkString(SLANT_RANGE_STRING_KEY, CALCULATED));
+        }
+
+        if (values.contains(FlagDataKey.ImageInvalid)) {
+            map.put(
+                    FlagDataKey.ImageInvalid,
+                    new UasDatalinkString(IMAGE_INVALID_STRING_KEY, IMAGE_INVALID));
+        } else {
+            map.put(
+                    FlagDataKey.ImageInvalid,
+                    new UasDatalinkString(IMAGE_INVALID_STRING_KEY, IMAGE_VALID));
+        }
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * @param bytes array of single byte containing flag values.
+     */
+    public GenericFlagData01(byte[] bytes) {
+        byte flags = bytes[bytes.length - 1];
+        if ((flags & 0x01) == 0x01) {
+            map.put(
+                    FlagDataKey.LaserRange,
+                    new UasDatalinkString(LASER_RANGE_STRING_KEY, LASER_ON));
+        } else {
+            map.put(
+                    FlagDataKey.LaserRange,
+                    new UasDatalinkString(LASER_RANGE_STRING_KEY, LASER_OFF));
+        }
+
+        if ((flags & 0x02) == 0x02) {
+            map.put(
+                    FlagDataKey.AutoTrack,
+                    new UasDatalinkString(AUTO_TRACK_STRING_KEY, AUTO_TRACK_ON));
+        } else {
+            map.put(
+                    FlagDataKey.AutoTrack,
+                    new UasDatalinkString(AUTO_TRACK_STRING_KEY, AUTO_TRACK_OFF));
+        }
+
+        if ((flags & 0x04) == 0x04) {
+            map.put(
+                    FlagDataKey.IR_Polarity,
+                    new UasDatalinkString(IR_POLARITY_STRING_KEY, BLACK_HOT));
+        } else {
+            map.put(
+                    FlagDataKey.IR_Polarity,
+                    new UasDatalinkString(IR_POLARITY_STRING_KEY, WHITE_HOT));
+        }
+
+        if ((flags & 0x08) == 0x08) {
+            map.put(
+                    FlagDataKey.IcingStatus,
+                    new UasDatalinkString(ICING_STATUS_STRING_KEY, ICING_DETECTED));
+        } else {
+            map.put(
+                    FlagDataKey.IcingStatus,
+                    new UasDatalinkString(ICING_STATUS_STRING_KEY, NO_ICING_DETECTED));
+        }
+
+        if ((flags & 0x10) == 0x10) {
+            map.put(
+                    FlagDataKey.SlantRange,
+                    new UasDatalinkString(SLANT_RANGE_STRING_KEY, MEASURED));
+        } else {
+            map.put(
+                    FlagDataKey.SlantRange,
+                    new UasDatalinkString(SLANT_RANGE_STRING_KEY, CALCULATED));
+        }
+
+        if ((flags & 0x20) == 0x20) {
+            map.put(
+                    FlagDataKey.ImageInvalid,
+                    new UasDatalinkString(IMAGE_INVALID_STRING_KEY, IMAGE_INVALID));
+        } else {
+            map.put(
+                    FlagDataKey.ImageInvalid,
+                    new UasDatalinkString(IMAGE_INVALID_STRING_KEY, IMAGE_VALID));
+        }
+    }
+
+    @Override
+    public byte[] getBytes() {
+        byte[] bytes = new byte[] {0x00};
+        if (map.get(FlagDataKey.LaserRange).getDisplayableValue().equals(LASER_ON)) {
+            bytes[0] += (byte) 0x01;
+        }
+        if (map.get(FlagDataKey.AutoTrack).getDisplayableValue().equals(AUTO_TRACK_ON)) {
+            bytes[0] += (byte) 0x02;
+        }
+        if (map.get(FlagDataKey.IR_Polarity).getDisplayableValue().equals(BLACK_HOT)) {
+            bytes[0] += (byte) 0x04;
+        }
+        if (map.get(FlagDataKey.IcingStatus).getDisplayableValue().equals(ICING_DETECTED)) {
+            bytes[0] += (byte) 0x08;
+        }
+        if (map.get(FlagDataKey.SlantRange).getDisplayableValue().equals(MEASURED)) {
+            bytes[0] += (byte) 0x10;
+        }
+        if (map.get(FlagDataKey.ImageInvalid).getDisplayableValue().equals(IMAGE_INVALID)) {
+            bytes[0] += (byte) 0x20;
+        }
+        return bytes;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Generic Flag Data 01";
+    }
+
+    @Override
+    public String getDisplayableValue() {
+        return "[Flag data]";
+    }
+
+    public UasDatalinkString getField(IKlvKey tag) {
+        if (tag instanceof FlagDataKey) {
+            return map.get((FlagDataKey) tag);
+        }
+        return null;
+    }
+
+    public Set<? extends IKlvKey> getTags() {
+        return map.keySet();
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkFactory.java
@@ -113,8 +113,7 @@ public class UasDatalinkFactory {
             case TargetErrorLe90:
                 return new TargetErrorEstimateLe90(bytes);
             case GenericFlagData01:
-                // TODO
-                return new OpaqueValue(bytes);
+                return new GenericFlagData01(bytes);
             case SecurityLocalMetadataSet:
                 return new NestedSecurityMetadata(bytes);
             case DifferentialPressure:

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -133,10 +133,10 @@ public enum UasDatalinkTag {
      * direction; Value is a {@link TargetErrorEstimateLe90}
      */
     TargetErrorLe90(46),
-    /** Tag 47; Generic metadata flags; Value is a {@link OpaqueValue} */
+    /** Tag 47; Generic metadata flags; Value is a {@link GenericFlagData01} */
     GenericFlagData01(47),
     /**
-     * Tag 48; MISB ST 0102 local let Security Metadata items; Value is a {@link
+     * Tag 48; MISB ST 0102 local set Security Metadata items; Value is a {@link
      * NestedSecurityMetadata}
      */
     SecurityLocalMetadataSet(48),

--- a/api/src/test/java/org/jmisb/api/klv/st0601/FlagDataKeyTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/FlagDataKeyTest.java
@@ -1,0 +1,18 @@
+package org.jmisb.api.klv.st0601;
+
+import static org.testng.Assert.*;
+
+import org.testng.annotations.Test;
+
+/** Tests for FlagDataKey enumeration. */
+public class FlagDataKeyTest {
+
+    @Test
+    public void checkEnumeration() {
+        assertEquals(FlagDataKey.LaserRange.getTag(), 0);
+
+        assertEquals(FlagDataKey.ImageInvalid.getTag(), 5);
+
+        assertEquals(FlagDataKey.IR_Polarity.getTag(), 2);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/GenericFlagData01Test.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/GenericFlagData01Test.java
@@ -1,0 +1,146 @@
+package org.jmisb.api.klv.st0601;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IKlvKey;
+import org.testng.annotations.Test;
+
+public class GenericFlagData01Test {
+    private final byte[] st_example_bytes = new byte[] {0x31};
+
+    @Test
+    public void testConstructFromValue() {
+        List<FlagDataKey> bitsToTurnOn = new ArrayList<>();
+        bitsToTurnOn.add(FlagDataKey.LaserRange);
+        bitsToTurnOn.add(FlagDataKey.SlantRange);
+        bitsToTurnOn.add(FlagDataKey.ImageInvalid);
+        GenericFlagData01 flags = new GenericFlagData01(bitsToTurnOn);
+        checkFlags(flags);
+    }
+
+    @Test
+    public void testConstructFromEncoded() {
+        GenericFlagData01 flags = new GenericFlagData01(st_example_bytes);
+        checkFlags(flags);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException {
+        IUasDatalinkValue v =
+                UasDatalinkFactory.createValue(UasDatalinkTag.GenericFlagData01, st_example_bytes);
+        assertTrue(v instanceof GenericFlagData01);
+        GenericFlagData01 flags = (GenericFlagData01) v;
+        checkFlags(flags);
+    }
+
+    private void checkFlags(GenericFlagData01 flags) {
+        assertEquals(flags.getField(FlagDataKey.LaserRange).getDisplayableValue(), "Laser on");
+        assertEquals(flags.getField(FlagDataKey.AutoTrack).getDisplayableValue(), "Auto-Track off");
+        assertEquals(flags.getField(FlagDataKey.IR_Polarity).getDisplayableValue(), "White Hot");
+        assertEquals(
+                flags.getField(FlagDataKey.IcingStatus).getDisplayableValue(), "No Icing Detected");
+        assertEquals(flags.getField(FlagDataKey.SlantRange).getDisplayableValue(), "Measured");
+        assertEquals(
+                flags.getField(FlagDataKey.ImageInvalid).getDisplayableValue(), "Image Invalid");
+        assertEquals(flags.getBytes(), st_example_bytes);
+        assertEquals(flags.getDisplayableValue(), "[Flag data]");
+        assertEquals(flags.getDisplayName(), "Generic Flag Data 01");
+        Set<FlagDataKey> expectedKeys = new HashSet<>();
+        expectedKeys.add(FlagDataKey.LaserRange);
+        expectedKeys.add(FlagDataKey.AutoTrack);
+        expectedKeys.add(FlagDataKey.IR_Polarity);
+        expectedKeys.add(FlagDataKey.IcingStatus);
+        expectedKeys.add(FlagDataKey.SlantRange);
+        expectedKeys.add(FlagDataKey.ImageInvalid);
+        assertEquals(flags.getTags(), expectedKeys);
+    }
+
+    @Test
+    public void testConstructFromValueAllOn() {
+        List<FlagDataKey> bitsToTurnOn = new ArrayList<>();
+        bitsToTurnOn.add(FlagDataKey.LaserRange);
+        bitsToTurnOn.add(FlagDataKey.AutoTrack);
+        bitsToTurnOn.add(FlagDataKey.IR_Polarity);
+        bitsToTurnOn.add(FlagDataKey.IcingStatus);
+        bitsToTurnOn.add(FlagDataKey.SlantRange);
+        bitsToTurnOn.add(FlagDataKey.ImageInvalid);
+        GenericFlagData01 flags = new GenericFlagData01(bitsToTurnOn);
+        checkFlagsAllOn(flags);
+    }
+
+    @Test
+    public void testConstructFromEncodedAllOn() {
+        GenericFlagData01 flags = new GenericFlagData01(new byte[] {0x3f});
+        checkFlagsAllOn(flags);
+    }
+
+    protected void checkFlagsAllOn(GenericFlagData01 flags) {
+        assertEquals(flags.getField(FlagDataKey.LaserRange).getDisplayableValue(), "Laser on");
+        assertEquals(flags.getField(FlagDataKey.AutoTrack).getDisplayableValue(), "Auto-Track on");
+        assertEquals(flags.getField(FlagDataKey.IR_Polarity).getDisplayableValue(), "Black Hot");
+        assertEquals(
+                flags.getField(FlagDataKey.IcingStatus).getDisplayableValue(), "Icing Detected");
+        assertEquals(flags.getField(FlagDataKey.SlantRange).getDisplayableValue(), "Measured");
+        assertEquals(
+                flags.getField(FlagDataKey.ImageInvalid).getDisplayableValue(), "Image Invalid");
+        assertEquals(flags.getBytes(), new byte[] {0x3f});
+        assertEquals(flags.getDisplayableValue(), "[Flag data]");
+        assertEquals(flags.getDisplayName(), "Generic Flag Data 01");
+        Set<FlagDataKey> expectedKeys = new HashSet<>();
+        expectedKeys.add(FlagDataKey.LaserRange);
+        expectedKeys.add(FlagDataKey.AutoTrack);
+        expectedKeys.add(FlagDataKey.IR_Polarity);
+        expectedKeys.add(FlagDataKey.IcingStatus);
+        expectedKeys.add(FlagDataKey.SlantRange);
+        expectedKeys.add(FlagDataKey.ImageInvalid);
+        assertEquals(flags.getTags(), expectedKeys);
+    }
+
+    @Test
+    public void testConstructFromValueAllOff() {
+        List<FlagDataKey> bitsToTurnOn = new ArrayList<>();
+        GenericFlagData01 flags = new GenericFlagData01(bitsToTurnOn);
+        checkFlagsAllOff(flags);
+    }
+
+    @Test
+    public void testConstructFromEncodedAllOff() {
+        GenericFlagData01 flags = new GenericFlagData01(new byte[] {0x00});
+        checkFlagsAllOff(flags);
+    }
+
+    protected void checkFlagsAllOff(GenericFlagData01 flags) {
+        assertEquals(flags.getField(FlagDataKey.LaserRange).getDisplayableValue(), "Laser off");
+        assertEquals(flags.getField(FlagDataKey.AutoTrack).getDisplayableValue(), "Auto-Track off");
+        assertEquals(flags.getField(FlagDataKey.IR_Polarity).getDisplayableValue(), "White Hot");
+        assertEquals(
+                flags.getField(FlagDataKey.IcingStatus).getDisplayableValue(), "No Icing Detected");
+        assertEquals(flags.getField(FlagDataKey.SlantRange).getDisplayableValue(), "Calculated");
+        assertEquals(flags.getField(FlagDataKey.ImageInvalid).getDisplayableValue(), "Image Valid");
+        assertEquals(flags.getBytes(), new byte[] {0x00});
+        assertEquals(flags.getDisplayableValue(), "[Flag data]");
+        assertEquals(flags.getDisplayName(), "Generic Flag Data 01");
+        Set<FlagDataKey> expectedKeys = new HashSet<>();
+        expectedKeys.add(FlagDataKey.LaserRange);
+        expectedKeys.add(FlagDataKey.AutoTrack);
+        expectedKeys.add(FlagDataKey.IR_Polarity);
+        expectedKeys.add(FlagDataKey.IcingStatus);
+        expectedKeys.add(FlagDataKey.SlantRange);
+        expectedKeys.add(FlagDataKey.ImageInvalid);
+        assertEquals(flags.getTags(), expectedKeys);
+    }
+
+    @Test
+    public void testNoKey() {
+        GenericFlagData01 flags = new GenericFlagData01(new byte[] {0x00});
+        IKlvKey noSuchKey = () -> 616;
+        assertNull(flags.getField(noSuchKey));
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Implements an item in ST0601 that we don't yet support.

Resolves #165.

## Description
Adds an IUasMetadataValue implementation, and an enumeration for the bit-level "keys".

The implementation is set up to support the nested display capability that I hope to merge soon.

## How Has This Been Tested?
Wrote new unit tests, and ran the viewer application against video that included this tag (from the MISB FLI data), and some other video that didn't include it.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

*Checks were restarted, and subsequently passed*
