### PR TITLE
st0603: minor javadoc style fixes

### DIFF
--- a/api/checkstyle_suppressions.xml
+++ b/api/checkstyle_suppressions.xml
@@ -6,7 +6,6 @@
     <suppress files="[\\/]api[\\/]common[\\/]" checks="[a-zA-Z0-9]*"/>
     <suppress files="[\\/]api[\\/]klv[\\/]eg0104[\\/]" checks="[a-zA-Z0-9]*"/>
     <suppress files="[\\/]api[\\/]klv[\\/]st0601[\\/]" checks="[a-zA-Z0-9]*"/>
-    <suppress files="[\\/]api[\\/]klv[\\/]st0603[\\/]" checks="[a-zA-Z0-9]*"/>
     <suppress files="[\\/]api[\\/]klv[\\/]st0805[\\/]" checks="[a-zA-Z0-9]*"/>
     <suppress files="[\\/]api[\\/]klv[\\/]st0806[\\/]" checks="[a-zA-Z0-9]*"/>
     <suppress files="[\\/]api[\\/]klv[\\/]st0903[\\/]" checks="[a-zA-Z0-9]*"/>

--- a/api/src/main/java/org/jmisb/api/klv/st0603/ST0603TimeStamp.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0603/ST0603TimeStamp.java
@@ -41,7 +41,7 @@ public class ST0603TimeStamp {
     }
 
     /**
-     * Create from {@code DateTime}
+     * Create from {@code DateTime}.
      *
      * @param dateTime The date and time
      */
@@ -88,7 +88,7 @@ public class ST0603TimeStamp {
     }
 
     /**
-     * Get the value as a {@code LocalDateTime}
+     * Get the value as a {@code LocalDateTime}.
      *
      * @return The date and time
      */


### PR DESCRIPTION
## Motivation and Context
Updates and extends javadoc in ST0603 implementation to fix checkstyle warnings.
Resolves #188

## Description
Update javadoc - two minor style fixes.
Enables warnings (removes supression) for this package.
No code changes.

## How Has This Been Tested?
Build / unit test only.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

