### PR TITLE
qa: disable tests in the QA checks

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           java-version: 1.11
       - name: Build and check dependencies
-        run: mvn -B install --file pom.xml -Pdependencycheck
+        run: mvn -B install --file pom.xml -Pdependencycheck -DskipTests


### PR DESCRIPTION
## Motivation and Context
The goal here is to check dependencies, but the IT tests are failing with

```
 java.lang.NoClassDefFoundError: Could not initialize class org.bytedeco.ffmpeg.global.swscale
```

That might be a JDK 11 issue, but in any case its defeating the point of this workflow.
So at least for now, disable the tests.

## Description
Adds `-DskipTests` to the configuration for this workflow

## How Has This Been Tested?
Will be tested as part of this PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

