### PR TITLE
st1909: initial implementation

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st1909/MetadataItems.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1909/MetadataItems.java
@@ -1,0 +1,58 @@
+package org.jmisb.api.klv.st1909;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * ST 1909 Metadata key/value pairs.
+ *
+ * <p>This is used to transfer metadata between the source format (e.g. ST0601) and the renderer.
+ */
+public class MetadataItems {
+    private Map<MetadataKey, String> items = new HashMap<>();
+
+    /**
+     * The keys in the metadata set.
+     *
+     * @return set of MetadataKey that have some data set (which might be an empty string).
+     */
+    public Set<MetadataKey> getItemKeys() {
+        return items.keySet();
+    }
+
+    /**
+     * Get the value for a specified key.
+     *
+     * @param key the key
+     * @return the string value, including any required prefix/suffix.
+     */
+    public String getValue(MetadataKey key) {
+        return items.get(key);
+    }
+
+    /**
+     * Add an item to the set of metadata key/value paris.
+     *
+     * @param key the key
+     * @param value the string value, including any required prefix/suffix.
+     */
+    public void addItem(MetadataKey key, String value) {
+        items.put(key, value);
+    }
+
+    /**
+     * Basic validity check for the metadata.
+     *
+     * @return true if there is some valid data to be shown.
+     */
+    public boolean isValid() {
+        // TODO: could be more sophisticated
+        return (!items.isEmpty());
+    }
+
+    /** Clear the metadata. */
+    public void clear() {
+        items.clear();
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st1909/MetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1909/MetadataKey.java
@@ -1,0 +1,46 @@
+package org.jmisb.api.klv.st1909;
+
+/**
+ * The valid keys for a metadata item.
+ *
+ * <p>This is not intended to be a normal KLV key, but rather the key in a key:value Map sense.
+ */
+public enum MetadataKey {
+    PlatformName("Platform Name"),
+    PlatformLatitude("Platform Latitude"),
+    PlatformLongitude("Platform Longitude"),
+    PlatformAltitude("Platform Altitude"),
+    TargetLatitude("Target Latitude"),
+    TargetLongitude("Target Longitude"),
+    TargetElevation("Target Elevation"),
+    VerticalFOV("Vertical FOV"),
+    HorizontalFOV("Horizontal FOV"),
+    TargetWidth("Target Width"),
+    SlantRange("Slant Range"),
+    MetadataTimestamp("Metadata Timestamp"),
+    LaserPrfCode("Laser PRF Code"),
+    MainSensorName("Main Sensor Name"),
+    AzAngle("Azimuth Angle"),
+    ElAngle("Elevation Angle"),
+    LaserSensorName("Laser Sensor Name"),
+    LaserSensorStatus("Laser Sensor Status"),
+    ClassificationAndReleasabilityLine1("Classification and Releasability Group Line 1"),
+    ClassificationAndReleasabilityLine2("Classification and Releasability Group Line 2"),
+    NorthAngle("True North Angle");
+
+    private final String text;
+
+    /**
+     * Constructor.
+     *
+     * @param text the human-readable name for the key.
+     */
+    MetadataKey(final String text) {
+        this.text = text;
+    }
+
+    @Override
+    public String toString() {
+        return text;
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st1909/OverlayRenderer.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1909/OverlayRenderer.java
@@ -1,0 +1,263 @@
+package org.jmisb.api.klv.st1909;
+
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Polygon;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.font.GlyphVector;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+
+/**
+ * Renderer for ST1909 Metadata Overlays.
+ *
+ * <p>This class takes BufferedImages and renders metadata text according to MISB ST1909 "Metadata
+ * Overlay for Visualization".
+ */
+public class OverlayRenderer {
+
+    private FontMetrics fontMetrics;
+    private int firstLineOffset;
+    private int lineSpacing;
+    private Graphics2D graphics2D;
+    private final OverlayRendererConfiguration configuration;
+
+    /**
+     * Create an overlay renderer with default options.
+     *
+     * <p>See {@link OverlayRendererConfiguration} for the options.
+     */
+    public OverlayRenderer() {
+        configuration = new OverlayRendererConfiguration();
+    }
+
+    /**
+     * Create overlay renderer with specified options.
+     *
+     * @param rendererConfiguration the configuration options.
+     */
+    public OverlayRenderer(OverlayRendererConfiguration rendererConfiguration) {
+        configuration = rendererConfiguration;
+    }
+
+    /**
+     * Render the metadata over the given image.
+     *
+     * @param image the image to draw on
+     * @param metadata the metadata key/value pairs
+     */
+    public void render(BufferedImage image, MetadataItems metadata) {
+        graphics2D = image.createGraphics();
+        graphics2D.setFont(configuration.getFont());
+        fontMetrics = graphics2D.getFontMetrics();
+        firstLineOffset = fontMetrics.getAscent();
+        lineSpacing = fontMetrics.getMaxAscent() + fontMetrics.getMaxDescent() + 1;
+        graphics2D.setColor(configuration.getFillColor());
+        graphics2D.setRenderingHint(
+                RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        graphics2D.setRenderingHint(
+                RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        renderMainSensorGroup(image, metadata);
+        renderTrueNorthArrowGroup(image, metadata);
+        renderLaserSensorGroup(image, metadata);
+        renderClassificationAndReleasabilityGroup(image, metadata);
+        renderPlatformGroup(image, metadata);
+        renderDateTimeGroup(image, metadata);
+        renderTargetGroup(image, metadata);
+        // TODO: reticle - need to manage target location if not in frame center mode, which will be
+        // messy.
+        graphics2D.dispose();
+    }
+
+    private void renderMainSensorGroup(BufferedImage image, MetadataItems metadata) {
+        // ST1909-02, but the rendering is based on the text base line, and we need to be strictly
+        // below that
+        int rowAnchor = (int) (image.getHeight() * 0.037) + firstLineOffset;
+        // ST1909-03
+        int columnAnchor = (int) (image.getWidth() * 0.02);
+        // ST1909-04
+        renderTextLeftAligned(metadata, MetadataKey.MainSensorName, columnAnchor, rowAnchor, 0);
+        renderTextLeftAligned(metadata, MetadataKey.AzAngle, columnAnchor, rowAnchor, 1);
+        renderTextLeftAligned(metadata, MetadataKey.ElAngle, columnAnchor, rowAnchor, 2);
+    }
+
+    private void renderTrueNorthArrowGroup(BufferedImage image, MetadataItems metadata) {
+        // ST1909-30
+        int columnAnchor = (int) (image.getWidth() * 0.02);
+        // ST1909-29
+        int rowAnchor = (int) (image.getHeight() * 0.5);
+        // ST1909-31
+        int size = configuration.getNorthCircleSize();
+        graphics2D.drawOval(columnAnchor, rowAnchor - size, 2 * size, 2 * size);
+        drawLetterN(columnAnchor, rowAnchor);
+        drawNorthArrow(metadata, columnAnchor, rowAnchor);
+    }
+
+    private void drawNorthArrow(MetadataItems metadata, int columnAnchor, int rowAnchor)
+            throws NumberFormatException {
+        if (metadata.getItemKeys().contains(MetadataKey.NorthAngle)) {
+            // ST1909-32
+            double northAngle =
+                    Double.parseDouble(metadata.getValue(MetadataKey.NorthAngle)) * Math.PI / 180.0;
+            Polygon triangle = calculateNorthArrowPolygon(northAngle, columnAnchor, rowAnchor);
+            graphics2D.drawPolygon(triangle);
+            graphics2D.fillPolygon(triangle);
+        }
+    }
+
+    private void drawLetterN(int columnAnchor, int rowAnchor) {
+        GlyphVector glyphVector =
+                configuration.getFont().createGlyphVector(graphics2D.getFontRenderContext(), "N");
+        Shape textShape = glyphVector.getOutline();
+        Rectangle2D bounds = textShape.getBounds2D();
+        int verticalOffset = (int) ((bounds.getMaxY() - bounds.getMinY()) / 2);
+        int horizontalOffset = (int) ((bounds.getMaxX() - bounds.getMinX()) / 2);
+        // ST1909-32
+        graphics2D.drawString(
+                "N",
+                columnAnchor + configuration.getNorthCircleSize() - horizontalOffset,
+                rowAnchor + verticalOffset);
+    }
+
+    private Polygon calculateNorthArrowPolygon(double northAngle, int columnAnchor, int rowAnchor) {
+        int size = configuration.getNorthCircleSize();
+        int columnOffset = size + calculateColumnOffset(size, northAngle);
+        int rowOffset = calculateRowOffset(size, northAngle);
+        Point triangleCentrePoint = new Point(columnAnchor + columnOffset, rowAnchor + rowOffset);
+        Polygon triangle = new Polygon();
+        int triangleSize = size / 4;
+        int x0 = triangleCentrePoint.x + calculateColumnOffset(triangleSize, northAngle);
+        int y0 = triangleCentrePoint.y + calculateRowOffset(triangleSize, northAngle);
+        double angle120 = 120.0 * Math.PI / 180.0;
+        triangle.addPoint(x0, y0);
+        int x1 = triangleCentrePoint.x + calculateColumnOffset(triangleSize, northAngle + angle120);
+        int y1 = triangleCentrePoint.y + calculateRowOffset(triangleSize, northAngle + angle120);
+        triangle.addPoint(x1, y1);
+        int x2 = triangleCentrePoint.x + calculateColumnOffset(triangleSize, northAngle - angle120);
+        int y2 = triangleCentrePoint.y + calculateRowOffset(triangleSize, northAngle - angle120);
+        triangle.addPoint(x2, y2);
+        return triangle;
+    }
+
+    // Exposed for unit testing purposes
+    protected int calculateRowOffset(int size, double northAngle) {
+        int rowOffset = (int) Math.round(Math.sin((-1 * northAngle) + (Math.PI / 2)) * size);
+        return -1 * rowOffset;
+    }
+
+    // Exposed for unit testing purposes
+    protected int calculateColumnOffset(int size, double northAngle) {
+        int columnOffset = (int) Math.round(Math.cos((-1 * northAngle) + (Math.PI / 2)) * size);
+        return columnOffset;
+    }
+
+    private void renderLaserSensorGroup(BufferedImage image, MetadataItems metadata) {
+        // ST1909-35
+        int columnAnchor = (int) (image.getWidth() * 0.02);
+        // ST1909-34
+        int rowAnchor = (int) (image.getHeight() * 0.963);
+        // ST1909-36
+        renderTextLeftAligned(metadata, MetadataKey.LaserSensorName, columnAnchor, rowAnchor, -2);
+        renderTextLeftAligned(metadata, MetadataKey.LaserSensorStatus, columnAnchor, rowAnchor, -1);
+        renderTextLeftAligned(metadata, MetadataKey.LaserPrfCode, columnAnchor, rowAnchor, 0);
+    }
+
+    private void renderClassificationAndReleasabilityGroup(
+            BufferedImage image, MetadataItems metadata) {
+        // ST1909-09, plus offset to make sure text is below anchor point per ST1909-11
+        int rowAnchor = (int) (image.getHeight() * 0.037) + firstLineOffset;
+        // ST1909-10
+        int columnAnchor = (int) (image.getWidth() * 0.5);
+        // ST1909-11
+        renderTextCentred(
+                metadata,
+                MetadataKey.ClassificationAndReleasabilityLine1,
+                columnAnchor,
+                rowAnchor,
+                0);
+        renderTextCentred(
+                metadata,
+                MetadataKey.ClassificationAndReleasabilityLine2,
+                columnAnchor,
+                rowAnchor,
+                1);
+    }
+
+    private void renderPlatformGroup(BufferedImage image, MetadataItems metadata) {
+        // ST1909-14, plus offset to make sure text is below anchor point per ST1909-16
+        int rowAnchor = (int) (image.getHeight() * 0.037) + firstLineOffset;
+        // ST1909-15
+        int columnAnchor = (int) (image.getWidth() * 0.98);
+        // ST1909-16
+        renderTextRightAligned(metadata, MetadataKey.PlatformName, columnAnchor, rowAnchor, 0);
+        renderTextRightAligned(metadata, MetadataKey.PlatformLatitude, columnAnchor, rowAnchor, 1);
+        renderTextRightAligned(metadata, MetadataKey.PlatformLongitude, columnAnchor, rowAnchor, 2);
+        renderTextRightAligned(metadata, MetadataKey.PlatformAltitude, columnAnchor, rowAnchor, 3);
+    }
+
+    private void renderTargetGroup(BufferedImage image, MetadataItems metadata) {
+        // ST1909-52
+        int columnAnchor = (int) (image.getWidth() * 0.98);
+        // ST1909-51
+        int rowAnchor = (int) (image.getHeight() * 0.963);
+        // ST1909-53
+        renderTextRightAligned(metadata, MetadataKey.TargetElevation, columnAnchor, rowAnchor, 0);
+        renderTextRightAligned(metadata, MetadataKey.TargetLongitude, columnAnchor, rowAnchor, -1);
+        renderTextRightAligned(metadata, MetadataKey.TargetLatitude, columnAnchor, rowAnchor, -2);
+        renderTextRightAligned(metadata, MetadataKey.VerticalFOV, columnAnchor, rowAnchor, -3);
+        renderTextRightAligned(metadata, MetadataKey.HorizontalFOV, columnAnchor, rowAnchor, -4);
+        renderTextRightAligned(metadata, MetadataKey.TargetWidth, columnAnchor, rowAnchor, -5);
+        renderTextRightAligned(metadata, MetadataKey.SlantRange, columnAnchor, rowAnchor, -6);
+    }
+
+    private void renderDateTimeGroup(BufferedImage image, MetadataItems metadata) {
+        // ST1909-44
+        int columnAnchor = (int) (image.getWidth() * 0.5);
+        // ST1909-43
+        int rowAnchor = (int) (image.getHeight() * 0.963);
+        // ST1909-45
+        renderTextCentred(metadata, MetadataKey.MetadataTimestamp, columnAnchor, rowAnchor, 0);
+        // TODO: frame timestamp.
+    }
+
+    private void renderTextLeftAligned(
+            MetadataItems metadata,
+            MetadataKey key,
+            int columnAnchor,
+            int rowAnchor,
+            int lineNumber) {
+        if (metadata.getItemKeys().contains(key)) {
+            graphics2D.drawString(
+                    metadata.getValue(key), columnAnchor, rowAnchor + lineNumber * lineSpacing);
+        }
+    }
+
+    private void renderTextCentred(
+            MetadataItems metadata,
+            MetadataKey metadataKey,
+            int columnAnchor,
+            int rowAnchor,
+            int lineNumber) {
+        String text = metadata.getValue(metadataKey);
+        if (text != null) {
+            int width = fontMetrics.stringWidth(text);
+            graphics2D.drawString(
+                    text, columnAnchor - width / 2, rowAnchor + lineNumber * lineSpacing);
+        }
+    }
+
+    private void renderTextRightAligned(
+            MetadataItems metadata,
+            MetadataKey key,
+            int columnAnchor,
+            int rowAnchor,
+            int lineNumber) {
+        if (metadata.getItemKeys().contains(key)) {
+            String text = metadata.getValue(key);
+            int width = fontMetrics.stringWidth(text);
+            graphics2D.drawString(text, columnAnchor - width, rowAnchor + lineNumber * lineSpacing);
+        }
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st1909/OverlayRendererConfiguration.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1909/OverlayRendererConfiguration.java
@@ -1,0 +1,67 @@
+package org.jmisb.api.klv.st1909;
+
+import java.awt.Color;
+import java.awt.Font;
+
+/** Configuration Options for the ST1909 OverlayRenderer. */
+public class OverlayRendererConfiguration {
+    private Color fillColor = Color.WHITE;
+    private Font font = new Font("Monospaced", Font.PLAIN, 20);
+    private int northCircleSize = 40;
+
+    public OverlayRendererConfiguration() {}
+
+    /**
+     * Get the current fill colour.
+     *
+     * @return the fill colour
+     */
+    public Color getFillColor() {
+        return fillColor;
+    }
+
+    /**
+     * Set the current fill colour.
+     *
+     * @param fillColor the fill colour
+     */
+    public void setFillColor(Color fillColor) {
+        this.fillColor = fillColor;
+    }
+
+    /**
+     * Get the current font.
+     *
+     * @return the current font
+     */
+    public Font getFont() {
+        return font;
+    }
+
+    /**
+     * Set the current font.
+     *
+     * @param font the current font
+     */
+    public void setFont(Font font) {
+        this.font = font;
+    }
+
+    /**
+     * The size of the north circle.
+     *
+     * @return the radius of the north circle, in pixels.
+     */
+    public int getNorthCircleSize() {
+        return northCircleSize;
+    }
+
+    /**
+     * Set the size of the north circle.
+     *
+     * @param northCircleSize the north circle radius, in pixels
+     */
+    public void setNorthCircleSize(int northCircleSize) {
+        this.northCircleSize = northCircleSize;
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st1909/ST0601Converter.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1909/ST0601Converter.java
@@ -1,0 +1,376 @@
+package org.jmisb.api.klv.st1909;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Collection;
+import java.util.EnumSet;
+import org.jmisb.api.klv.st0102.SecurityMetadataKey;
+import org.jmisb.api.klv.st0102.localset.SecurityMetadataLocalSet;
+import org.jmisb.api.klv.st0601.CornerOffset;
+import org.jmisb.api.klv.st0601.FlagDataKey;
+import org.jmisb.api.klv.st0601.FrameCenterElevation;
+import org.jmisb.api.klv.st0601.FrameCenterHae;
+import org.jmisb.api.klv.st0601.GenericFlagData01;
+import org.jmisb.api.klv.st0601.IUasDatalinkValue;
+import org.jmisb.api.klv.st0601.NestedSecurityMetadata;
+import org.jmisb.api.klv.st0601.PrecisionTimeStamp;
+import org.jmisb.api.klv.st0601.SensorEllipsoidHeight;
+import org.jmisb.api.klv.st0601.SensorTrueAltitude;
+import org.jmisb.api.klv.st0601.SlantRange;
+import org.jmisb.api.klv.st0601.TargetLocationElevation;
+import org.jmisb.api.klv.st0601.TargetWidth;
+import org.jmisb.api.klv.st0601.TargetWidthExtended;
+import org.jmisb.api.klv.st0601.UasDatalinkMessage;
+import org.jmisb.api.klv.st0601.UasDatalinkTag;
+
+/** Utility converter for extracting ST1909 information from ST0601 metadata message. */
+public class ST0601Converter {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER;
+
+    static {
+        DATE_TIME_FORMATTER =
+                new DateTimeFormatterBuilder()
+                        .append(DateTimeFormatter.ISO_DATE)
+                        .appendLiteral('T')
+                        .appendPattern("HH:mm:ss.S")
+                        .toFormatter();
+    }
+
+    /**
+     * Convert an ST0601 message into the ST1909 metadata format.
+     *
+     * <p>This will extract the relevant items, and format them as required by ST1909.
+     *
+     * <p>Existing ST1909 data will be updated if applicable, or retained if not present in the
+     * ST0601 message.
+     *
+     * @param message the source ST0601 message.
+     * @param metadata the ST1909 metadata state to convert into.
+     */
+    public static void convertST0601(UasDatalinkMessage message, MetadataItems metadata) {
+        convertMainSensorGroupValues(message, metadata);
+        convertClassificationAndReleasabilityGroupValues(message, metadata);
+        convertPlatformInformationGroupValues(message, metadata);
+        convertTrueNorthArrowGroupValues(message, metadata);
+        convertLaserSensorGroupValues(message, metadata);
+        convertTargetGroupValues(message, metadata);
+        convertDateTimeGroupValues(message, metadata);
+    }
+
+    private static void convertMainSensorGroupValues(
+            UasDatalinkMessage message, MetadataItems metadata) {
+        convertTagIfPresent(
+                message, UasDatalinkTag.ImageSourceSensor, metadata, MetadataKey.MainSensorName);
+        convertTagIfPresent(
+                message,
+                UasDatalinkTag.SensorRelativeAzimuthAngle,
+                metadata,
+                MetadataKey.AzAngle,
+                "REL AZ %1$10s");
+        convertTagIfPresent(
+                message,
+                UasDatalinkTag.SensorRelativeElevationAngle,
+                metadata,
+                MetadataKey.ElAngle,
+                "REL EL %1$10s");
+    }
+
+    private static void convertClassificationAndReleasabilityGroupValues(
+            UasDatalinkMessage message, MetadataItems metadata) {
+        if (message.getTags().contains(UasDatalinkTag.SecurityLocalMetadataSet)) {
+            NestedSecurityMetadata securityItem =
+                    (NestedSecurityMetadata)
+                            (message.getField(UasDatalinkTag.SecurityLocalMetadataSet));
+            SecurityMetadataLocalSet securityMetadataLocalSet = securityItem.getLocalSet();
+            if (securityMetadataLocalSet.getKeys().contains(SecurityMetadataKey.ClassifyingCountry)
+                    && securityMetadataLocalSet
+                            .getKeys()
+                            .contains(SecurityMetadataKey.SecurityClassification)) {
+                String baseValue =
+                        securityMetadataLocalSet
+                                        .getField(SecurityMetadataKey.ClassifyingCountry)
+                                        .getDisplayableValue()
+                                + " "
+                                + securityMetadataLocalSet
+                                        .getField(SecurityMetadataKey.SecurityClassification)
+                                        .getDisplayableValue();
+                String scishi = "";
+                if (securityMetadataLocalSet.getKeys().contains(SecurityMetadataKey.SciShiInfo)) {
+                    scishi =
+                            securityMetadataLocalSet
+                                    .getField(SecurityMetadataKey.SciShiInfo)
+                                    .getDisplayableValue();
+                }
+                String caveats = "";
+                if (securityMetadataLocalSet.getKeys().contains(SecurityMetadataKey.Caveats)) {
+                    caveats =
+                            securityMetadataLocalSet
+                                    .getField(SecurityMetadataKey.Caveats)
+                                    .getDisplayableValue();
+                }
+                String relto = "";
+                if (securityMetadataLocalSet
+                        .getKeys()
+                        .contains(SecurityMetadataKey.ReleasingInstructions)) {
+                    relto =
+                            securityMetadataLocalSet
+                                    .getField(SecurityMetadataKey.ReleasingInstructions)
+                                    .getDisplayableValue();
+                }
+                // TODO: append the caveats, compartments and releasability using something from a
+                // resource or configuration
+                String line1 = baseValue + " " + caveats + " " + scishi + " " + relto;
+                metadata.addItem(MetadataKey.ClassificationAndReleasabilityLine1, line1.trim());
+            }
+        }
+    }
+
+    private static void convertDateTimeGroupValues(
+            UasDatalinkMessage message, MetadataItems metadata) {
+        IUasDatalinkValue metadataTimestamp = message.getField(UasDatalinkTag.PrecisionTimeStamp);
+        if (metadataTimestamp != null) {
+            PrecisionTimeStamp precisionTimeStamp = (PrecisionTimeStamp) metadataTimestamp;
+            String mt = "MT " + DATE_TIME_FORMATTER.format(precisionTimeStamp.getDateTime()) + "Z";
+            metadata.addItem(MetadataKey.MetadataTimestamp, mt);
+        }
+    }
+
+    private static void convertTargetGroupValues(
+            UasDatalinkMessage message, MetadataItems metadata) {
+        if ((message.getTags().contains(UasDatalinkTag.TargetLocationLatitude))
+                && (message.getTags().contains(UasDatalinkTag.TargetLocationLongitude))
+                && (message.getTags().contains(UasDatalinkTag.TargetLocationElevation))) {
+            metadata.addItem(
+                    MetadataKey.TargetLatitude,
+                    message.getField(UasDatalinkTag.TargetLocationLatitude).getDisplayableValue()
+                            + " TL LAT");
+            metadata.addItem(
+                    MetadataKey.TargetLongitude,
+                    message.getField(UasDatalinkTag.TargetLocationLongitude).getDisplayableValue()
+                            + " TL LON");
+            IUasDatalinkValue value = message.getField(UasDatalinkTag.TargetLocationElevation);
+            TargetLocationElevation targetLocationElevation = (TargetLocationElevation) value;
+            metadata.addItem(
+                    MetadataKey.TargetElevation,
+                    "" + (int) (targetLocationElevation.getMeters()) + "m HAE TL EL");
+        } else if ((message.getTags().contains(UasDatalinkTag.FrameCenterLatitude))
+                && (message.getTags().contains(UasDatalinkTag.FrameCenterLongitude))) {
+            metadata.addItem(
+                    MetadataKey.TargetLatitude,
+                    message.getField(UasDatalinkTag.FrameCenterLatitude).getDisplayableValue()
+                            + " FC LAT");
+            metadata.addItem(
+                    MetadataKey.TargetLongitude,
+                    message.getField(UasDatalinkTag.FrameCenterLongitude).getDisplayableValue()
+                            + " FC LON");
+            if (message.getTags().contains(UasDatalinkTag.FrameCenterHae)) {
+                IUasDatalinkValue value = message.getField(UasDatalinkTag.FrameCenterHae);
+                FrameCenterHae frameCenterHae = (FrameCenterHae) value;
+                metadata.addItem(
+                        MetadataKey.TargetElevation,
+                        "" + (int) (frameCenterHae.getMeters()) + "m HAE FC EL");
+            } else if (message.getTags().contains(UasDatalinkTag.FrameCenterElevation)) {
+                IUasDatalinkValue value = message.getField(UasDatalinkTag.FrameCenterElevation);
+                FrameCenterElevation frameCenterElevation = (FrameCenterElevation) value;
+                metadata.addItem(
+                        MetadataKey.TargetElevation,
+                        "" + (int) (frameCenterElevation.getMeters()) + "m MSL FC EL");
+            }
+        }
+        convertTagIfPresent(
+                message,
+                UasDatalinkTag.SensorHorizontalFov,
+                metadata,
+                MetadataKey.HorizontalFOV,
+                "%s HFOV");
+        convertTagIfPresent(
+                message,
+                UasDatalinkTag.SensorVerticalFov,
+                metadata,
+                MetadataKey.VerticalFOV,
+                "%s VFOV");
+        convertTargetWidthExtendedOrTargetWidthIfPresent(message, metadata);
+        convertSlantRangeIfPresent(message, metadata);
+    }
+
+    private static void convertSlantRangeIfPresent(
+            UasDatalinkMessage message, MetadataItems metadata) {
+        IUasDatalinkValue slantRangeValue = message.getField(UasDatalinkTag.SlantRange);
+        if (slantRangeValue != null) {
+            SlantRange slantRange = (SlantRange) slantRangeValue;
+            metadata.addItem(MetadataKey.SlantRange, "" + (int) slantRange.getMeters() + "m SR");
+        }
+    }
+
+    private static void convertTargetWidthExtendedOrTargetWidthIfPresent(
+            UasDatalinkMessage message, MetadataItems metadata) {
+        IUasDatalinkValue targetWidthValue = message.getField(UasDatalinkTag.TargetWidthExtended);
+        if (targetWidthValue != null) {
+            TargetWidthExtended targetWidthExtended = (TargetWidthExtended) targetWidthValue;
+            String targetWidth = "" + Math.round(targetWidthExtended.getMeters()) + "m TW";
+            metadata.addItem(MetadataKey.TargetWidth, targetWidth);
+        } else if (message.getTags().contains(UasDatalinkTag.TargetWidth)) {
+            targetWidthValue = message.getField(UasDatalinkTag.TargetWidth);
+            String targetWidth =
+                    "" + Math.round(((TargetWidth) targetWidthValue).getMeters()) + "m TW";
+            metadata.addItem(MetadataKey.TargetWidth, targetWidth);
+        }
+    }
+
+    private static void convertPlatformInformationGroupValues(
+            UasDatalinkMessage message, MetadataItems metadata) {
+        if (message.getTags().contains(UasDatalinkTag.PlatformDesignation)) {
+            if (message.getTags().contains(UasDatalinkTag.PlatformCallSign)) {
+                metadata.addItem(
+                        MetadataKey.PlatformName,
+                        message.getField(UasDatalinkTag.PlatformDesignation).getDisplayableValue()
+                                + " "
+                                + message.getField(UasDatalinkTag.PlatformCallSign)
+                                        .getDisplayableValue());
+            } else {
+                convertTag(
+                        message,
+                        UasDatalinkTag.PlatformDesignation,
+                        metadata,
+                        MetadataKey.PlatformName);
+            }
+        }
+        convertTagIfPresent(
+                message,
+                UasDatalinkTag.SensorLatitude,
+                metadata,
+                MetadataKey.PlatformLatitude,
+                "%s LAT");
+        convertTagIfPresent(
+                message,
+                UasDatalinkTag.SensorLongitude,
+                metadata,
+                MetadataKey.PlatformLongitude,
+                "%s LON");
+        if (message.getTags().contains(UasDatalinkTag.SensorEllipsoidHeight)) {
+            IUasDatalinkValue value = message.getField(UasDatalinkTag.SensorEllipsoidHeight);
+            SensorEllipsoidHeight sensorEllipsoidHeight = (SensorEllipsoidHeight) value;
+            metadata.addItem(
+                    MetadataKey.PlatformAltitude,
+                    "" + (int) (sensorEllipsoidHeight.getMeters()) + "m HAE ALT");
+        } else if (message.getTags().contains(UasDatalinkTag.SensorTrueAltitude)) {
+            IUasDatalinkValue value = message.getField(UasDatalinkTag.SensorTrueAltitude);
+            SensorTrueAltitude sensorTrueAltitude = (SensorTrueAltitude) value;
+            metadata.addItem(
+                    MetadataKey.PlatformAltitude,
+                    "" + (int) (sensorTrueAltitude.getMeters()) + "m MSL ALT");
+        }
+    }
+
+    private static void convertTrueNorthArrowGroupValues(
+            UasDatalinkMessage message, MetadataItems metadata) {
+        // TODO: build this from corner values if offsets aren't available
+        Collection<UasDatalinkTag> tags = message.getTags();
+        Collection<UasDatalinkTag> offsetCornerTags =
+                EnumSet.of(
+                        UasDatalinkTag.OffsetCornerLatitudePoint1,
+                        UasDatalinkTag.OffsetCornerLatitudePoint2,
+                        UasDatalinkTag.OffsetCornerLatitudePoint3,
+                        UasDatalinkTag.OffsetCornerLatitudePoint4,
+                        UasDatalinkTag.OffsetCornerLongitudePoint1,
+                        UasDatalinkTag.OffsetCornerLongitudePoint2,
+                        UasDatalinkTag.OffsetCornerLongitudePoint3,
+                        UasDatalinkTag.OffsetCornerLongitudePoint4);
+        if (tags.containsAll(offsetCornerTags)) {
+            double lat1 =
+                    ((CornerOffset) (message.getField(UasDatalinkTag.OffsetCornerLatitudePoint1)))
+                            .getDegrees();
+            double lon1 =
+                    ((CornerOffset) (message.getField(UasDatalinkTag.OffsetCornerLongitudePoint1)))
+                            .getDegrees();
+            double lat4 =
+                    ((CornerOffset) (message.getField(UasDatalinkTag.OffsetCornerLatitudePoint4)))
+                            .getDegrees();
+            double lon4 =
+                    ((CornerOffset) (message.getField(UasDatalinkTag.OffsetCornerLongitudePoint4)))
+                            .getDegrees();
+            double angleLeftSide = Math.atan2(lat1 - lat4, lon1 - lon4) * 180.0 / Math.PI;
+            angleLeftSide -= 90.0;
+
+            double lat2 =
+                    ((CornerOffset) (message.getField(UasDatalinkTag.OffsetCornerLatitudePoint2)))
+                            .getDegrees();
+            double lon2 =
+                    ((CornerOffset) (message.getField(UasDatalinkTag.OffsetCornerLongitudePoint2)))
+                            .getDegrees();
+            double lat3 =
+                    ((CornerOffset) (message.getField(UasDatalinkTag.OffsetCornerLatitudePoint3)))
+                            .getDegrees();
+            double lon3 =
+                    ((CornerOffset) (message.getField(UasDatalinkTag.OffsetCornerLongitudePoint3)))
+                            .getDegrees();
+            double angleRightSide = Math.atan2(lat2 - lat3, lon2 - lon3) * 180.0 / Math.PI;
+            angleRightSide -= 90.0;
+            double averageAngle = (angleLeftSide + angleRightSide) / 2.0;
+            metadata.addItem(MetadataKey.NorthAngle, "" + averageAngle);
+        }
+    }
+
+    private static void convertTagIfPresent(
+            UasDatalinkMessage message,
+            UasDatalinkTag sourceTag,
+            MetadataItems metadata,
+            MetadataKey st1909DestinationKey) {
+        if (message.getTags().contains(sourceTag)) {
+            convertTag(message, sourceTag, metadata, st1909DestinationKey);
+        }
+    }
+
+    private static void convertTagIfPresent(
+            UasDatalinkMessage message,
+            UasDatalinkTag sourceTag,
+            MetadataItems metadata,
+            MetadataKey st1909DestinationKey,
+            String format) {
+        if (message.getTags().contains(sourceTag)) {
+            convertTag(message, sourceTag, metadata, st1909DestinationKey, format);
+        }
+    }
+
+    private static void convertTag(
+            UasDatalinkMessage message,
+            UasDatalinkTag sourceTag,
+            MetadataItems metadata,
+            MetadataKey st1909DestinationKey) {
+        metadata.addItem(
+                st1909DestinationKey, message.getField(sourceTag).getDisplayableValue().trim());
+    }
+
+    private static void convertTag(
+            UasDatalinkMessage message,
+            UasDatalinkTag sourceTag,
+            MetadataItems metadata,
+            MetadataKey st1909DestinationKey,
+            String format) {
+        String formattedValue =
+                String.format(format, message.getField(sourceTag).getDisplayableValue().trim());
+        metadata.addItem(st1909DestinationKey, formattedValue);
+    }
+
+    private static void convertLaserSensorGroupValues(
+            UasDatalinkMessage message, MetadataItems metadata) {
+        // ST1909-37 - probably needs to be changed in the spec.
+        metadata.addItem(MetadataKey.LaserSensorName, "Laser Rangefinder");
+        if (message.getTags().contains(UasDatalinkTag.GenericFlagData01)) {
+            GenericFlagData01 flagData =
+                    (GenericFlagData01) message.getField(UasDatalinkTag.GenericFlagData01);
+            if (flagData.getField(FlagDataKey.LaserRange).getValue().toLowerCase().contains("on")) {
+                metadata.addItem(MetadataKey.LaserSensorStatus, "Laser ON");
+            } else {
+                metadata.addItem(MetadataKey.LaserSensorStatus, "Laser OFF");
+            }
+        }
+        convertTagIfPresent(
+                message,
+                UasDatalinkTag.LaserPrfCode,
+                metadata,
+                MetadataKey.LaserPrfCode,
+                "Laser PRF Code %1$6s");
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st1909/package-info.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1909/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * ST 1909 Metadata Overlay for Visualization.
+ *
+ * <p>This standard defines a graphical, non-destructive, metadata overlay for Motion Imagery
+ * visualization. The content display locations scale according to a display’s native spatial
+ * density.
+ */
+package org.jmisb.api.klv.st1909;

--- a/api/src/test/java/org/jmisb/api/klv/st1909/MetadataItemsTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1909/MetadataItemsTest.java
@@ -1,0 +1,26 @@
+package org.jmisb.api.klv.st1909;
+
+import static org.testng.Assert.*;
+
+import org.testng.annotations.Test;
+
+/** Unit tests for MetadataItems class. */
+public class MetadataItemsTest {
+
+    public MetadataItemsTest() {}
+
+    @Test
+    public void lifecycle() {
+        MetadataItems metadataItems = new MetadataItems();
+        assertFalse(metadataItems.isValid());
+        assertEquals(metadataItems.getItemKeys().size(), 0);
+        metadataItems.addItem(MetadataKey.AzAngle, "X");
+        assertTrue(metadataItems.isValid());
+        assertEquals(metadataItems.getItemKeys().size(), 1);
+        assertTrue(metadataItems.getItemKeys().contains(MetadataKey.AzAngle));
+        assertEquals(metadataItems.getValue(MetadataKey.AzAngle), "X");
+        metadataItems.clear();
+        assertFalse(metadataItems.isValid());
+        assertEquals(metadataItems.getItemKeys().size(), 0);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st1909/MetadataKeyTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1909/MetadataKeyTest.java
@@ -1,0 +1,16 @@
+package org.jmisb.api.klv.st1909;
+
+import static org.testng.Assert.*;
+
+import org.testng.annotations.Test;
+
+/** Unit tests for the ST1909 MetadataKey implementation. */
+public class MetadataKeyTest {
+
+    public MetadataKeyTest() {}
+
+    @Test
+    public void testToString() {
+        assertEquals(MetadataKey.AzAngle.toString(), "Azimuth Angle");
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st1909/OverlayRendererConfigurationTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1909/OverlayRendererConfigurationTest.java
@@ -1,0 +1,47 @@
+package org.jmisb.api.klv.st1909;
+
+import static org.testng.Assert.*;
+
+import java.awt.Color;
+import java.awt.Font;
+import org.testng.annotations.Test;
+
+/** Unit tests for OverlayRendererConfiguration class. */
+public class OverlayRendererConfigurationTest {
+
+    public OverlayRendererConfigurationTest() {}
+
+    @Test
+    public void checkFontGetter() {
+        OverlayRendererConfiguration overlayRendererConfiguration =
+                new OverlayRendererConfiguration();
+        assertEquals(overlayRendererConfiguration.getFont().getSize(), 20);
+    }
+
+    @Test
+    public void checkFontSetter() {
+        OverlayRendererConfiguration overlayRendererConfiguration =
+                new OverlayRendererConfiguration();
+        Font newFont = new Font("Monospaced", Font.PLAIN, 10);
+        overlayRendererConfiguration.setFont(newFont);
+        assertEquals(overlayRendererConfiguration.getFont().getSize(), 10);
+    }
+
+    @Test
+    public void checkCircleSize() {
+        OverlayRendererConfiguration overlayRendererConfiguration =
+                new OverlayRendererConfiguration();
+        assertEquals(overlayRendererConfiguration.getNorthCircleSize(), 40);
+        overlayRendererConfiguration.setNorthCircleSize(100);
+        assertEquals(overlayRendererConfiguration.getNorthCircleSize(), 100);
+    }
+
+    @Test
+    public void checkColour() {
+        OverlayRendererConfiguration overlayRendererConfiguration =
+                new OverlayRendererConfiguration();
+        assertEquals(overlayRendererConfiguration.getFillColor(), Color.WHITE);
+        overlayRendererConfiguration.setFillColor(Color.BLUE);
+        assertEquals(overlayRendererConfiguration.getFillColor(), Color.BLUE);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st1909/OverlayRendererTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1909/OverlayRendererTest.java
@@ -1,0 +1,164 @@
+package org.jmisb.api.klv.st1909;
+
+import static org.testng.Assert.*;
+
+import java.awt.image.BufferedImage;
+import org.testng.annotations.Test;
+
+/** Unit tests for OverlayRenderer */
+public class OverlayRendererTest {
+
+    public OverlayRendererTest() {}
+
+    @Test
+    public void rowOffsetForNorth() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        int rowOffset = renderer.calculateRowOffset(100, 0.0);
+        // True north should have all Y offset.
+        // Negative because the coordinate system is left/down.
+        assertEquals(rowOffset, -100);
+    }
+
+    @Test
+    public void rowOffsetForEast() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        int rowOffset = renderer.calculateRowOffset(100, 90.0 * Math.PI / 180.0);
+        // Should have no offset.
+        assertEquals(rowOffset, 0);
+    }
+
+    @Test
+    public void rowOffsetForWest() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        int rowOffset = renderer.calculateRowOffset(100, 270.0 * Math.PI / 180.0);
+        // Should have no offset.
+        assertEquals(rowOffset, 0);
+    }
+
+    @Test
+    public void rowOffsetForSouth() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        int rowOffset = renderer.calculateRowOffset(100, Math.PI);
+        // South should have all Y offset.
+        assertEquals(rowOffset, 100);
+    }
+
+    @Test
+    public void columnOffsetForNorth() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        int columnOffset = renderer.calculateColumnOffset(100, 0.0);
+        // True north should have no x offset
+        assertEquals(columnOffset, 0);
+    }
+
+    @Test
+    public void columnOffsetForWest() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        int columnOffset = renderer.calculateColumnOffset(100, 270.0 * Math.PI / 180.0);
+        // Back at the origin.
+        assertEquals(columnOffset, -100);
+    }
+
+    @Test
+    public void columnOffsetForSouth() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        int columnOffset = renderer.calculateColumnOffset(100, Math.PI);
+        // No x offset,
+        assertEquals(columnOffset, 0);
+    }
+
+    @Test
+    public void columnOffsetForEast() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        int columnOffset = renderer.calculateColumnOffset(100, 90.0 * Math.PI / 180.0);
+        assertEquals(columnOffset, 100);
+    }
+
+    @Test
+    public void checkOffsetsFor45Degrees() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        double angle = 45 * Math.PI / 180.0;
+        int columnOffset = renderer.calculateColumnOffset(100, angle);
+        assertEquals(columnOffset, 71);
+        int rowOffset = renderer.calculateRowOffset(100, angle);
+        assertEquals(rowOffset, -71);
+    }
+
+    @Test
+    public void checkOffsetsFor135Degrees() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        double angle = 135 * Math.PI / 180.0;
+        int columnOffset = renderer.calculateColumnOffset(100, angle);
+        assertEquals(columnOffset, 71);
+        int rowOffset = renderer.calculateRowOffset(100, angle);
+        assertEquals(rowOffset, 71);
+    }
+
+    @Test
+    public void checkOffsetsFor225Degrees() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        double angle = 225 * Math.PI / 180.0;
+        int columnOffset = renderer.calculateColumnOffset(100, angle);
+        assertEquals(columnOffset, -71);
+        int rowOffset = renderer.calculateRowOffset(100, angle);
+        assertEquals(rowOffset, 71);
+    }
+
+    @Test
+    public void checkOffsetsFor315Degrees() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        double angle = 315 * Math.PI / 180.0;
+        int columnOffset = renderer.calculateColumnOffset(100, angle);
+        assertEquals(columnOffset, -71);
+        int rowOffset = renderer.calculateRowOffset(100, angle);
+        assertEquals(rowOffset, -71);
+    }
+
+    @Test
+    public void checkOffsetsForNegative45Degrees() {
+        OverlayRenderer renderer = new OverlayRenderer();
+        double angle = -45 * Math.PI / 180.0;
+        int columnOffset = renderer.calculateColumnOffset(100, angle);
+        assertEquals(columnOffset, -71);
+        int rowOffset = renderer.calculateRowOffset(100, angle);
+        assertEquals(rowOffset, -71);
+    }
+
+    @Test
+    public void checkRenderEmpty() {
+        OverlayRenderer renderer = new OverlayRenderer(new OverlayRendererConfiguration());
+        BufferedImage image = new BufferedImage(1920, 1080, BufferedImage.TYPE_INT_RGB);
+        MetadataItems metadataItems = new MetadataItems();
+        renderer.render(image, metadataItems);
+        assertNotNull(image);
+    }
+
+    @Test
+    public void checkRenderMost() {
+        OverlayRenderer renderer = new OverlayRenderer(new OverlayRendererConfiguration());
+        BufferedImage image = new BufferedImage(1920, 1080, BufferedImage.TYPE_INT_RGB);
+        MetadataItems metadataItems = new MetadataItems();
+        metadataItems.addItem(MetadataKey.AzAngle, "1.2");
+        metadataItems.addItem(MetadataKey.ElAngle, "3.2");
+        metadataItems.addItem(MetadataKey.ClassificationAndReleasabilityLine1, "L1");
+        metadataItems.addItem(MetadataKey.HorizontalFOV, "0.1");
+        metadataItems.addItem(MetadataKey.VerticalFOV, "0.2");
+        metadataItems.addItem(MetadataKey.LaserPrfCode, "Laser PRF 1234");
+        metadataItems.addItem(MetadataKey.LaserSensorName, "Laser Designator");
+        metadataItems.addItem(MetadataKey.LaserSensorStatus, "Laser ON");
+        metadataItems.addItem(MetadataKey.MainSensorName, "Sensor A");
+        metadataItems.addItem(MetadataKey.MetadataTimestamp, "MT 2020-01-02T12:23:34.3Z");
+        metadataItems.addItem(MetadataKey.NorthAngle, "60.0");
+        metadataItems.addItem(MetadataKey.PlatformAltitude, "1425m HAE ALT");
+        metadataItems.addItem(MetadataKey.PlatformLatitude, "LAT");
+        metadataItems.addItem(MetadataKey.PlatformLongitude, "LON");
+        metadataItems.addItem(MetadataKey.PlatformName, "MQ-99 SURE THING");
+        metadataItems.addItem(MetadataKey.SlantRange, "33.34");
+        metadataItems.addItem(MetadataKey.TargetElevation, "0.1m HAE");
+        metadataItems.addItem(MetadataKey.TargetLatitude, "Target LAT");
+        metadataItems.addItem(MetadataKey.TargetLongitude, "Target LON");
+        metadataItems.addItem(MetadataKey.TargetWidth, "340.3m");
+        renderer.render(image, metadataItems);
+        assertNotNull(image);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st1909/ST0601ConverterTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1909/ST0601ConverterTest.java
@@ -1,0 +1,870 @@
+package org.jmisb.api.klv.st1909;
+
+import static org.testng.Assert.*;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.jmisb.api.klv.st0102.Classification;
+import org.jmisb.api.klv.st0102.CountryCodingMethod;
+import org.jmisb.api.klv.st0102.ISecurityMetadataValue;
+import org.jmisb.api.klv.st0102.ObjectCountryCodeString;
+import org.jmisb.api.klv.st0102.ST0102Version;
+import org.jmisb.api.klv.st0102.SecurityMetadataKey;
+import org.jmisb.api.klv.st0102.SecurityMetadataString;
+import org.jmisb.api.klv.st0102.localset.CcMethod;
+import org.jmisb.api.klv.st0102.localset.ClassificationLocal;
+import org.jmisb.api.klv.st0102.localset.OcMethod;
+import org.jmisb.api.klv.st0102.localset.SecurityMetadataLocalSet;
+import org.jmisb.api.klv.st0102.localset.SecurityMetadataLocalSet.Builder;
+import org.jmisb.api.klv.st0601.CornerOffset;
+import org.jmisb.api.klv.st0601.FlagDataKey;
+import org.jmisb.api.klv.st0601.FrameCenterElevation;
+import org.jmisb.api.klv.st0601.FrameCenterHae;
+import org.jmisb.api.klv.st0601.FrameCenterLatitude;
+import org.jmisb.api.klv.st0601.FrameCenterLongitude;
+import org.jmisb.api.klv.st0601.GenericFlagData01;
+import org.jmisb.api.klv.st0601.HorizontalFov;
+import org.jmisb.api.klv.st0601.IUasDatalinkValue;
+import org.jmisb.api.klv.st0601.LaserPrfCode;
+import org.jmisb.api.klv.st0601.NestedSecurityMetadata;
+import org.jmisb.api.klv.st0601.PrecisionTimeStamp;
+import org.jmisb.api.klv.st0601.SensorEllipsoidHeight;
+import org.jmisb.api.klv.st0601.SensorLatitude;
+import org.jmisb.api.klv.st0601.SensorLongitude;
+import org.jmisb.api.klv.st0601.SensorRelativeAzimuth;
+import org.jmisb.api.klv.st0601.SensorRelativeElevation;
+import org.jmisb.api.klv.st0601.SensorTrueAltitude;
+import org.jmisb.api.klv.st0601.SlantRange;
+import org.jmisb.api.klv.st0601.TargetLocationElevation;
+import org.jmisb.api.klv.st0601.TargetLocationLatitude;
+import org.jmisb.api.klv.st0601.TargetLocationLongitude;
+import org.jmisb.api.klv.st0601.TargetWidth;
+import org.jmisb.api.klv.st0601.TargetWidthExtended;
+import org.jmisb.api.klv.st0601.UasDatalinkMessage;
+import org.jmisb.api.klv.st0601.UasDatalinkString;
+import org.jmisb.api.klv.st0601.UasDatalinkTag;
+import org.jmisb.api.klv.st0601.VerticalFov;
+import org.testng.annotations.Test;
+
+/** Unit tests for ST0601Converter. */
+public class ST0601ConverterTest {
+
+    public ST0601ConverterTest() {}
+
+    @Test
+    public void checkPlatformNameFromDesignationOnly() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.PlatformDesignation,
+                new UasDatalinkString(UasDatalinkString.PLATFORM_DESIGNATION, "Testname"));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.PlatformName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertEquals(metadata.getValue(MetadataKey.PlatformName), "Testname");
+    }
+
+    @Test
+    public void checkPlatformNameFromDesignationAndCallsign() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.PlatformDesignation,
+                new UasDatalinkString(UasDatalinkString.PLATFORM_DESIGNATION, "Testname"));
+        map.put(
+                UasDatalinkTag.PlatformCallSign,
+                new UasDatalinkString(UasDatalinkString.PLATFORM_CALL_SIGN, "Romeo Sierra"));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.PlatformName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertEquals(metadata.getValue(MetadataKey.PlatformName), "Testname Romeo Sierra");
+    }
+
+    @Test
+    public void checkPlatformLatitude() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorLatitude, new SensorLatitude(-34.34211));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.PlatformLatitude));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        // ST1909-17, ST1909-18, ST1909-19
+        assertEquals(metadata.getValue(MetadataKey.PlatformLatitude), "-34.3421\u00B0 LAT");
+    }
+
+    @Test
+    public void checkPlatformLongitude() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorLongitude, new SensorLongitude(150.87432));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.PlatformLongitude));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        // ST1909-20, ST1909-21, ST1909-22
+        assertEquals(metadata.getValue(MetadataKey.PlatformLongitude), "150.8743\u00B0 LON");
+    }
+
+    @Test
+    public void checkPlatformAltitudeHAE() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorEllipsoidHeight, new SensorEllipsoidHeight(1150.872));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.PlatformAltitude));
+        // ST1909-23, ST1909-24, ST1909-26, ST1909-27, ST1909-28
+        assertEquals(metadata.getValue(MetadataKey.PlatformAltitude), "1150m HAE ALT");
+    }
+
+    @Test
+    public void checkPlatformAltitudeMSL() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorTrueAltitude, new SensorTrueAltitude(1150.872));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.PlatformAltitude));
+        // ST1909-23, ST1909-24, ST1909-25, ST1909-27, ST1909-28
+        assertEquals(metadata.getValue(MetadataKey.PlatformAltitude), "1150m MSL ALT");
+    }
+
+    @Test
+    public void checkPlatformAltitudePreferHAEoverMSL() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorEllipsoidHeight, new SensorEllipsoidHeight(1150.872));
+        map.put(UasDatalinkTag.SensorTrueAltitude, new SensorTrueAltitude(2432.1));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.PlatformAltitude));
+        assertEquals(metadata.getValue(MetadataKey.PlatformAltitude), "1150m HAE ALT");
+    }
+
+    @Test
+    public void checkPlatformInformationGroup() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.PlatformDesignation,
+                new UasDatalinkString(UasDatalinkString.PLATFORM_DESIGNATION, "Testname"));
+        map.put(
+                UasDatalinkTag.PlatformCallSign,
+                new UasDatalinkString(UasDatalinkString.PLATFORM_CALL_SIGN, "Romeo Sierra"));
+        map.put(UasDatalinkTag.SensorLatitude, new SensorLatitude(-34.34211));
+        map.put(UasDatalinkTag.SensorLongitude, new SensorLongitude(150.87432));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 4);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.PlatformName));
+        assertEquals(metadata.getValue(MetadataKey.PlatformName), "Testname Romeo Sierra");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.PlatformLatitude));
+        assertEquals(metadata.getValue(MetadataKey.PlatformLatitude), "-34.3421\u00B0 LAT");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.PlatformLongitude));
+        assertEquals(metadata.getValue(MetadataKey.PlatformLongitude), "150.8743\u00B0 LON");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+    }
+
+    @Test
+    public void checkTargetSlantRange() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SlantRange, new SlantRange(8763.4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.SlantRange));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertEquals(metadata.getValue(MetadataKey.SlantRange), "8763m SR");
+    }
+
+    @Test
+    public void checkTargetWidthOnlyRounding() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.TargetWidth, new TargetWidth(132.89));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetWidth));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertEquals(metadata.getValue(MetadataKey.TargetWidth), "133m TW");
+    }
+
+    @Test
+    public void checkTargetWidthExtendedOnlyRounding() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.TargetWidthExtended, new TargetWidthExtended(1499999.9));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetWidth));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertEquals(metadata.getValue(MetadataKey.TargetWidth), "1500000m TW");
+    }
+
+    @Test
+    public void checkSlantRange() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SlantRange, new SlantRange(7654.32));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.SlantRange));
+        // ST1909-54, ST1909-55, ST1909-56, ST1909-57
+        assertEquals(metadata.getValue(MetadataKey.SlantRange), "7654m SR");
+    }
+
+    @Test
+    public void checkTargetWidth() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.TargetWidth, new TargetWidth(154.32));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetWidth));
+        // ST1909-58, ST1909-59, ST1909-60
+        assertEquals(metadata.getValue(MetadataKey.TargetWidth), "154m TW");
+    }
+
+    @Test
+    public void checkTargetWidthExtended() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.TargetWidthExtended, new TargetWidthExtended(113154.32));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetWidth));
+        // ST1909-58, ST1909-59, ST1909-60
+        assertEquals(metadata.getValue(MetadataKey.TargetWidth), "113154m TW");
+    }
+
+    @Test
+    public void checkTargetWidthExtendedIsPreferredOverTargetWidth() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.TargetWidth, new TargetWidth(154.32));
+        map.put(UasDatalinkTag.TargetWidthExtended, new TargetWidthExtended(113154.32));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetWidth));
+        // ST1909-58, ST1909-59, ST1909-60
+        assertEquals(metadata.getValue(MetadataKey.TargetWidth), "113154m TW");
+    }
+
+    @Test
+    public void checkHorizontalFieldOfView() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorHorizontalFov, new HorizontalFov(1.34));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.HorizontalFOV));
+        // ST1909-61, ST1909-62, ST1909-63
+        assertEquals(metadata.getValue(MetadataKey.HorizontalFOV), "1.3400\u00B0 HFOV");
+    }
+
+    @Test
+    public void checkVerticalFieldOfView() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorVerticalFov, new VerticalFov(0.9865432));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.VerticalFOV));
+        // ST1909-64, ST1909-65, ST1909-66
+        assertEquals(metadata.getValue(MetadataKey.VerticalFOV), "0.9865\u00B0 VFOV");
+    }
+
+    @Test
+    public void checkVerticalFieldOfView180() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorVerticalFov, new VerticalFov(180.0));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.VerticalFOV));
+        // ST1909-64, ST1909-65, ST1909-66
+        assertEquals(metadata.getValue(MetadataKey.VerticalFOV), "180.0000\u00B0 VFOV");
+    }
+
+    @Test
+    public void checkMainSensorName() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.ImageSourceSensor,
+                new UasDatalinkString(UasDatalinkString.IMAGE_SOURCE_SENSOR, "EO Nose"));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.MainSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertEquals(metadata.getValue(MetadataKey.MainSensorName), "EO Nose");
+    }
+
+    @Test
+    public void checkMainSensorRelativeAzimuth() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorRelativeAzimuthAngle, new SensorRelativeAzimuth(0.0));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.AzAngle));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        // ST1909-05 and ST1909-06
+        assertEquals(metadata.getValue(MetadataKey.AzAngle), "REL AZ    0.0000\u00B0");
+    }
+
+    @Test
+    public void checkMainSensorRelativeAzimuth360() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorRelativeAzimuthAngle, new SensorRelativeAzimuth(360.0));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.AzAngle));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        // ST1909-05 and ST1909-06
+        assertEquals(metadata.getValue(MetadataKey.AzAngle), "REL AZ  360.0000\u00B0");
+    }
+
+    @Test
+    public void checkMainSensorRelativeElevation() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorRelativeElevationAngle, new SensorRelativeElevation(0.0));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.ElAngle));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        // ST1909-07 and ST1909-08
+        assertEquals(metadata.getValue(MetadataKey.ElAngle), "REL EL    0.0000\u00B0");
+    }
+
+    @Test
+    public void checkMainSensorRelativeElevationNeg180() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorRelativeElevationAngle, new SensorRelativeElevation(-180.0));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.ElAngle));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        // ST1909-07 and ST1909-08
+        assertEquals(metadata.getValue(MetadataKey.ElAngle), "REL EL -180.0000\u00B0");
+    }
+
+    @Test
+    public void checkMainSensorRelativeElevationPos180() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.SensorRelativeElevationAngle, new SensorRelativeElevation(180.0));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.ElAngle));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        // ST1909-07 and ST1909-08
+        assertEquals(metadata.getValue(MetadataKey.ElAngle), "REL EL  180.0000\u00B0");
+    }
+
+    @Test
+    public void checkLaserOnFlag() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        List<FlagDataKey> keyList = new ArrayList<>();
+        keyList.add(FlagDataKey.LaserRange);
+        map.put(UasDatalinkTag.GenericFlagData01, new GenericFlagData01(keyList));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorStatus));
+        // ST1909-38
+        assertEquals(metadata.getValue(MetadataKey.LaserSensorStatus), "Laser ON");
+    }
+
+    @Test
+    public void checkLaserOffFlag() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        List<FlagDataKey> keyList = new ArrayList<>();
+        keyList.add(FlagDataKey.AutoTrack); // Doesn't really matter - just not LaserRange.
+        map.put(UasDatalinkTag.GenericFlagData01, new GenericFlagData01(keyList));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorStatus));
+        // ST1909-39
+        assertEquals(metadata.getValue(MetadataKey.LaserSensorStatus), "Laser OFF");
+    }
+
+    @Test
+    public void checkLaserOffNoFlags() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        List<FlagDataKey> keyList = new ArrayList<>();
+        map.put(UasDatalinkTag.GenericFlagData01, new GenericFlagData01(keyList));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorStatus));
+        // ST1909-39
+        assertEquals(metadata.getValue(MetadataKey.LaserSensorStatus), "Laser OFF");
+    }
+
+    @Test
+    public void checkLaserPRFcode() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.LaserPrfCode, new LaserPrfCode(111));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserPrfCode));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        // ST1909-40, ST1909-41, ST1909-42
+        assertEquals(metadata.getValue(MetadataKey.LaserPrfCode), "Laser PRF Code    111");
+    }
+
+    @Test
+    public void checkLaserPRFcode8888() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.LaserPrfCode, new LaserPrfCode(8888));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserPrfCode));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        // ST1909-40, ST1909-41, ST1909-42
+        assertEquals(metadata.getValue(MetadataKey.LaserPrfCode), "Laser PRF Code   8888");
+    }
+
+    @Test
+    public void checkTargetLocationLatitudeLongitudeAltitude() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.TargetLocationLatitude, new TargetLocationLatitude(-34.34211));
+        map.put(UasDatalinkTag.TargetLocationLongitude, new TargetLocationLongitude(150.87432));
+        map.put(UasDatalinkTag.TargetLocationElevation, new TargetLocationElevation(873.43));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 4);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLatitude));
+        // ST1909-81, ST1909-82, ST1909-83
+        assertEquals(metadata.getValue(MetadataKey.TargetLatitude), "-34.3421\u00B0 TL LAT");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLongitude));
+        // ST1909-84, ST1909-85, ST1909-86
+        assertEquals(metadata.getValue(MetadataKey.TargetLongitude), "150.8743\u00B0 TL LON");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetElevation));
+        // ST1909-87, ST1909-88, ST1909-89, ST1909-90, ST1909-91
+        assertEquals(metadata.getValue(MetadataKey.TargetElevation), "873m HAE TL EL");
+    }
+
+    @Test
+    public void checkFrameCenterLatitudeLongitudeAltitudeHAE() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.FrameCenterLatitude, new FrameCenterLatitude(-34.34211));
+        map.put(UasDatalinkTag.FrameCenterLongitude, new FrameCenterLongitude(150.87432));
+        map.put(UasDatalinkTag.FrameCenterHae, new FrameCenterHae(873.43));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 4);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLatitude));
+        // ST1909-69, ST1909-70, ST1909-71
+        assertEquals(metadata.getValue(MetadataKey.TargetLatitude), "-34.3421\u00B0 FC LAT");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLongitude));
+        // ST1909-72, ST1909-73, ST1909-74
+        assertEquals(metadata.getValue(MetadataKey.TargetLongitude), "150.8743\u00B0 FC LON");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetElevation));
+        // ST1909-75, ST1909-76, ST1909-78, ST1909-79, ST1909-80
+        assertEquals(metadata.getValue(MetadataKey.TargetElevation), "873m HAE FC EL");
+    }
+
+    @Test
+    public void checkFrameCenterLatitudeLongitudeAltitudeMSL() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.FrameCenterLatitude, new FrameCenterLatitude(-34.34211));
+        map.put(UasDatalinkTag.FrameCenterLongitude, new FrameCenterLongitude(150.87432));
+        map.put(UasDatalinkTag.FrameCenterElevation, new FrameCenterElevation(873.43));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 4);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLatitude));
+        // ST1909-69, ST1909-70, ST1909-71
+        assertEquals(metadata.getValue(MetadataKey.TargetLatitude), "-34.3421\u00B0 FC LAT");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLongitude));
+        // ST1909-72, ST1909-73, ST1909-74
+        assertEquals(metadata.getValue(MetadataKey.TargetLongitude), "150.8743\u00B0 FC LON");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetElevation));
+        // ST1909-75, ST1909-76, ST1909-77, ST1909-79, ST1909-80
+        assertEquals(metadata.getValue(MetadataKey.TargetElevation), "873m MSL FC EL");
+    }
+
+    @Test
+    public void checkFrameCenterLatitudeLongitudeAltitudeHAEisPreferred() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.FrameCenterLatitude, new FrameCenterLatitude(-34.34211));
+        map.put(UasDatalinkTag.FrameCenterLongitude, new FrameCenterLongitude(150.87432));
+        map.put(UasDatalinkTag.FrameCenterHae, new FrameCenterHae(873.43));
+        map.put(UasDatalinkTag.FrameCenterElevation, new FrameCenterElevation(674.43));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 4);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLatitude));
+        // ST1909-69, ST1909-70, ST1909-71
+        assertEquals(metadata.getValue(MetadataKey.TargetLatitude), "-34.3421\u00B0 FC LAT");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLongitude));
+        // ST1909-72, ST1909-73, ST1909-74
+        assertEquals(metadata.getValue(MetadataKey.TargetLongitude), "150.8743\u00B0 FC LON");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetElevation));
+        // ST1909-75, ST1909-76, ST1909-78, ST1909-79, ST1909-80
+        assertEquals(metadata.getValue(MetadataKey.TargetElevation), "873m HAE FC EL");
+    }
+
+    @Test
+    public void checkFrameCenterLatitudeLongitudeNoAlt() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.FrameCenterLatitude, new FrameCenterLatitude(-34.34211));
+        map.put(UasDatalinkTag.FrameCenterLongitude, new FrameCenterLongitude(150.87432));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 3);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLatitude));
+        // ST1909-69, ST1909-70, ST1909-71
+        assertEquals(metadata.getValue(MetadataKey.TargetLatitude), "-34.3421\u00B0 FC LAT");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLongitude));
+        // ST1909-72, ST1909-73, ST1909-74
+        assertEquals(metadata.getValue(MetadataKey.TargetLongitude), "150.8743\u00B0 FC LON");
+    }
+
+    @Test
+    public void checkTargetLocationIsPreferredOverFrameCenter() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.TargetLocationLatitude, new TargetLocationLatitude(-34.34211));
+        map.put(UasDatalinkTag.TargetLocationLongitude, new TargetLocationLongitude(150.87432));
+        map.put(UasDatalinkTag.TargetLocationElevation, new TargetLocationElevation(873.43));
+        map.put(UasDatalinkTag.FrameCenterLatitude, new FrameCenterLatitude(-32.34211));
+        map.put(UasDatalinkTag.FrameCenterLongitude, new FrameCenterLongitude(151.87432));
+        map.put(UasDatalinkTag.FrameCenterHae, new FrameCenterHae(803.43));
+        map.put(UasDatalinkTag.FrameCenterElevation, new FrameCenterElevation(674.43));
+        // ST1909-67 and ST1909-68
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 4);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLatitude));
+        // ST1909-81, ST1909-82, ST1909-83
+        assertEquals(metadata.getValue(MetadataKey.TargetLatitude), "-34.3421\u00B0 TL LAT");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLongitude));
+        // ST1909-84, ST1909-85, ST1909-86
+        assertEquals(metadata.getValue(MetadataKey.TargetLongitude), "150.8743\u00B0 TL LON");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetElevation));
+        // ST1909-87, ST1909-88, ST1909-89, ST1909-90, ST1909-91
+        assertEquals(metadata.getValue(MetadataKey.TargetElevation), "873m HAE TL EL");
+    }
+
+    @Test
+    public void checkFrameCenterIsPreferredOverIncompleteTargetLocation() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.FrameCenterLatitude, new FrameCenterLatitude(-34.34211));
+        map.put(UasDatalinkTag.FrameCenterLongitude, new FrameCenterLongitude(150.87432));
+        map.put(UasDatalinkTag.TargetLocationLongitude, new TargetLocationLongitude(150.87432));
+        map.put(UasDatalinkTag.FrameCenterElevation, new FrameCenterElevation(873.43));
+        // ST1909-67 and ST1909-68
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 4);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLatitude));
+        // ST1909-69, ST1909-70, ST1909-71
+        assertEquals(metadata.getValue(MetadataKey.TargetLatitude), "-34.3421\u00B0 FC LAT");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLongitude));
+        // ST1909-72, ST1909-73, ST1909-74
+        assertEquals(metadata.getValue(MetadataKey.TargetLongitude), "150.8743\u00B0 FC LON");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetElevation));
+        // ST1909-75, ST1909-76, ST1909-77, ST1909-79, ST1909-80
+        assertEquals(metadata.getValue(MetadataKey.TargetElevation), "873m MSL FC EL");
+    }
+
+    @Test
+    public void checkFrameCenterIsPreferredOverIncompleteTargetLocationNoAlt() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.TargetLocationLatitude, new TargetLocationLatitude(-34.94211));
+        map.put(UasDatalinkTag.FrameCenterLatitude, new FrameCenterLatitude(-34.34211));
+        map.put(UasDatalinkTag.FrameCenterLongitude, new FrameCenterLongitude(150.87432));
+        map.put(UasDatalinkTag.TargetLocationLongitude, new TargetLocationLongitude(150.87432));
+        map.put(UasDatalinkTag.FrameCenterElevation, new FrameCenterElevation(873.43));
+        // ST1909-67 and ST1909-68
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 4);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLatitude));
+        // ST1909-69, ST1909-70, ST1909-71
+        assertEquals(metadata.getValue(MetadataKey.TargetLatitude), "-34.3421\u00B0 FC LAT");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLongitude));
+        // ST1909-72, ST1909-73, ST1909-74
+        assertEquals(metadata.getValue(MetadataKey.TargetLongitude), "150.8743\u00B0 FC LON");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetElevation));
+        // ST1909-75, ST1909-76, ST1909-77, ST1909-79, ST1909-80
+        assertEquals(metadata.getValue(MetadataKey.TargetElevation), "873m MSL FC EL");
+    }
+
+    @Test
+    public void checkFrameCenterIsPreferredOverIncompleteTargetLocationNoAltNoLon() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.TargetLocationLatitude, new TargetLocationLatitude(-34.94211));
+        map.put(UasDatalinkTag.FrameCenterLatitude, new FrameCenterLatitude(-34.34211));
+        map.put(UasDatalinkTag.FrameCenterLongitude, new FrameCenterLongitude(150.87432));
+        map.put(UasDatalinkTag.FrameCenterElevation, new FrameCenterElevation(873.43));
+        // ST1909-67 and ST1909-68
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 4);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLatitude));
+        // ST1909-69, ST1909-70, ST1909-71
+        assertEquals(metadata.getValue(MetadataKey.TargetLatitude), "-34.3421\u00B0 FC LAT");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetLongitude));
+        // ST1909-72, ST1909-73, ST1909-74
+        assertEquals(metadata.getValue(MetadataKey.TargetLongitude), "150.8743\u00B0 FC LON");
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.TargetElevation));
+        // ST1909-75, ST1909-76, ST1909-77, ST1909-79, ST1909-80
+        assertEquals(metadata.getValue(MetadataKey.TargetElevation), "873m MSL FC EL");
+    }
+
+    @Test
+    public void checkFrameCenterLatitudeIncomplete() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(UasDatalinkTag.FrameCenterLatitude, new FrameCenterLatitude(-34.34211));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        // ST1909-67 and ST1909-68
+        assertEquals(metadata.getItemKeys().size(), 1);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+    }
+
+    @Test
+    public void checkMetadataDateTime() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.PrecisionTimeStamp,
+                new PrecisionTimeStamp(
+                        LocalDateTime.of(2020, Month.JULY, 21, 10, 59, 24, 123000000)));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.MetadataTimestamp));
+        // ST1909-46, ST1909-49, ST1909-50
+        assertEquals(metadata.getValue(MetadataKey.MetadataTimestamp), "MT 2020-07-21T10:59:24.1Z");
+    }
+
+    @Test
+    public void checkClassificationAndReleasabilityGroupBasic() {
+        // Security markings for test purposes only, content is all unclassified
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> securityMetadataMap =
+                new TreeMap<>();
+        securityMetadataMap.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        securityMetadataMap.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.ISO3166_THREE_LETTER));
+        securityMetadataMap.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AUS"));
+        securityMetadataMap.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.ISO3166_THREE_LETTER));
+        securityMetadataMap.put(
+                SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AUS;PNG"));
+        securityMetadataMap.put(SecurityMetadataKey.Version, new ST0102Version(12));
+        SecurityMetadataLocalSet securityMetadata =
+                new SecurityMetadataLocalSet(securityMetadataMap);
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.SecurityLocalMetadataSet,
+                new NestedSecurityMetadata(securityMetadata));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(
+                metadata.getItemKeys().contains(MetadataKey.ClassificationAndReleasabilityLine1));
+        assertFalse(
+                metadata.getItemKeys().contains(MetadataKey.ClassificationAndReleasabilityLine2));
+        assertEquals(
+                metadata.getValue(MetadataKey.ClassificationAndReleasabilityLine1),
+                "//AUS UNCLASSIFIED");
+    }
+
+    @Test
+    public void checkClassificationAndReleasabilityGroupMissing() {
+        // Security markings for test purposes only, content is all unclassified
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> securityMetadataMap =
+                new TreeMap<>();
+        securityMetadataMap.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AUS"));
+        securityMetadataMap.put(SecurityMetadataKey.Version, new ST0102Version(12));
+        SecurityMetadataLocalSet securityMetadata =
+                new SecurityMetadataLocalSet(securityMetadataMap);
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.SecurityLocalMetadataSet,
+                new NestedSecurityMetadata(securityMetadata));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 1);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+    }
+
+    @Test
+    public void checkClassificationAndReleasabilityGroupMissingClassification() {
+        // Security markings for test purposes only, content is all unclassified
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> securityMetadataMap =
+                new TreeMap<>();
+        securityMetadataMap.put(SecurityMetadataKey.Version, new ST0102Version(12));
+        SecurityMetadataLocalSet securityMetadata =
+                new SecurityMetadataLocalSet(securityMetadataMap);
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.SecurityLocalMetadataSet,
+                new NestedSecurityMetadata(securityMetadata));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 1);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+    }
+
+    @Test
+    public void checkClassificationAndReleasabilityGroupAll() {
+        // Security markings for test purposes only, content is all unclassified
+        Builder st0102builder =
+                new Builder(Classification.UNCLASSIFIED)
+                        .ccMethod(CountryCodingMethod.ISO3166_THREE_LETTER)
+                        .classifyingCountry("//AUS")
+                        .ocMethod(CountryCodingMethod.ISO3166_THREE_LETTER)
+                        .objectCountryCodes("AUS;PNG")
+                        .sciShiInfo("BUTTER POPCORN/WIBBLE//")
+                        .caveats("FOUO")
+                        .releasingInstructions("REL TO ANYBODY")
+                        .version(12);
+        SecurityMetadataLocalSet securityMetadata = st0102builder.build();
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.SecurityLocalMetadataSet,
+                new NestedSecurityMetadata(securityMetadata));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(
+                metadata.getItemKeys().contains(MetadataKey.ClassificationAndReleasabilityLine1));
+        assertFalse(
+                metadata.getItemKeys().contains(MetadataKey.ClassificationAndReleasabilityLine2));
+        assertEquals(
+                metadata.getValue(MetadataKey.ClassificationAndReleasabilityLine1),
+                "//AUS UNCLASSIFIED FOUO BUTTER POPCORN/WIBBLE// REL TO ANYBODY");
+    }
+
+    @Test
+    public void checkNorthGroupAngle0() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint1,
+                new CornerOffset(0.01, CornerOffset.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint2,
+                new CornerOffset(0.01, CornerOffset.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint3,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint4,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint1,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint2,
+                new CornerOffset(0.01, CornerOffset.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint3,
+                new CornerOffset(0.01, CornerOffset.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint4,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "0.0");
+    }
+
+    @Test
+    public void checkClassInstantiation() {
+        ST0601Converter converter = new ST0601Converter();
+        assertNotNull(converter);
+    }
+}

--- a/viewer/src/main/java/org/jmisb/viewer/MisbViewer.java
+++ b/viewer/src/main/java/org/jmisb/viewer/MisbViewer.java
@@ -91,6 +91,12 @@ public class MisbViewer extends JFrame implements ActionListener {
         streamInfo.addActionListener(this);
         viewMenu.add(streamInfo);
 
+        JCheckBoxMenuItem metadataOverlay = new JCheckBoxMenuItem("Metadata Overlay (ST1909)");
+        metadataOverlay.setName("View|MetadataOverlay");
+        metadataOverlay.setMnemonic(KeyEvent.VK_O);
+        metadataOverlay.addActionListener(this);
+        viewMenu.add(metadataOverlay);
+
         setJMenuBar(menuBar);
 
         setLayout(new MigLayout("fill", "", "[fill][38:38:38]"));
@@ -129,6 +135,10 @@ public class MisbViewer extends JFrame implements ActionListener {
                     break;
                 case "View|StreamInfo":
                     displayStreamInfo();
+                    break;
+                case "View|MetadataOverlay":
+                    JCheckBoxMenuItem cbItem = (JCheckBoxMenuItem) item;
+                    metadataOverlayState(cbItem.getState());
                     break;
                 default:
                     if (item.getName().startsWith("File|Mru|")) {
@@ -182,6 +192,7 @@ public class MisbViewer extends JFrame implements ActionListener {
             setTitle("jmisb - " + filename);
 
             fileInput.addFrameListener(videoPanel);
+            fileInput.addMetadataListener(videoPanel);
             fileInput.addMetadataListener(metadataPanel);
             fileInput.addFrameListener(controlPanel);
 
@@ -202,6 +213,10 @@ public class MisbViewer extends JFrame implements ActionListener {
     private void displayStreamInfo() {
         StreamInfoDialog dialog = new StreamInfoDialog(this, videoInput);
         dialog.setVisible(true);
+    }
+
+    private void metadataOverlayState(boolean state) {
+        videoPanel.setMetadataOverlayState(state);
     }
 
     private void addMruMenuItems() {


### PR DESCRIPTION
## Motivation and Context
This is an reasonably complete implementation of ST1909 "Metadata Overlay for Visualization".

Resolves #61.

## Description
Adds a new module. Updates the viewer application to (optionally) display the visualisation.

The timestamp for metadata is MISP time, not UTC. We have existing items for that work, and I'll update the completion criteria to include this.

There are a few parts that aren't implemented - the reticle, the bounding box for next zoom, and the FT metadata. We need more ST0604 support for the FT metadata (frame timestamp). The reticle is easy for where its on Frame Center, but hard for when its on another target location. Those are all optional to implement - we can add tickets later if its important.

## How Has This Been Tested?
Reasonable level of unit testing in the `api` module. Used viewer application.

## Screenshots (if appropriate):
![Screenshot_20200727_213246](https://user-images.githubusercontent.com/174642/88537368-ccca6a00-d050-11ea-9244-f748ee963fd1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

