### PR TITLE
build: add dependency check to continuous integration

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,20 @@
+name: Quality Assurance Checks
+
+on:
+    push:
+      branches: [ develop ]
+    pull_request:
+      branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Build and check dependencies
+        run: mvn -B package --file pom.xml -Pdependencycheck

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           java-version: 1.11
       - name: Build and check dependencies
-        run: mvn -B package --file pom.xml -Pdependencycheck
+        run: mvn -B install --file pom.xml -Pdependencycheck

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -166,7 +166,7 @@
                         <artifactId>dependency-check-maven</artifactId>
                         <version>${owasp.version}</version>
                         <configuration>
-                            <failBuildOnCVSS>8</failBuildOnCVSS>
+                            <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                             <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         </configuration>
                         <executions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -93,7 +93,7 @@
                         <artifactId>dependency-check-maven</artifactId>
                         <version>${owasp.version}</version>
                         <configuration>
-                            <failBuildOnCVSS>8</failBuildOnCVSS>
+                            <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                             <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         </configuration>
                         <executions>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -115,7 +115,7 @@
                         <artifactId>dependency-check-maven</artifactId>
                         <version>${owasp.version}</version>
                         <configuration>
-                            <failBuildOnCVSS>8</failBuildOnCVSS>
+                            <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                             <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         </configuration>
                         <executions>


### PR DESCRIPTION
## Motivation and Context
We have a `dependencycheck` profile, but it isn't in the main build (because it takes a fair time to run, especially the first time each day). This adds the profile to a CI action.

Resolves #178.

## Description
Uses github actions to build on linux with the profile enabled. The profile configuration is updated to fail the build if there are any vulnerable dependencies.

## How Has This Been Tested?
Tested by updating to 5.3.2 (see #180) and running the build (with `-Pdependencycheck`), which causes a build failure.
That is verified during this PR. 

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

*Note the failing QA check - that is "success" for this PR, and is resolved in #179.*
