### PR TITLE
Javadoc updates and check infrastructure

### DIFF
--- a/api/checkstyle.xml
+++ b/api/checkstyle.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+
+  Checkstyle configuration that checks the sun coding conventions from:
+
+    - the Java Language Specification at
+      https://docs.oracle.com/javase/specs/jls/se11/html/index.html
+
+    - the Sun Code Conventions at https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
+
+    - the Javadoc guidelines at
+      https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html
+
+    - the JDK Api documentation https://docs.oracle.com/en/java/javase/11/
+
+    - some best practices
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  https://checkstyle.org (or in your downloaded distribution).
+
+  Most Checks are configurable, be sure to consult the documentation.
+
+  To completely disable a check, just comment it out or delete it from the file.
+  To suppress certain violations please review suppression filters.
+
+  Finally, it is worth reading the documentation.
+
+-->
+
+<module name="Checker">
+  <!--
+      If you set the basedir property below, then all reported file
+      names will be relative to the specified directory. See
+      https://checkstyle.org/config.html#Checker
+
+      <property name="basedir" value="${basedir}"/>
+  -->
+  <property name="severity" value="warning"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/config_filefilters.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
+  <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+              default="checkstyle_suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- Checks that a package-info.java file exists for each package.     -->
+  <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
+  <module name="JavadocPackage"/>
+
+  <!-- Checks whether files end with a new line.                        -->
+  <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+  <module name="NewlineAtEndOfFile"/>
+
+  <!-- Checks that property files contain the same keys.         -->
+  <!-- See https://checkstyle.org/config_misc.html#Translation -->
+  <!--
+  <module name="Translation"/>
+  -->
+
+  <!-- Checks for Size Violations.                    -->
+  <!-- See https://checkstyle.org/config_sizes.html -->
+  <!--
+  <module name="FileLength"/>
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+  </module>
+  -->
+
+  <!-- Checks for whitespace                               -->
+  <!-- See https://checkstyle.org/config_whitespace.html -->
+  <!--
+  <module name="FileTabCharacter"/>
+  -->
+
+  <!-- Miscellaneous other checks.                   -->
+  <!-- See https://checkstyle.org/config_misc.html -->
+  <!--
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="minimum" value="0"/>
+    <property name="maximum" value="0"/>
+    <property name="message" value="Line has trailing spaces."/>
+  </module>
+  -->
+
+  <!-- Checks for Headers                                -->
+  <!-- See https://checkstyle.org/config_header.html   -->
+  <!-- <module name="Header"> -->
+  <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+  <!--   <property name="fileExtensions" value="java"/> -->
+  <!-- </module> -->
+
+  <module name="TreeWalker">
+
+    <!-- Checks for Javadoc comments.                     -->
+    <!-- See https://checkstyle.org/config_javadoc.html -->
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocMethod"/>
+    <module name="JavadocType"/>
+    <module name="JavadocVariable">
+        <!-- this is a variation from the default rules - javadocs for private variables is a step too far at this stage -->
+        <property name="excludeScope" value="private"/>
+    </module>
+    <module name="JavadocStyle"/>
+    <module name="MissingJavadocMethod"/>
+
+    <!-- Checks for Naming Conventions.                  -->
+    <!-- See https://checkstyle.org/config_naming.html -->
+    <!--
+    <module name="ConstantName"/>
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName"/>
+    <module name="MemberName"/>
+    <module name="MethodName"/>
+    <module name="PackageName"/>
+    <module name="ParameterName"/>
+    <module name="StaticVariableName"/>
+    <module name="TypeName"/>
+    -->
+
+    <!-- Checks for imports                              -->
+    <!-- See https://checkstyle.org/config_imports.html -->
+    <!--
+    <module name="AvoidStarImport"/>
+    <module name="IllegalImport"/>
+    <module name="RedundantImport"/>
+    <module name="UnusedImports">
+      <property name="processJavadoc" value="false"/>
+    </module>
+    -->
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See https://checkstyle.org/config_sizes.html -->
+    <!--
+    <module name="MethodLength"/>
+    <module name="ParameterNumber"/>
+    -->
+
+    <!-- Checks for whitespace                               -->
+    <!-- See https://checkstyle.org/config_whitespace.html -->
+    <!--
+    <module name="EmptyForIteratorPad"/>
+    <module name="GenericWhitespace"/>
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter"/>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OperatorWrap"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad"/>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround"/>
+    -->
+
+    <!-- Modifier Checks                                    -->
+    <!-- See https://checkstyle.org/config_modifiers.html -->
+    <!--
+    <module name="ModifierOrder"/>
+    <module name="RedundantModifier"/>
+    -->
+
+    <!-- Checks for blocks. You know, those {}'s         -->
+    <!-- See https://checkstyle.org/config_blocks.html -->
+    <!--
+    <module name="AvoidNestedBlocks"/>
+    <module name="EmptyBlock"/>
+    <module name="LeftCurly"/>
+    <module name="NeedBraces"/>
+    <module name="RightCurly"/>
+    -->
+
+    <!-- Checks for common coding problems               -->
+    <!-- See https://checkstyle.org/config_coding.html -->
+    <!--
+    <module name="EmptyStatement"/>
+    <module name="EqualsHashCode"/>
+    <module name="HiddenField"/>
+    <module name="IllegalInstantiation"/>
+    <module name="InnerAssignment"/>
+    <module name="MagicNumber"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="SimplifyBooleanExpression"/>
+    <module name="SimplifyBooleanReturn"/>
+    -->
+
+    <!-- Checks for class design                         -->
+    <!-- See https://checkstyle.org/config_design.html -->
+    <!--
+    <module name="DesignForExtension"/>
+    <module name="FinalClass"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="InterfaceIsType"/>
+    <module name="VisibilityModifier"/>
+    -->
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See https://checkstyle.org/config_misc.html -->
+    <!--
+    <module name="ArrayTypeStyle"/>
+    <module name="FinalParameters"/>
+    <module name="TodoComment"/>
+    <module name="UpperEll"/>
+    -->
+
+    <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+                default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
+
+  </module>
+
+</module>

--- a/api/checkstyle_suppressions.xml
+++ b/api/checkstyle_suppressions.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress files="[\\/]api[\\/]common[\\/]" checks="[a-zA-Z0-9]*"/>
+    <suppress files="[\\/]api[\\/]klv[\\/]eg0104[\\/]" checks="[a-zA-Z0-9]*"/>
+    <suppress files="[\\/]api[\\/]klv[\\/]st0601[\\/]" checks="[a-zA-Z0-9]*"/>
+    <suppress files="[\\/]api[\\/]klv[\\/]st0603[\\/]" checks="[a-zA-Z0-9]*"/>
+    <suppress files="[\\/]api[\\/]klv[\\/]st0805[\\/]" checks="[a-zA-Z0-9]*"/>
+    <suppress files="[\\/]api[\\/]klv[\\/]st0806[\\/]" checks="[a-zA-Z0-9]*"/>
+    <suppress files="[\\/]api[\\/]klv[\\/]st0903[\\/]" checks="[a-zA-Z0-9]*"/>
+    <suppress files="[\\/]api[\\/]klv[\\/]st1201[\\/]" checks="[a-zA-Z0-9]*"/>
+    <suppress files="[\\/]api[\\/]video[\\/]" checks="[a-zA-Z0-9]*"/>
+</suppressions>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -119,6 +119,27 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <linkXRef>false</linkXRef>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/api/src/main/java/org/jmisb/api/klv/BerEncoder.java
+++ b/api/src/main/java/org/jmisb/api/klv/BerEncoder.java
@@ -9,7 +9,7 @@ public class BerEncoder {
     private BerEncoder() {}
 
     /**
-     * Encode an integer using Basic Encoding Rules (BER)
+     * Encode an integer using Basic Encoding Rules (BER).
      *
      * @param value The value to encode (must be non-negative)
      * @param ber Encoding type
@@ -76,7 +76,7 @@ public class BerEncoder {
     }
 
     /**
-     * Encode an integer using short or long form, whichever is more compact
+     * Encode an integer using short or long form, whichever is more compact.
      *
      * @param value The value to encode (must be non-negative)
      * @return The encoded value

--- a/api/src/main/java/org/jmisb/api/klv/BerField.java
+++ b/api/src/main/java/org/jmisb/api/klv/BerField.java
@@ -1,15 +1,15 @@
 package org.jmisb.api.klv;
 
-/** Represents a BER-encoded field (length and integer value) */
+/** Represents a BER-encoded field (length and integer value). */
 public class BerField {
-    /** Size of the field in bytes */
+    /** Size of the field in bytes. */
     private int length;
 
-    /** The encoded value */
+    /** The encoded value. */
     private int value;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param length Size of the field in bytes
      * @param value The (non-negative) integer value
@@ -24,7 +24,7 @@ public class BerField {
     }
 
     /**
-     * Get the length
+     * Get the length.
      *
      * @return Size of the field in bytes
      */
@@ -33,7 +33,7 @@ public class BerField {
     }
 
     /**
-     * Get the value
+     * Get the value.
      *
      * @return The value as an integer
      */

--- a/api/src/main/java/org/jmisb/api/klv/Group.java
+++ b/api/src/main/java/org/jmisb/api/klv/Group.java
@@ -1,25 +1,25 @@
 package org.jmisb.api.klv;
 
-/** Group (Sets and Packs) */
+/** Group (Sets and Packs). */
 public enum Group {
-    /** Universal Data Sets are composed of elements that use a full 16-byte UL as the key */
+    /** Universal Data Sets are composed of elements that use a full 16-byte UL as the key. */
     UNIVERSAL_SET,
 
-    /** Global Data Sets are composed of elements that have the same high-order key values */
+    /** Global Data Sets are composed of elements that have the same high-order key values. */
     GLOBAL_SET,
 
-    /** Local Data Sets specify a mapping of integer tags to data elements */
+    /** Local Data Sets specify a mapping of integer tags to data elements. */
     LOCAL_DATA_SET,
 
     /**
      * Variable Length Packs eliminate the key field and instead use a defined sequence of data
-     * elements
+     * elements.
      */
     VARIABLE_LENGTH_PACK,
 
     /**
      * Defined Length Packs eliminate both key and length fields and use pre-defined lengths for all
-     * elements
+     * elements.
      */
     DEFINED_LENGTH_PACK;
 }

--- a/api/src/main/java/org/jmisb/api/klv/IMisbMessage.java
+++ b/api/src/main/java/org/jmisb/api/klv/IMisbMessage.java
@@ -1,16 +1,16 @@
 package org.jmisb.api.klv;
 
-/** A packet containing MISB-compliant metadata */
+/** A packet containing MISB-compliant metadata. */
 public interface IMisbMessage {
     /**
-     * Get the Universal Label (UL) identifying the message type
+     * Get the Universal Label (UL) identifying the message type.
      *
      * @return The {@link UniversalLabel}
      */
     UniversalLabel getUniversalLabel();
 
     /**
-     * Frame the message into a byte array
+     * Frame the message into a byte array.
      *
      * @param isNested If true, the key and length field are omitted, and only the value will be
      *     written
@@ -19,7 +19,9 @@ public interface IMisbMessage {
     byte[] frameMessage(boolean isNested);
 
     /**
-     * A display header for the message type (e.g. which standard it conforms to).
+     * A display header for the message type.
+     *
+     * <p>This will typically identify which standard the message conforms to.
      *
      * @return String containing human-readable metadata message label.
      */

--- a/api/src/main/java/org/jmisb/api/klv/KlvConstants.java
+++ b/api/src/main/java/org/jmisb/api/klv/KlvConstants.java
@@ -1,10 +1,10 @@
 package org.jmisb.api.klv;
 
-/** Various constants such as Universal Labels */
+/** Various constants such as Universal Labels. */
 public class KlvConstants {
     private KlvConstants() {}
 
-    /** Universal label for UAS Datalink Local Metadata Set (ST 0601) */
+    /** Universal label for UAS Datalink Local Metadata Set (ST 0601). */
     public static final UniversalLabel UasDatalinkLocalUl =
             new UniversalLabel(
                     new byte[] {
@@ -12,7 +12,7 @@ public class KlvConstants {
                         0x01, 0x00, 0x00, 0x00
                     });
 
-    /** Universal label for Security Metadata Set Local Set (ST 0102) */
+    /** Universal label for Security Metadata Set Local Set (ST 0102). */
     public static final UniversalLabel SecurityMetadataLocalSetUl =
             new UniversalLabel(
                     new byte[] {
@@ -20,7 +20,7 @@ public class KlvConstants {
                         0x02, 0x00, 0x00, 0x00
                     });
 
-    /** Universal label for Security Metadata Set Universal Set (ST 0102) */
+    /** Universal label for Security Metadata Set Universal Set (ST 0102). */
     public static final UniversalLabel SecurityMetadataUniversalSetUl =
             new UniversalLabel(
                     new byte[] {
@@ -28,7 +28,7 @@ public class KlvConstants {
                         0x00, 0x00, 0x00, 0x00
                     });
 
-    /** Universal label for Generalized Transformation Set (ST 1202) */
+    /** Universal label for Generalized Transformation Set (ST 1202). */
     public static final UniversalLabel GeneralizedTransformationUl =
             new UniversalLabel(
                     new byte[] {
@@ -36,7 +36,7 @@ public class KlvConstants {
                         0x05, 0x00, 0x00, 0x00
                     });
 
-    /** Universal label for Remote Video Terminal (RVT) Metadata Local Set (ST0806) */
+    /** Universal label for Remote Video Terminal (RVT) Metadata Local Set (ST0806). */
     public static final UniversalLabel RvtLocalSetUl =
             new UniversalLabel(
                     new byte[] {
@@ -44,7 +44,7 @@ public class KlvConstants {
                         0x02, 0x00, 0x00, 0x00
                     });
 
-    /** Universal label for VMTI Local Set (ST 0903) */
+    /** Universal label for VMTI Local Set (ST 0903). */
     public static final UniversalLabel VmtiLocalSetUl =
             new UniversalLabel(
                     new byte[] {
@@ -52,7 +52,7 @@ public class KlvConstants {
                         0x06, 0x00, 0x00, 0x00
                     });
 
-    /** Universal label for obsolete Predator UAV Basic Universal Metadata Set (EG0104.5) */
+    /** Universal label for obsolete Predator UAV Basic Universal Metadata Set (EG0104.5). */
     public static final UniversalLabel PredatorMetadataLocalSetUl =
             new UniversalLabel(
                     new byte[] {

--- a/api/src/main/java/org/jmisb/api/klv/KlvParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/KlvParser.java
@@ -11,14 +11,14 @@ import org.jmisb.api.klv.st0601.UasDatalinkMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Parse metadata to extract individual {@link IMisbMessage} packets */
+/** Parse metadata to extract individual {@link IMisbMessage} packets. */
 public class KlvParser {
     private static Logger logger = LoggerFactory.getLogger(KlvParser.class);
 
     private KlvParser() {}
 
     /**
-     * Parse a byte array containing one or more {@link IMisbMessage}s
+     * Parse a byte array containing one or more {@link IMisbMessage}s.
      *
      * <p>This is the main interface for parsing KLV metadata. It assumes that {@code bytes}
      * contains one or more top-level messages, i.e., byte sequences starting with a Universal Label
@@ -85,7 +85,7 @@ public class KlvParser {
     }
 
     /**
-     * Extract the next top-level message
+     * Extract the next top-level message.
      *
      * @param bytes The original byte array, assumed to begin with 16-byte UL
      * @return Byte array containing the full top-level message, including UL key, length, and value

--- a/api/src/main/java/org/jmisb/api/klv/LdsField.java
+++ b/api/src/main/java/org/jmisb/api/klv/LdsField.java
@@ -1,13 +1,13 @@
 package org.jmisb.api.klv;
 
-/** Local Data Set field, comprised of a tag (the key) and its value */
+/** Local Data Set field, comprised of a tag (the key) and its value. */
 public class LdsField {
     private final int tag;
 
     private final byte[] data;
 
     /**
-     * Create an LDS field
+     * Create an LDS field.
      *
      * @param tag The integer tag
      * @param data Byte array containing the value
@@ -18,7 +18,7 @@ public class LdsField {
     }
 
     /**
-     * Get the tag
+     * Get the tag.
      *
      * @return The integer tag
      */
@@ -27,7 +27,7 @@ public class LdsField {
     }
 
     /**
-     * Get the value
+     * Get the value.
      *
      * @return The value stored as a byte array
      */

--- a/api/src/main/java/org/jmisb/api/klv/LdsParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/LdsParser.java
@@ -7,14 +7,14 @@ import org.jmisb.api.common.KlvParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Parse fields from a Local Data Set (LDS) */
+/** Parse fields from a Local Data Set (LDS). */
 public class LdsParser {
     private static Logger logger = LoggerFactory.getLogger(LdsParser.class);
 
     private LdsParser() {}
 
     /**
-     * Parse {@link LdsField}s from a byte array
+     * Parse {@link LdsField}s from a byte array.
      *
      * @param bytes Byte array to parse
      * @param start Index of the first byte to parse

--- a/api/src/main/java/org/jmisb/api/klv/RawMisbMessage.java
+++ b/api/src/main/java/org/jmisb/api/klv/RawMisbMessage.java
@@ -1,10 +1,16 @@
 package org.jmisb.api.klv;
 
-/** Represents an unparsed {@link IMisbMessage} */
+/** Represents an unparsed {@link IMisbMessage}. */
 public class RawMisbMessage implements IMisbMessage {
     private UniversalLabel universalLabel;
     private byte[] bytes;
 
+    /**
+     * Constructor.
+     *
+     * @param universalLabel the universal label for the message.
+     * @param bytes the byte array of the message data, including the 16-byte UL and length fields
+     */
     public RawMisbMessage(UniversalLabel universalLabel, byte[] bytes) {
         this.universalLabel = universalLabel;
         this.bytes = bytes.clone();
@@ -16,7 +22,7 @@ public class RawMisbMessage implements IMisbMessage {
     }
 
     /**
-     * Get the raw data, including 16-byte UL and length fields
+     * Get the raw data, including 16-byte UL and length fields.
      *
      * @return The raw byte array
      */

--- a/api/src/main/java/org/jmisb/api/klv/RegistryCategory.java
+++ b/api/src/main/java/org/jmisb/api/klv/RegistryCategory.java
@@ -1,16 +1,16 @@
 package org.jmisb.api.klv;
 
-/** Identifies the category of a registry as specified by a Universal Label (UL) */
+/** Identifies the category of a registry as specified by a Universal Label (UL). */
 public enum RegistryCategory {
-    /** Definitions of individual data elements */
+    /** Definitions of individual data elements. */
     DICTIONARIES,
 
-    /** Definitions of sets (groups) of data elements, such as a Set or a Pack */
+    /** Definitions of sets (groups) of data elements, such as a Set or a Pack. */
     GROUPS,
 
-    /** Definitions of frameworks for collections of information */
+    /** Definitions of frameworks for collections of information. */
     WRAPPERS_AND_CONTAINERS,
 
-    /** Definitions of descriptions that augment ULs */
+    /** Definitions of descriptions that augment ULs. */
     LABELS;
 }

--- a/api/src/main/java/org/jmisb/api/klv/UdsField.java
+++ b/api/src/main/java/org/jmisb/api/klv/UdsField.java
@@ -1,20 +1,36 @@
 package org.jmisb.api.klv;
 
-/** Universal Data Set field, comprised of its Universal Label (key) and its value */
+/** Universal Data Set field, comprised of its Universal Label (key) and its value. */
 public class UdsField {
     private final UniversalLabel key;
 
     private final byte[] value;
 
+    /**
+     * Constructor.
+     *
+     * @param key the Universal Label for the Universal Data Set
+     * @param value the value associated with the Universal Data Set metadata item
+     */
     public UdsField(UniversalLabel key, byte[] value) {
         this.key = key;
         this.value = value.clone();
     }
 
+    /**
+     * Universal Label for the Universal Data Set.
+     *
+     * @return universal label identifying the metadata item.
+     */
     public UniversalLabel getKey() {
         return key;
     }
 
+    /**
+     * Value associated with the Universal Data Set metadata item.
+     *
+     * @return value of the metadata item
+     */
     public byte[] getValue() {
         return value.clone();
     }

--- a/api/src/main/java/org/jmisb/api/klv/UdsParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/UdsParser.java
@@ -5,12 +5,12 @@ import java.util.Arrays;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
 
-/** Parse fields from a Universal Data Set (UDS) */
+/** Parse fields from a Universal Data Set (UDS). */
 public class UdsParser {
     private UdsParser() {}
 
     /**
-     * Parse {@link UdsField}s from a byte array
+     * Parse {@link UdsField}s from a byte array.
      *
      * @param bytes Array representing encoded UDS bytes
      * @param start Offset location to start parsing (must be at the start of a 16-byte UL)

--- a/api/src/main/java/org/jmisb/api/klv/UniversalLabel.java
+++ b/api/src/main/java/org/jmisb/api/klv/UniversalLabel.java
@@ -2,7 +2,7 @@ package org.jmisb.api.klv;
 
 import java.util.Arrays;
 
-/** Represents a 16-byte Universal Label (UL) */
+/** Represents a 16-byte Universal Label (UL). */
 public class UniversalLabel {
     public static final int LENGTH = 16;
     private final byte[] bytes;
@@ -12,7 +12,7 @@ public class UniversalLabel {
     private static final int SMPTE_DESIGNATOR_FIELD = 3;
 
     /**
-     * Construct a UL from a byte array
+     * Construct a UL from a byte array.
      *
      * @param bytes The UL byte array
      * @throws IllegalArgumentException if the array does not contain a valid UL
@@ -23,7 +23,7 @@ public class UniversalLabel {
     }
 
     /**
-     * Get the byte array
+     * Get the byte array.
      *
      * @return The 16-byte array
      */
@@ -56,7 +56,7 @@ public class UniversalLabel {
     }
 
     /**
-     * Test whether an array of bytes contains a valid UL
+     * Test whether an array of bytes contains a valid UL.
      *
      * @param bytes The byte array
      * @throws IllegalArgumentException if the array does not contain a valid UL

--- a/api/src/main/java/org/jmisb/api/klv/package-info.java
+++ b/api/src/main/java/org/jmisb/api/klv/package-info.java
@@ -1,2 +1,2 @@
-/** Key-Length-Value processing, including framing and parsing */
+/** Key-Length-Value processing, including framing and parsing. */
 package org.jmisb.api.klv;

--- a/api/src/main/java/org/jmisb/api/klv/st0102/CcmDate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/CcmDate.java
@@ -7,15 +7,33 @@ import java.time.LocalDate;
 
 /**
  * Classifying Country and Releasing Instructions Country Coding Method Version Date (ST 0102 tag
- * 23)
+ * 23).
+ *
+ * <p>This metadata item provides the effective date (promulgation date) of the source (FIPS 10-4,
+ * ISO 3166, GENC, or STANAG 1059) used for the Classifying Country and Releasing Instructions
+ * Country Coding Method. As ISO 3166 is updated by dated circulars, not by version revision, the
+ * ISO 8601 YYYY-MM-DD formatted date is used. The valid country codes (and the corresponding
+ * meanings) can vary between versions of those coding methods, so this metadata item can be used to
+ * identify the exact version of the coding method.
  */
 public class CcmDate implements ISecurityMetadataValue {
+
     private LocalDate date;
 
+    /**
+     * Construct CcmDate from a LocalDate.
+     *
+     * @param date the date for the coding method version.
+     */
     public CcmDate(LocalDate date) {
         this.date = date;
     }
 
+    /**
+     * Construct CcmDate from encoded bytes.
+     *
+     * @param bytes byte array with encoded value for CcmDate.
+     */
     public CcmDate(byte[] bytes) {
         if (bytes.length != 10) {
             throw new IllegalArgumentException(
@@ -27,6 +45,14 @@ public class CcmDate implements ISecurityMetadataValue {
         date = LocalDate.parse(dateString, ISO_LOCAL_DATE);
     }
 
+    /**
+     * The date value.
+     *
+     * <p>These dates are somewhat arbitrary, and do not have associated time zones. It is probably
+     * safest to treat them as identifiers with ordering.
+     *
+     * @return the date of the Country Coding Method.
+     */
     public LocalDate getValue() {
         return date;
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0102/Classification.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/Classification.java
@@ -3,13 +3,32 @@ package org.jmisb.api.klv.st0102;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Allowed classification levels in ST 0102 */
+/** Allowed classification levels in ST 0102. */
 public enum Classification {
+    /**
+     * The Classification is unknown.
+     *
+     * <p>This value is not valid, and should not be used. It is an implementation detail.
+     */
     UNKNOWN((byte) 0x00),
+    /**
+     * Unclassified.
+     *
+     * <p>Motion Imagery data that is unclassified needs to be explicitly marked (see ST 0102.10-54
+     * and ST 0102.10-51).
+     */
     UNCLASSIFIED((byte) 0x01),
+    /**
+     * Restricted.
+     *
+     * <p>This is a NATO marking, and is not a valid US marking.
+     */
     RESTRICTED((byte) 0x02),
+    /** Confidential. */
     CONFIDENTIAL((byte) 0x03),
+    /** Secret. */
     SECRET((byte) 0x04),
+    /** Top Secret. */
     TOP_SECRET((byte) 0x05);
 
     private byte code;
@@ -26,10 +45,21 @@ public enum Classification {
         code = c;
     }
 
+    /**
+     * Get the code for this classification.
+     *
+     * @return the associated byte value (e.g. {@code 0x03 for Confidential}.
+     */
     public byte getCode() {
         return code;
     }
 
+    /**
+     * Look up the classification for a given code.
+     *
+     * @param code the byte value for the Classification value.
+     * @return the corresponding Classification.
+     */
     public static Classification getClassification(byte code) {
         if (lookupTable.containsKey(code)) {
             return lookupTable.get(code);

--- a/api/src/main/java/org/jmisb/api/klv/st0102/CountryCodingMethod.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/CountryCodingMethod.java
@@ -1,20 +1,84 @@
 package org.jmisb.api.klv.st0102;
 
-/** Country coding methods */
+/**
+ * Country coding methods.
+ *
+ * <p>Country codes are used in security markings for identifying which country classified the
+ * motion imagery, which countries the motion imagery is releasable to, and which countries are the
+ * object of the motion imagery (in the frame). There are various ways in which country codes are to
+ * be interpreted, as shown in this enumeration.
+ */
 public enum CountryCodingMethod {
+    /**
+     * ISO-3166 Two Letter codes.
+     *
+     * <p>For example, Australia is "AU".
+     */
     ISO3166_TWO_LETTER,
+    /**
+     * ISO-3166 Three Letter codes.
+     *
+     * <p>For example, Australia is "AUS".
+     */
     ISO3166_THREE_LETTER,
     ISO3166_MIXED,
+    /**
+     * ISO-3166 Numeric codes.
+     *
+     * <p>For example, Australia is "036".
+     */
     ISO3166_NUMERIC,
+    /**
+     * FIPS 10-4 codes.
+     *
+     * <p>For example, Australia is "AS".
+     *
+     * <p>This is a legacy coding method, only used in the US.
+     */
     FIPS10_4_TWO_LETTER,
     FIPS10_4_FOUR_LETTER,
     FIPS10_4_MIXED,
+    /**
+     * STANAG 1059 Two Letter codes.
+     *
+     * <p>Similar to an old version of ISO-3166 Two Letter codes, but with some changes for NATO
+     * policy.
+     */
     C1059_TWO_LETTER,
+    /**
+     * STANAG 1059 Three Letter codes.
+     *
+     * <p>Similar to an old version of ISO-3166 Three Letter codes, but with some changes for NATO
+     * policy.
+     */
     C1059_THREE_LETTER,
+    /**
+     * Used for values that do not have corresponding meaning.
+     *
+     * <p>This is not valid, and should not be created.
+     */
     OMITTED_VALUE,
     STANAG_1059_MIXED,
+    /**
+     * GENC Two Letter codes.
+     *
+     * <p>Similar to ISO-3166 Two Letter codes, but with some changes for US policy. Only used in
+     * the US.
+     */
     GENC_TWO_LETTER,
+    /**
+     * GENC Three Letter codes.
+     *
+     * <p>Similar to ISO-3166 Three Letter codes, but with some changes for US policy. Only used in
+     * the USA.
+     */
     GENC_THREE_LETTER,
+    /**
+     * GENC Numeric codes.
+     *
+     * <p>Similar to ISO-3166 Numeric codes, but with some changes for US policy. Only used in the
+     * US.
+     */
     GENC_NUMERIC,
     GENC_MIXED,
     GENC_ADMINSUB

--- a/api/src/main/java/org/jmisb/api/klv/st0102/DeclassificationDate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/DeclassificationDate.java
@@ -5,14 +5,30 @@ import static java.time.format.DateTimeFormatter.BASIC_ISO_DATE;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 
-/** Declassification Date (ST 0102 tag 10) */
+/**
+ * Declassification Date (ST 0102 tag 10).
+ *
+ * <p>The Declassification Date metadata element provides a date when the classified material may be
+ * automatically declassified.
+ */
 public class DeclassificationDate implements ISecurityMetadataValue {
     private LocalDate date;
 
+    /**
+     * Construct DeclassificationDate from a LocalDate.
+     *
+     * @param date the date for the declassification date.
+     */
     public DeclassificationDate(LocalDate date) {
         this.date = date;
     }
 
+    /**
+     * Construct DeclassificationDate from encoded bytes.
+     *
+     * @param bytes byte array with encoded value for DeclassificationDate (exactly 8 bytes, see
+     *     ST0102).
+     */
     public DeclassificationDate(byte[] bytes) {
         if (bytes.length != 8) {
             throw new IllegalArgumentException(
@@ -24,6 +40,14 @@ public class DeclassificationDate implements ISecurityMetadataValue {
         date = LocalDate.parse(dateString, BASIC_ISO_DATE);
     }
 
+    /**
+     * The date value.
+     *
+     * <p>These dates are somewhat arbitrary (defined in years from classification), and do not have
+     * associated time zones.
+     *
+     * @return the declassification date.
+     */
     public LocalDate getValue() {
         return date;
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0102/ISecurityMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/ISecurityMetadataValue.java
@@ -2,12 +2,16 @@ package org.jmisb.api.klv.st0102;
 
 import org.jmisb.api.klv.IKlvValue;
 
-/** ST 0102 value */
+/**
+ * ST 0102 value.
+ *
+ * <p>Each metadata element within ST0102 consists of a key (e.g. tag number, or universal key)
+ * represented by a {@link SecurityMetadataKey} instance, and a value represented by a instance
+ * implementing this interface.
+ */
 public interface ISecurityMetadataValue extends IKlvValue {
     /**
      * Get the encoded bytes.
-     *
-     * <p>
      *
      * @return The encoded byte array
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/ItemDesignatorId.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/ItemDesignatorId.java
@@ -25,7 +25,7 @@ public class ItemDesignatorId implements ISecurityMetadataValue {
     private byte[] itemDesignatorId;
 
     /**
-     * Create from encoded bytes or value
+     * Create from encoded bytes or value.
      *
      * @param bytes Byte array of length 16
      */
@@ -37,7 +37,7 @@ public class ItemDesignatorId implements ISecurityMetadataValue {
     }
 
     /**
-     * Get the item designator id
+     * Get the item designator id.
      *
      * @return The id as an array
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/ObjectCountryCodeString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/ObjectCountryCodeString.java
@@ -2,12 +2,12 @@ package org.jmisb.api.klv.st0102;
 
 import java.nio.charset.StandardCharsets;
 
-/** Represents an Object Country Code value in ST 0102 */
+/** Represents an Object Country Code value in ST 0102. */
 public class ObjectCountryCodeString implements ISecurityMetadataValue {
     private String stringValue;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param value The string value
      */
@@ -16,7 +16,7 @@ public class ObjectCountryCodeString implements ISecurityMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes Encoded byte array
      */
@@ -25,7 +25,7 @@ public class ObjectCountryCodeString implements ISecurityMetadataValue {
     }
 
     /**
-     * Get the value
+     * Get the value.
      *
      * @return The string value
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/OcmDate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/OcmDate.java
@@ -5,14 +5,32 @@ import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 
-/** Object Country Coding Method Version Date (ST 0102 tag 24) */
+/**
+ * Object Country Coding Method Version Date (ST 0102 tag 24).
+ *
+ * <p>This metadata item provides the effective date (promulgation date) of the source (FIPS 10-4,
+ * ISO 3166, GENC, or STANAG 1059) used for the Object Country Coding Method. As ISO 3166 is updated
+ * by dated circulars, not by version revision, the ISO 8601 YYYY-MM-DD formatted date is used. The
+ * valid country codes (and the corresponding meanings) can vary between versions of those coding
+ * methods, so this metadata item can be used to identify the exact version of the coding method.
+ */
 public class OcmDate implements ISecurityMetadataValue {
     private LocalDate date;
 
+    /**
+     * Construct OcmDate from a LocalDate.
+     *
+     * @param date the date for the coding method version.
+     */
     public OcmDate(LocalDate date) {
         this.date = date;
     }
 
+    /**
+     * Construct OcmDate from encoded bytes.
+     *
+     * @param bytes byte array with encoded value for OcmDate (exactly 10 bytes, see ST0102)
+     */
     public OcmDate(byte[] bytes) {
         if (bytes.length != 10) {
             throw new IllegalArgumentException(
@@ -24,6 +42,14 @@ public class OcmDate implements ISecurityMetadataValue {
         date = LocalDate.parse(dateString, ISO_LOCAL_DATE);
     }
 
+    /**
+     * The date value.
+     *
+     * <p>These dates are somewhat arbitrary, and do not have associated time zones. It is probably
+     * safest to treat them as identifiers with ordering.
+     *
+     * @return the date of the Country Coding Method.
+     */
     public LocalDate getValue() {
         return date;
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0102/ST0102Version.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/ST0102Version.java
@@ -2,12 +2,12 @@ package org.jmisb.api.klv.st0102;
 
 import org.jmisb.core.klv.PrimitiveConverter;
 
-/** Security Metadata version number (ST 0102 tag 22) */
+/** Security Metadata version number (ST 0102 tag 22). */
 public class ST0102Version implements ISecurityMetadataValue {
     private int version;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param version The version number
      */
@@ -16,7 +16,7 @@ public class ST0102Version implements ISecurityMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes Byte array of length 2
      */
@@ -29,7 +29,7 @@ public class ST0102Version implements ISecurityMetadataValue {
     }
 
     /**
-     * Get the version number
+     * Get the version number.
      *
      * @return The version number
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataConstants.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataConstants.java
@@ -2,9 +2,9 @@ package org.jmisb.api.klv.st0102;
 
 import org.jmisb.api.klv.UniversalLabel;
 
-/** Constants used by ST 0102 */
+/** Constants used by ST 0102. */
 public class SecurityMetadataConstants {
-    /** The currently-supported revision is 0102.12 */
+    /** The currently-supported revision of ST0102. */
     public static final short ST_VERSION_NUMBER = 12;
 
     private SecurityMetadataConstants() {}

--- a/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataKey.java
@@ -5,7 +5,15 @@ import java.util.Map;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.UniversalLabel;
 
-/** ST 0102 key */
+/**
+ * ST 0102 key.
+ *
+ * <p>Each metadata element within ST0102 consists of a key represented by a instance of this
+ * enumeration, and a value represented by a instance implementing {@link ISecurityMetadataValue}.
+ *
+ * <p>The key has two representations - a tag number for the local set, and a universal label for
+ * the universal set.
+ */
 public enum SecurityMetadataKey implements IKlvKey {
     Undefined(
             0,
@@ -14,26 +22,288 @@ public enum SecurityMetadataKey implements IKlvKey {
                         0x06, 0x0e, 0x2b, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                         0x00, 0x00, 0x00, 0x00
                     })),
+    /**
+     * Security Classification.
+     *
+     * <p>Value is a {@link org.jmisb.api.klv.st0102.localset.ClassificationLocal} in the local set
+     * and a {@link org.jmisb.api.klv.st0102.universalset.ClassificationUniversal} in the universal
+     * set.
+     *
+     * <p>This item is required for the security local set or universal set to be valid.
+     */
     SecurityClassification(1, SecurityMetadataConstants.securityClassificationUl),
+    /**
+     * Coding method for Classifying Country and Releasing Instructions.
+     *
+     * <p>This indicates how the {@link ClassifyingCountry} and {@link ReleasingInstructions} are to
+     * be interpreted. Value is a {@link CountryCodingMethod}.
+     *
+     * <p>This item is required for the security local set or universal set to be valid.
+     */
     CcCodingMethod(2, SecurityMetadataConstants.ccCodingMethodUl),
+    /**
+     * The classifying country.
+     *
+     * <p>This specifies which country classified the data (or possibly which country's security
+     * rules / guidance are being used for the classification). Value is a {@link
+     * SecurityMetadataString} with a {@code displayName} of {@code CLASSIFYING_COUNTRY} and a
+     * {@code value} corresponding to the country code preceded by {@code //}.
+     *
+     * <p>For example, if the {@link CcCodingMethod} is {@code ISO3166_THREE_LETTER}, then Australia
+     * would be represented as {@code new
+     * SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AUS")}.
+     *
+     * <p>This item is required for the security local set or universal set to be valid.
+     */
     ClassifyingCountry(3, SecurityMetadataConstants.classifyingCountryUl),
+    /**
+     * Security Sensitive Compartmented Information (SCI) / Special Handling Instructions (SHI)
+     * information.
+     *
+     * <p>When special handling instructions or compartmented information are used, Motion Imagery
+     * Data shall contain the Sensitive Compartmented Information (SCI) / Special Handling
+     * Instructions (SHI) metadata element. When used, SCI/SHI digraphs, trigraphs, or compartment
+     * names shall be added identifying a single or a combination of special handling instructions.
+     *
+     * <p>A single entry shall be ended with a double forward slash “//”.
+     *
+     * <p>Multiple digraphs, trigraphs, or compartment names shall be separated by a single forward
+     * slash “/”.
+     *
+     * <p>Multiple digraphs, trigraphs, or compartment names shall be ended with a double forward
+     * slash “//”.
+     *
+     * <p>Value is a {@link SecurityMetadataString} with a {@code displayName} of {@code
+     * SCI_SHI_INFO} and a {@code value} corresponding to the rules above. For example, if the
+     * Motion Imagery was in the fictitious "Butter Popcorn" compartment, the value might be: {@code
+     * new SecurityMetadataString(SecurityMetadataString.SCI_SHI_INFO, "BUTTER POPCORN//")}.
+     */
     SciShiInfo(4, SecurityMetadataConstants.sciShiInfoUl),
+    /**
+     * Security Caveats.
+     *
+     * <p>The Caveats metadata element represents pertinent caveats (or code words) from each
+     * category of the appropriate security entity register. Entries in this field may be
+     * abbreviated or spelled out as free text entries.
+     *
+     * <p>Value is a {@link SecurityMetadataString} with a {@code displayName} of {@code CAVEATS}
+     * and a {@code value} of the caveat text or abbreviation. For example, if the Motion Imagery
+     * was considered Unclassified, For Official Use Only, the value might be: {@code new
+     * SecurityMetadataString(SecurityMetadataString.CAVEATS, "FOUO")}.
+     */
     Caveats(5, SecurityMetadataConstants.caveatsUl),
+    /**
+     * The countries to which the motion imagery data is releasable to.
+     *
+     * <p>The Releasing Instructions metadata element contains a list of country codes to indicate
+     * the countries to which the Motion Imagery Data is releasable.
+     *
+     * <p>Value is a {@link SecurityMetadataString} with a {@code displayName} of {@code
+     * RELEASING_INSTRUCTIONS} and a {@code value} corresponding to the country codes separated by
+     * spaces. For example, if the {@link CcCodingMethod} is {@code ISO3166_THREE_LETTER}, then
+     * release to Canada and the United States would be represented as {@code new
+     * SecurityMetadataString(SecurityMetadataString.RELEASING_INSTRUCTIONS, "CAN USA")}.
+     *
+     * <p>This item is required if releasing instructions are required.
+     */
     ReleasingInstructions(6, SecurityMetadataConstants.releasingInstructionsUl),
+    /**
+     * Classified By.
+     *
+     * <p>The Classified By metadata element identifies the name and type of authority used to
+     * classify the Motion Imagery Data. The metadata element is free text and can contain either
+     * the original classification authority name and position or personal identifier, or the title
+     * of the document or security classification guide used to classify the data.
+     *
+     * <p>Value is a {@link SecurityMetadataString} with a {@code displayName} of {@code
+     * CLASSIFIED_BY} and a {@code value} corresponding to the classified by text. For example, if
+     * the classification was performed by "Mark W. Ewing, ODNI Chief Management Officer", it could
+     * be shown as {@code new SecurityMetadataString(SecurityMetadataString.CLASSIFIED_BY, "Mark W.
+     * Ewing, ODNI Chief Management Officer")}.
+     */
     ClassifiedBy(7, SecurityMetadataConstants.classifiedByUl),
+    /**
+     * Derived From.
+     *
+     * <p>The Derived From metadata element contains information about the original source of data
+     * from which the classification was derived. The metadata element is free text.
+     *
+     * <p>Value is a {@link SecurityMetadataString} with a {@code displayName} of {@code
+     * DERIVED_FROM} and a {@code value} corresponding to the derivative source. For example, if the
+     * classification was derived from multiple sources, it could be shown as {@code new
+     * SecurityMetadataString(SecurityMetadataString.DERIVED_FROM, "Multiple Sources")}.
+     */
     DerivedFrom(8, SecurityMetadataConstants.derivedFromUl),
+    /**
+     * Classification Reason.
+     *
+     * <p>The Classification Reason metadata element contains the reason for classification or a
+     * citation from a document. The metadata element is free text.
+     *
+     * <p>Value is a {@link SecurityMetadataString} with a {@code displayName} of {@code
+     * CLASSIFICATION_REASON} and a {@code value} corresponding to the classification reason or
+     * citation. For example, if the classification reason is in section 1.4(c), it could be shown
+     * as {@code new SecurityMetadataString(SecurityMetadataString.CLASSIFICATION_REASON,
+     * "1.4(c)")}.
+     */
     ClassificationReason(9, SecurityMetadataConstants.classificationReasonUl),
+    /**
+     * Declassification Date.
+     *
+     * <p>The Declassification Date metadata element provides a date when the classified material
+     * may be automatically declassified.
+     *
+     * <p>Value is a {@link DeclassificationDate}. As an example, if the declassification date (from
+     * policy) is 31 December 2039, this would be {@code new DeclassificationDate(LocalDate.of(2039,
+     * 12, 31))}.
+     */
     DeclassificationDate(10, SecurityMetadataConstants.declassificationDateUl),
+    /**
+     * Classification and Marking System.
+     *
+     * <p>The Classification and Marking System metadata element identifies the classification or
+     * marking system used in the Security Metadata set as determined by the appropriate security
+     * entity for the country originating the data. This is free text.
+     *
+     * <p>Value is a {@link SecurityMetadataString} with a {@code displayName} of {@code
+     * MARKING_SYSTEM} and a {@code value} corresponding to the classification and marking system.
+     */
     MarkingSystem(11, SecurityMetadataConstants.markingSystemUl),
+    /**
+     * Object Country Coding Method.
+     *
+     * <p>The Object Country Coding Method metadata element identifies the coding method for the
+     * {@link ObjectCountryCodes} metadata. This element allows use of GEC two-letter or four-letter
+     * alphabetic country code (legacy systems only); ISO-3166 two-letter, three-letter, or
+     * three-digit numeric; STANAG 1059 two-letter or three-letter codes; and GENC two-letter,
+     * three-letter, three-digit numeric or administrative subdivisions. Early (ST0102-5 and
+     * earlier) versions allowed this element to be optional; its absence indicates the default GENC
+     * two-letter coding method was used in the Object Country Code element.
+     *
+     * <p>Value is an {@link org.jmisb.api.klv.st0102.localset.OcMethod} for security metadata local
+     * set. For example, {@code new OcMethod(CountryCodingMethod.ISO3166_TWO_LETTER)}.
+     *
+     * <p>Value is an {@link ObjectCountryCodeString} for security metadata universal set.
+     *
+     * <p>This item is required for the security local set or universal set to be valid.
+     */
     OcCodingMethod(12, SecurityMetadataConstants.ocCodingMethodUl),
+    /**
+     * Object Country Codes.
+     *
+     * <p>The Object Country Codes metadata element contains a value identifying the country or
+     * countries that are the object of the Motion Imagery Data.
+     *
+     * <p>Multiple Object Country Codes shall be separated by a semi-colon “;” (no spaces).
+     *
+     * <p>The object country code of the geographic region lying under the center of the image frame
+     * shall populate the Object Country Code metadata element. The object country codes of other
+     * represented geographic regions may be included in addition to the country code of the
+     * geographic region under the center of the image frame.
+     *
+     * <p>Value is a {@link ObjectCountryCodeString} with a {@code value} corresponding to the
+     * country code or codes. For example, if the {@link OcCodingMethod} is {@code
+     * ISO3166_THREE_LETTER}, then Australia would be represented as {@code new
+     * ObjectCountryCodeString("AUS")}. If the imagery also contained part of New Zealand, then it
+     * could be represented {@code new ObjectCountryCodeString("AUS;NZL")}
+     */
     ObjectCountryCodes(13, SecurityMetadataConstants.objectCountryCodesUl),
+    /**
+     * Classification Comments.
+     *
+     * <p>The Classification Comments metadata element allows for security related comments and
+     * format changes necessary in the future. This field may be used in addition to those required
+     * by appropriate security entity and is optional.
+     *
+     * <p>The Classification Comments metadata element shall only be used to convey non-essential
+     * security-related information.
+     *
+     * <p>Value is a {@link SecurityMetadataString} with a {@code displayName} of {@code
+     * CLASSIFICATION_COMMENTS} and a {@code value} providing the free text comments.
+     */
     ClassificationComments(14, SecurityMetadataConstants.classificationCommentsUl),
     // TODO: 15 - 18, UMID - this is a difficult case for UL variation.
+    /**
+     * Stream Identifier (Deprecated).
+     *
+     * <p>This is a legacy identifier, no longer valid, provided to support ST0102.10 and earlier.
+     *
+     * <p>In MPEG-2 Program Streams and Packetized Elementary Streams (PES) it specifies the type
+     * and number of the Elementary Stream. In MPEG-2 Transport Streams the it may be set by the
+     * user to any valid value which correctly describes the Elementary Stream type.
+     *
+     * <p>Note that the current MISB position is that the security metadata applies to the
+     * information as a whole - there is no marking of individual streams.
+     *
+     * <p>Value is a StreamId. It should not be instantiated, and there is no "construct from value"
+     * for StreamId.
+     */
     StreamId(19, SecurityMetadataConstants.streamIdUl),
+    /**
+     * Transport Stream Identifier (Deprecated).
+     *
+     * <p>This is a legacy identifier, no longer valid, provided to support ST0102.10 and earlier.
+     *
+     * <p>When multiple Transport Streams are present in a network environment the transport stream
+     * identifier uniquely identifies a specific Transport Stream from any other Transport Stream to
+     * remove any ambiguity. Its value is defined by the originator.
+     *
+     * <p>Note that the current MISB position is that the security metadata applies to the
+     * information as a whole - there is no marking of individual streams.
+     *
+     * <p>Value is a TransportStreamId. It should not be instantiated, and there is no "construct
+     * from value" for TransportStreamId.
+     */
     TransportStreamId(20, SecurityMetadataConstants.transportStreamIdUl),
+    /**
+     * Item Designator Identifier (Deprecated).
+     *
+     * <p>This is a legacy identifier, no longer valid, provided to support ST0102.10 and earlier.
+     *
+     * <p>Note that the current MISB position is that the security metadata applies to the
+     * information as a whole - there is no marking of individual items.
+     *
+     * <p>Value is an ItemDesignatorId. It should not be instantiated, and there is no "construct
+     * from value" for ItemDesignatorId.
+     */
     ItemDesignatorId(21, SecurityMetadataConstants.itemDesignatorIdUl),
+    /**
+     * Version of Security Metadata Standard.
+     *
+     * <p>The Version metadata element indicates the version number of MISB ST 0102 referenced.
+     *
+     * <p>Value is a {@link ST0102Version}. As an example, {@code new
+     * ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER)} for the current version supported
+     * by jMISB.
+     */
     Version(22, SecurityMetadataConstants.versionUl),
+    /**
+     * Country Coding Method Version Date.
+     *
+     * <p>This metadata item provides the effective date (promulgation date) of the source (FIPS
+     * 10-4, ISO 3166, GENC, or STANAG 1059) used for the Classifying Country and Releasing
+     * Instructions Country Coding Method. As ISO 3166 is updated by dated circulars, not by version
+     * revision, the ISO 8601 YYYY-MM-DD formatted date is used. The valid country codes (and the
+     * corresponding meanings) can vary between versions of those coding methods, so this metadata
+     * item can be used to identify the exact version of the coding method.
+     *
+     * <p>Value is a CcmDate. For example, if using a GENC baseline of 14 November 2013, this could
+     * be {@code new CcmDate(LocalDate.of(2013, 11, 14))}.
+     */
     CcCodingMethodVersionDate(23, SecurityMetadataConstants.ccCodingMethodVersionDateUl),
+    /**
+     * Object Country Coding Method Version Date.
+     *
+     * <p>This metadata item provides the effective date (promulgation date) of the source (FIPS
+     * 10-4, ISO 3166, GENC, or STANAG 1059) used for the Object Country Coding Method. As ISO 3166
+     * is updated by dated circulars, not by version revision, the ISO 8601 YYYY-MM-DD formatted
+     * date is used. The valid country codes (and the corresponding meanings) can vary between
+     * versions of those coding methods, so this metadata item can be used to identify the exact
+     * version of the coding method.
+     *
+     * <p>Value is an OcmDate. For example, if using a GENC baseline of 14 November 2013, this could
+     * be {@code new CcmDate(LocalDate.of(2013, 11, 14))}.
+     */
     OcCodingMethodVersionDate(24, SecurityMetadataConstants.ocCodingMethodVersionDateUl);
 
     private int tag;
@@ -59,14 +329,33 @@ public enum SecurityMetadataKey implements IKlvKey {
         return tag;
     }
 
+    /**
+     * Get the {@link UniversalLabel} for this metadata key.
+     *
+     * @return the universal label for this key.
+     */
     public UniversalLabel getUl() {
         return ul;
     }
 
+    /**
+     * Look up the SecurityMetadataKey by tag value.
+     *
+     * <p>As an example, looking up {@code 5} will return {@link #Caveats}.
+     *
+     * @param tag the tag value
+     * @return the corresponding SecurityMetadataKey.
+     */
     public static SecurityMetadataKey getKey(int tag) {
         return tagTable.containsKey(tag) ? tagTable.get(tag) : Undefined;
     }
 
+    /**
+     * Look up the SecurityMetadataKey by universal label.
+     *
+     * @param ul the universal label.
+     * @return the corresponding SecurityMetadataKey.
+     */
     public static SecurityMetadataKey getKey(UniversalLabel ul) {
         return ulTable.containsKey(ul) ? ulTable.get(ul) : Undefined;
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataMessage.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataMessage.java
@@ -5,13 +5,13 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.klv.IMisbMessage;
 
-/** Abstract base class for Security Metadata Local and Universal sets */
+/** Abstract base class for Security Metadata Local and Universal sets. */
 public abstract class SecurityMetadataMessage implements IMisbMessage {
-    /** Map containing all data elements in the message */
+    /** Map containing all data elements in the message. */
     protected SortedMap<SecurityMetadataKey, ISecurityMetadataValue> map = new TreeMap<>();
 
     /**
-     * Set a message field
+     * Set a message field.
      *
      * @param key The key
      * @param value The value
@@ -21,7 +21,7 @@ public abstract class SecurityMetadataMessage implements IMisbMessage {
     }
 
     /**
-     * Get a message field
+     * Get a message field.
      *
      * @param key The key
      * @return The value
@@ -31,7 +31,7 @@ public abstract class SecurityMetadataMessage implements IMisbMessage {
     }
 
     /**
-     * Get the available message keys
+     * Get the available message keys.
      *
      * @return Collection of the keys in the security metadata message.
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataString.java
@@ -2,7 +2,12 @@ package org.jmisb.api.klv.st0102;
 
 import java.nio.charset.StandardCharsets;
 
-/** Represents a string value in ST 0102 */
+/**
+ * Represents a string value in ST 0102.
+ *
+ * <p>Strings are used across a range of security metadata items. This class represents the various
+ * kinds of strings.
+ */
 public class SecurityMetadataString implements ISecurityMetadataValue {
     public static final String CAVEATS = "Caveats";
     public static final String CLASSIFICATION_COMMENTS = "Classification Comments";
@@ -20,7 +25,7 @@ public class SecurityMetadataString implements ISecurityMetadataValue {
     private String displayName;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param displayName the display name for this particular string (see static values)
      * @param value The string value
@@ -31,7 +36,7 @@ public class SecurityMetadataString implements ISecurityMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param displayName the display name for this particular string (see static values)
      * @param bytes Encoded byte array
@@ -42,7 +47,7 @@ public class SecurityMetadataString implements ISecurityMetadataValue {
     }
 
     /**
-     * Get the value
+     * Get the value.
      *
      * @return The string value
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/StreamId.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/StreamId.java
@@ -24,7 +24,7 @@ public class StreamId implements ISecurityMetadataValue {
     private int id;
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes Byte array of length 1
      */
@@ -36,7 +36,7 @@ public class StreamId implements ISecurityMetadataValue {
     }
 
     /**
-     * Get the stream identifier
+     * Get the stream identifier.
      *
      * @return The stream identifier
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/TransportStreamId.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/TransportStreamId.java
@@ -24,7 +24,7 @@ public class TransportStreamId implements ISecurityMetadataValue {
     private int id;
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes Byte array of length 2
      */
@@ -37,7 +37,7 @@ public class TransportStreamId implements ISecurityMetadataValue {
     }
 
     /**
-     * Get the transport stream identifier
+     * Get the transport stream identifier.
      *
      * @return The transport stream identifier
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/CcMethod.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/CcMethod.java
@@ -5,12 +5,12 @@ import static org.jmisb.api.klv.st0102.CountryCodingMethod.ISO3166_MIXED;
 import org.jmisb.api.klv.st0102.CountryCodingMethod;
 import org.jmisb.api.klv.st0102.ISecurityMetadataValue;
 
-/** Classifying Country and Releasing Instructions Country Coding Method (ST 0102 tag 2) */
+/** Classifying Country and Releasing Instructions Country Coding Method (ST 0102 tag 2). */
 public class CcMethod implements ISecurityMetadataValue {
     private byte method;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param method The country coding method
      */
@@ -68,7 +68,7 @@ public class CcMethod implements ISecurityMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes Encoded byte array
      */
@@ -86,7 +86,7 @@ public class CcMethod implements ISecurityMetadataValue {
     }
 
     /**
-     * Get the country coding method
+     * Get the country coding method.
      *
      * @return The country coding method
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/ClassificationLocal.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/ClassificationLocal.java
@@ -3,12 +3,12 @@ package org.jmisb.api.klv.st0102.localset;
 import org.jmisb.api.klv.st0102.Classification;
 import org.jmisb.api.klv.st0102.ISecurityMetadataValue;
 
-/** Security classification level as defined by Security Metadata Local Set (ST 0102 tag 1) */
+/** Security classification level as defined by Security Metadata Local Set (ST 0102 tag 1). */
 public class ClassificationLocal implements ISecurityMetadataValue {
     private Classification value;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param classification The classification level
      */
@@ -17,7 +17,7 @@ public class ClassificationLocal implements ISecurityMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes The encoded byte array
      */
@@ -30,7 +30,7 @@ public class ClassificationLocal implements ISecurityMetadataValue {
     }
 
     /**
-     * Get the classification level
+     * Get the classification level.
      *
      * @return The classification level
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/LocalSetFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/LocalSetFactory.java
@@ -7,7 +7,7 @@ public class LocalSetFactory {
     private LocalSetFactory() {}
 
     /**
-     * Create a {@link ISecurityMetadataValue} instance from encoded bytes
+     * Create a {@link ISecurityMetadataValue} instance from encoded bytes.
      *
      * @param tag The tag defining the value type
      * @param bytes Encoded bytes

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/OcMethod.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/OcMethod.java
@@ -7,7 +7,7 @@ import org.jmisb.api.klv.st0102.CountryCodingMethod;
 import org.jmisb.api.klv.st0102.CountryCodingMethodUtilities;
 import org.jmisb.api.klv.st0102.ISecurityMetadataValue;
 
-/** Object Country Coding Method (ST 0102 tag 12) */
+/** Object Country Coding Method (ST 0102 tag 12). */
 public class OcMethod implements ISecurityMetadataValue {
     private byte method;
     private static Set<Byte> legal =
@@ -31,7 +31,7 @@ public class OcMethod implements ISecurityMetadataValue {
                             (byte) 0x40));
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param method Country coding method
      */
@@ -40,7 +40,7 @@ public class OcMethod implements ISecurityMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes Encoded byte array
      */
@@ -57,7 +57,7 @@ public class OcMethod implements ISecurityMetadataValue {
     }
 
     /**
-     * Get the country coding method
+     * Get the country coding method.
      *
      * @return The country coding method
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/package-info.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/package-info.java
@@ -1,2 +1,8 @@
-/** ST 0102 Local Set-specific types */
+/**
+ * ST 0102 Local Set-specific types.
+ *
+ * <p>ST0102 has two representations. The most common is as a nested Local Set (e.g. nested within
+ * ST0601 Item 48), and that is the usage supported by this package. The other representation is as
+ * a Universal Set, which is supported by {@link org.jmisb.api.klv.st0102.universalset}.
+ */
 package org.jmisb.api.klv.st0102.localset;

--- a/api/src/main/java/org/jmisb/api/klv/st0102/package-info.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/package-info.java
@@ -1,2 +1,18 @@
-/** ST 0102: Security Metadata Universal and Local Sets */
+/**
+ * ST 0102: Security Metadata Universal and Local Sets.
+ *
+ * <p>This standard defines a Security Metadata Universal Set and a Security Metadata Local Set
+ * encoded as KLV (Key-Length-Value) elements for marking Motion Imagery Data with security
+ * classification information.
+ *
+ * <p>The methods used to gather security information, mark Motion Imagery Data with security
+ * information, and display security information are the responsibility of application system
+ * developers in concert with appropriate security officials. Originators and users of Motion
+ * Imagery Data are responsible for the proper handling, and ultimately, for the use and disposition
+ * of classified information. This standard is not a security manual or instruction on when or how
+ * to use security markings or caveats. Use of this standard does not ensure a Motion Imagery System
+ * will be accredited by security officials.
+ *
+ * <p>Before version 0102.5, this document was a Recommended Practice (RP).
+ */
 package org.jmisb.api.klv.st0102;

--- a/api/src/main/java/org/jmisb/api/klv/st0102/universalset/ClassificationUniversal.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/universalset/ClassificationUniversal.java
@@ -4,12 +4,12 @@ import java.nio.charset.StandardCharsets;
 import org.jmisb.api.klv.st0102.Classification;
 import org.jmisb.api.klv.st0102.ISecurityMetadataValue;
 
-/** Security classification level as defined by Security Metadata Universal Set (ST 0102 tag 1) */
+/** Security classification level as defined by Security Metadata Universal Set (ST 0102 tag 1). */
 public class ClassificationUniversal implements ISecurityMetadataValue {
     private Classification value;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param classification The classification level
      */
@@ -18,7 +18,7 @@ public class ClassificationUniversal implements ISecurityMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes The encoded byte array
      */
@@ -47,7 +47,7 @@ public class ClassificationUniversal implements ISecurityMetadataValue {
     }
 
     /**
-     * Get the classification level
+     * Get the classification level.
      *
      * @return The classification level
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/universalset/SecurityMetadataUniversalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/universalset/SecurityMetadataUniversalSet.java
@@ -8,10 +8,10 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.*;
 import org.jmisb.api.klv.st0102.*;
 
-/** Security Metadata Universal Set message packet defined by ST 0102 */
+/** Security Metadata Universal Set message packet defined by ST 0102. */
 public class SecurityMetadataUniversalSet extends SecurityMetadataMessage {
     /**
-     * Create the message from the given key/value pairs
+     * Create the message from the given key/value pairs.
      *
      * @param values Key/value pairs to be included in the message
      */
@@ -21,7 +21,7 @@ public class SecurityMetadataUniversalSet extends SecurityMetadataMessage {
     }
 
     /**
-     * Create a Security Metadata Universal Set message by parsing the given byte array
+     * Create a Security Metadata Universal Set message by parsing the given byte array.
      *
      * @param bytes Byte array containing a Security Metadata Universal Set message
      * @throws KlvParseException if a parsing error occurs
@@ -100,7 +100,7 @@ public class SecurityMetadataUniversalSet extends SecurityMetadataMessage {
         return "ST 0102 (universal)";
     }
 
-    /** Builder class for {@link SecurityMetadataUniversalSet} objects */
+    /** Builder class for {@link SecurityMetadataUniversalSet} objects. */
     public static class Builder {
         private final Classification classification;
         private SecurityMetadataString ccMethod;
@@ -120,33 +120,118 @@ public class SecurityMetadataUniversalSet extends SecurityMetadataMessage {
         private CcmDate ccmDate;
         private OcmDate ocmDate;
 
+        /**
+         * Constructor.
+         *
+         * @param classification the classification to use in this {@link
+         *     SecurityMetadataUniversalSet}
+         */
         public Builder(Classification classification) {
             this.classification = classification;
         }
 
+        /**
+         * Coding method for Classifying Country and Releasing Instructions.
+         *
+         * <p>This indicates how the {@link #classifyingCountry} and {@link #releasingInstructions}
+         * are to be interpreted.
+         *
+         * <p>This item is required for the security universal set to be valid. If it is not
+         * provided, {@code "GENC Two Letter"} will be used as a default value.
+         *
+         * <p>Consider setting {@link #ccmDate} to indicate a specific version of the coding method.
+         *
+         * @param value the country coding method
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder ccMethod(String value) {
             this.ccMethod =
                     new SecurityMetadataString(SecurityMetadataString.COUNTRY_CODING_METHOD, value);
             return this;
         }
 
+        /**
+         * The classifying country.
+         *
+         * <p>This specifies which country classified the data (or possibly which country's security
+         * rules / guidance are being used for the classification). The value is the country code
+         * preceded by {@code //}. For example, if the {@link #ccMethod} is {@code "ISO-3166 Three
+         * Letter"}, then Australia would be represented as {@code "//AUS"}.
+         *
+         * <p>This item is required for the security universal set to be valid. There is no default
+         * value, and the {@link #build()} will fail if it is not provided.
+         *
+         * @param value the country code (including the required "//" part).
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder classifyingCountry(String value) {
             this.classifyingCountry =
                     new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, value);
             return this;
         }
 
+        /**
+         * Security Sensitive Compartmented Information (SCI) / Special Handling Instructions (SHI)
+         * information.
+         *
+         * <p>When special handling instructions or compartmented information are used, Motion
+         * Imagery Data shall contain the Sensitive Compartmented Information (SCI) / Special
+         * Handling Instructions (SHI) metadata element. When used, SCI/SHI digraphs, trigraphs, or
+         * compartment names shall be added identifying a single or a combination of special
+         * handling instructions.
+         *
+         * <p>A single entry shall be ended with a double forward slash “//”.
+         *
+         * <p>Multiple digraphs, trigraphs, or compartment names shall be separated by a single
+         * forward slash “/”.
+         *
+         * <p>Multiple digraphs, trigraphs, or compartment names shall be ended with a double
+         * forward slash “//”.
+         *
+         * @param value the SCI / SHI information, including the ending double forward slash and any
+         *     single forward slash separators.
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder sciShiInfo(String value) {
             this.sciShiInfo =
                     new SecurityMetadataString(SecurityMetadataString.SCI_SHI_INFO, value);
             return this;
         }
 
+        /**
+         * Security Caveats.
+         *
+         * <p>The Caveats metadata element represents pertinent caveats (or code words) from each
+         * category of the appropriate security entity register. Entries in this field may be
+         * abbreviated or spelled out as free text entries.
+         *
+         * <p>Value is the caveat text or abbreviation. For example, if the Motion Imagery was
+         * considered Unclassified, For Official Use Only, the value might be: {@code "FOUO"}.
+         *
+         * @param value the caveat text or abbreviation
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder caveats(String value) {
             this.caveats = new SecurityMetadataString(SecurityMetadataString.CAVEATS, value);
             return this;
         }
 
+        /**
+         * The countries that the motion imagery data is releasable to.
+         *
+         * <p>The Releasing Instructions metadata element contains a list of country codes to
+         * indicate the countries to which the Motion Imagery Data is releasable.
+         *
+         * <p>Value is the country codes for those countries (as specified in the {@link
+         * #classifyingCountry(String value)} separated by spaces. For example, if the {@link
+         * #ccMethod} is {@code "ISO-3166 Three Letter"}, then release to Canada and the United
+         * States would be represented as {@code "CAN USA"}.
+         *
+         * <p>This item is required if releasing instructions are required.
+         *
+         * @param value the space separated list of country codes.
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder releasingInstructions(String value) {
             this.releasingInstructions =
                     new SecurityMetadataString(
@@ -154,35 +239,106 @@ public class SecurityMetadataUniversalSet extends SecurityMetadataMessage {
             return this;
         }
 
+        /**
+         * Classified By.
+         *
+         * <p>The Classified By metadata element identifies the name and type of authority used to
+         * classify the Motion Imagery Data. The metadata element is free text and can contain
+         * either the original classification authority name and position or personal identifier, or
+         * the title of the document or security classification guide used to classify the data.
+         *
+         * <p>An example might be {@code "Mark W. Ewing, ODNI Chief Management Officer")}.
+         *
+         * @param value the classified by text
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder classifiedBy(String value) {
             this.classifiedBy =
                     new SecurityMetadataString(SecurityMetadataString.CLASSIFIED_BY, value);
             return this;
         }
 
+        /**
+         * Derived From.
+         *
+         * <p>The Derived From metadata element contains information about the original source of
+         * data from which the classification was derived. The metadata element is free text.
+         *
+         * <p>Value is the derivative source text. For example, if the classification was derived
+         * from multiple sources, it could be shown as {@code "Multiple Sources"}.
+         *
+         * @param value the derived from text
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder derivedFrom(String value) {
             this.derivedFrom =
                     new SecurityMetadataString(SecurityMetadataString.DERIVED_FROM, value);
             return this;
         }
 
+        /**
+         * Classification Reason.
+         *
+         * <p>The Classification Reason metadata element contains the reason for classification or a
+         * citation from a document. The metadata element is free text.
+         *
+         * <p>For example, if the classification reason is in section 1.4(c), it could be shown as
+         * {@code "1.4(c)"}.
+         *
+         * @param value the classification reason or citation
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder classificationReason(String value) {
             this.classificationReason =
                     new SecurityMetadataString(SecurityMetadataString.CLASSIFICATION_REASON, value);
             return this;
         }
 
+        /**
+         * Declassification Date.
+         *
+         * <p>The Declassification Date metadata element provides a date when the classified
+         * material may be automatically declassified.
+         *
+         * @param value the declassification date
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder declassificationDate(LocalDate value) {
             this.declassificationDate = new DeclassificationDate(value);
             return this;
         }
 
+        /**
+         * Classification and Marking System.
+         *
+         * <p>The Classification and Marking System metadata element identifies the classification
+         * or marking system used in the Security Metadata set as determined by the appropriate
+         * security entity for the country originating the data. This is free text.
+         *
+         * @param value text describing or identifying the classification and marking system
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder markingSystem(String value) {
             this.markingSystem =
                     new SecurityMetadataString(SecurityMetadataString.MARKING_SYSTEM, value);
             return this;
         }
 
+        /**
+         * Object Country Coding Method.
+         *
+         * <p>The Object Country Coding Method metadata element identifies the coding method for the
+         * {@link #objectCountryCodes} metadata. This element allows use of GEC two-letter or
+         * four-letter alphabetic country code (legacy systems only); ISO-3166 two-letter,
+         * three-letter, or three-digit numeric; STANAG 1059 two-letter or three-letter codes; and
+         * GENC two-letter, three-letter, three-digit numeric or administrative subdivisions.
+         *
+         * <p>This item is required for the universal set to be valid. If it is not provided, {@code
+         * "GENC Two Letter"} will be used as a default value.
+         *
+         * @param value the country coding method to be used for object country codes
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder ocMethod(String value) {
             this.ocMethod =
                     new SecurityMetadataString(
@@ -190,11 +346,43 @@ public class SecurityMetadataUniversalSet extends SecurityMetadataMessage {
             return this;
         }
 
+        /**
+         * Object Country Codes.
+         *
+         * <p>The Object Country Codes metadata element contains a value identifying the country or
+         * countries that are the object of the Motion Imagery Data.
+         *
+         * <p>Multiple Object Country Codes shall be separated by a semi-colon “;” (no spaces).
+         *
+         * <p>The object country code of the geographic region lying under the center of the image
+         * frame shall populate the Object Country Code metadata element. The object country codes
+         * of other represented geographic regions may be included in addition to the country code
+         * of the geographic region under the center of the image frame.
+         *
+         * <p>This item is required for the security universal set to be valid. There is no default
+         * value, and the {@link #build()} will fail if it is not provided.
+         *
+         * @param value the country code, or codes separated with semi-colon characters
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder objectCountryCodes(String value) {
             this.objectCountryCodes = new ObjectCountryCodeString(value);
             return this;
         }
 
+        /**
+         * Classification Comments.
+         *
+         * <p>The Classification Comments metadata element allows for security related comments and
+         * format changes necessary in the future. This field may be used in addition to those
+         * required by appropriate security entity and is optional.
+         *
+         * <p>The Classification Comments metadata element shall only be used to convey
+         * non-essential security-related information.
+         *
+         * @param value free text classification comments
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder classificationComments(String value) {
             this.classificationComments =
                     new SecurityMetadataString(
@@ -202,28 +390,74 @@ public class SecurityMetadataUniversalSet extends SecurityMetadataMessage {
             return this;
         }
 
+        /**
+         * Version of Security Metadata Standard.
+         *
+         * <p>The Version metadata element indicates the version number of MISB ST 0102 referenced.
+         * For example, ST 0102.12 would have the value {@code 12}.
+         *
+         * <p>{@link org.jmisb.api.klv.st0102.SecurityMetadataConstants#ST_VERSION_NUMBER} will
+         * provide the current version supported by jMISB.
+         *
+         * @param value the version number of ST 0102 document
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder version(int value) {
             this.version = new ST0102Version(value);
             return this;
         }
 
+        /**
+         * Country Coding Method Version Date.
+         *
+         * <p>This metadata item provides the effective date (promulgation date) of the source (FIPS
+         * 10-4, ISO 3166, GENC, or STANAG 1059) used for the Classifying Country and Releasing
+         * Instructions Country Coding Method. As ISO 3166 is updated by dated circulars, not by
+         * version revision, the ISO 8601 YYYY-MM-DD formatted date is used. The valid country codes
+         * (and the corresponding meanings) can vary between versions of those coding methods, so
+         * this metadata item can be used to identify the exact version of the coding method.
+         *
+         * @param value the effective date of the Country Coding Method source document.
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder ccmDate(LocalDate value) {
             this.ccmDate = new CcmDate(value);
             return this;
         }
 
+        /**
+         * Object Country Coding Method Version Date.
+         *
+         * <p>This metadata item provides the effective date (promulgation date) of the source (FIPS
+         * 10-4, ISO 3166, GENC, or STANAG 1059) used for the Object Country Coding Method. As ISO
+         * 3166 is updated by dated circulars, not by version revision, the ISO 8601 YYYY-MM-DD
+         * formatted date is used. The valid country codes (and the corresponding meanings) can vary
+         * between versions of those coding methods, so this metadata item can be used to identify
+         * the exact version of the coding method.
+         *
+         * @param value the effective date of the Country Coding Method source document.
+         * @return instance of this Builder, to support method chaining.
+         */
         public Builder ocmDate(LocalDate value) {
             this.ocmDate = new OcmDate(value);
             return this;
         }
 
+        /**
+         * Build the security universal set.
+         *
+         * <p>This takes the security information specified in the previous Builder calls and builds
+         * a @@link SecurityMetadataUniversalSet}, filling in any default values.
+         *
+         * @return the resulting universal set.
+         */
         public SecurityMetadataUniversalSet build() {
             return new SecurityMetadataUniversalSet(this);
         }
     }
 
     /**
-     * Construct from Builder
+     * Construct from Builder.
      *
      * @param builder The builder
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0102/universalset/UniversalSetFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/universalset/UniversalSetFactory.java
@@ -7,7 +7,7 @@ public class UniversalSetFactory {
     private UniversalSetFactory() {}
 
     /**
-     * Create a {@link ISecurityMetadataValue} instance from encoded bytes
+     * Create a {@link ISecurityMetadataValue} instance from encoded bytes.
      *
      * @param key Tag defining the value type
      * @param bytes Encoded bytes

--- a/api/src/main/java/org/jmisb/api/klv/st0102/universalset/package-info.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/universalset/package-info.java
@@ -1,2 +1,8 @@
-/** ST 0102 Universal Set-specific types */
+/**
+ * ST 0102 Universal Set-specific types.
+ *
+ * <p>ST0102 has two representations. The less common is as a Universal Set, and that is the usage
+ * supported by this package. The other representation is as a local set which is supported by
+ * {@link org.jmisb.api.klv.st0102.localset}.
+ */
 package org.jmisb.api.klv.st0102.universalset;

--- a/api/src/main/java/org/jmisb/api/klv/st1204/IdType.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1204/IdType.java
@@ -75,9 +75,17 @@ public enum IdType {
     /**
      * Lookup an identifier by specified value.
      *
-     * <p>< pre>{@code IdType idType = IdType.fromValue(2); // idType is IdType.Virtual }</pre>
+     * <p>For {@code IdType.Virtual}:
      *
-     * <p>< pre>{@code IdType idType = IdType.fromValue(0); // idType is IdType.None }</pre>
+     * <p>
+     *
+     * <pre>{@code IdType idType = IdType.fromValue(2);}</pre>
+     *
+     * <p>For {@code IdType.None}:
+     *
+     * <p>
+     *
+     * <pre>{@code IdType idType = IdType.fromValue(0);}</pre>
      *
      * @param i the integer value of the identifier.
      * @return the equivalent IdType.


### PR DESCRIPTION
## Motivation and Context
While we have some good javadocs, there are some classes that have very little. This change set completes missing javadoc across a small subset of the API module packages.

Resolves #182  

## Description

No code changes.

Adds a checkstyle module and configuration to check javadocs are as expected. That can be expanded later to check for other stylistic things, but for now the only checks are javadoc.

Updates the `st0102` documentation, core `klv` classes, and one part in `st1204`. The other module have suppressions - there is a fair amount of warnings (or errors, depending on configuration / opinion) to fix in some of it.

## How Has This Been Tested?
Unit tests only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

