### PR TITLE
klv: allow different parser strategies for errors

### DIFF
--- a/api/src/main/java/org/jmisb/api/common/IInvalidDataHandlerStrategy.java
+++ b/api/src/main/java/org/jmisb/api/common/IInvalidDataHandlerStrategy.java
@@ -1,0 +1,17 @@
+package org.jmisb.api.common;
+
+import org.slf4j.Logger;
+
+/** Strategy to handle invalid data. */
+public interface IInvalidDataHandlerStrategy {
+
+    /**
+     * Process the invalid data event according to the implementing strategy.
+     *
+     * @param logger a source logger, for use in strategies that log errors
+     * @param message a message associated with the source event, ideally describing the nature of
+     *     the invalid data
+     * @throws org.jmisb.api.common.KlvParseException if the strategy throws
+     */
+    public void process(Logger logger, String message) throws KlvParseException;
+}

--- a/api/src/main/java/org/jmisb/api/common/InvalidDataHandler.java
+++ b/api/src/main/java/org/jmisb/api/common/InvalidDataHandler.java
@@ -1,0 +1,124 @@
+package org.jmisb.api.common;
+
+import org.slf4j.Logger;
+
+/**
+ * Handler for invalid data cases.
+ *
+ * <p>This is a singleton implementation that allows different strategies to be applied to different
+ * kinds of invalid data.
+ */
+public class InvalidDataHandler {
+
+    private static final InvalidDataHandler INSTANCE = new InvalidDataHandler();
+    private IInvalidDataHandlerStrategy invalidChecksumStrategy = new ThrowOnInvalidDataStrategy();
+    private IInvalidDataHandlerStrategy missingChecksumStrategy = new ThrowOnInvalidDataStrategy();
+    private IInvalidDataHandlerStrategy dataOverrunStrategy = new ThrowOnInvalidDataStrategy();
+    private IInvalidDataHandlerStrategy invalidFieldEncodingStrategy =
+            new ThrowOnInvalidDataStrategy();
+
+    private InvalidDataHandler() {}
+
+    public static InvalidDataHandler getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Set the strategy to use in case of an invalid checksum.
+     *
+     * @param strategy the strategy to use.
+     */
+    public void setInvalidChecksumStrategy(IInvalidDataHandlerStrategy strategy) {
+        invalidChecksumStrategy = strategy;
+    }
+
+    /**
+     * Set the strategy to use in case of an required, but missing, checksum.
+     *
+     * @param strategy the strategy to use.
+     */
+    public void setMissingChecksumStrategy(IInvalidDataHandlerStrategy strategy) {
+        missingChecksumStrategy = strategy;
+    }
+
+    /**
+     * Set the strategy to use in case of a data overrun.
+     *
+     * @param strategy the strategy to use.
+     */
+    public void setOverrunStrategy(IInvalidDataHandlerStrategy strategy) {
+        dataOverrunStrategy = strategy;
+    }
+
+    /**
+     * Set the strategy to use in case of invalid field encoding.
+     *
+     * @param strategy the strategy to use.
+     */
+    public void setInvalidFieldEncodingStrategy(IInvalidDataHandlerStrategy strategy) {
+        invalidFieldEncodingStrategy = strategy;
+    }
+
+    /**
+     * Handle the case where the checksum is invalid.
+     *
+     * <p>Invalid in this case means that the checksum is present, but does not have the expected
+     * value. This usually indicates some kind of data corruption in the message between production
+     * and processing. It could mean that the producer has an incorrect checksum implementation. Its
+     * possible that it indicates an error in the jMISB implementation.
+     *
+     * @param logger source logger, not null
+     * @param message a message associated with the source event, ideally describing the nature of
+     *     the invalid data
+     * @throws KlvParseException if the handling strategy chooses to throw.
+     */
+    public void handleInvalidChecksum(Logger logger, String message) throws KlvParseException {
+        this.invalidChecksumStrategy.process(logger, message);
+    }
+
+    /**
+     * Handle the case where the checksum is missing.
+     *
+     * <p>Missing in this case means that the checksum is required, but is not present. This usually
+     * means an incorrect producer implementation.
+     *
+     * <p>Do not use this in cases where the checksum is optional.
+     *
+     * @param logger source logger, not null
+     * @param message a message associated with the source event, ideally describing the nature of
+     *     the invalid data
+     * @throws KlvParseException if the handling strategy chooses to throw.
+     */
+    public void handleMissingChecksum(Logger logger, String message) throws KlvParseException {
+        this.missingChecksumStrategy.process(logger, message);
+    }
+
+    /**
+     * Handle the case where the the parsing overruns the available data.
+     *
+     * <p>Overrun means that not enough data was available to complete the current parse option. In
+     * KLV parsing, this could mean some the available length is less than the length specified by
+     * the L part of the KLV. This usually results from some kind of data corruption, or incorrect
+     * producer implementation.
+     *
+     * @param logger source logger, not null
+     * @param message a message associated with the source event, ideally describing the nature of
+     *     the invalid data
+     * @throws KlvParseException if the handling strategy chooses to throw.
+     */
+    public void handleOverrun(Logger logger, String message) throws KlvParseException {
+        this.dataOverrunStrategy.process(logger, message);
+    }
+
+    /**
+     * Handle the case where the field could not be decoded correctly.
+     *
+     * @param logger source logger, not null
+     * @param message a message associated with the source event, ideally describing the nature of
+     *     the invalid data
+     * @throws KlvParseException if the handling strategy chooses to throw.
+     */
+    public void handleInvalidFieldEncoding(Logger logger, String message) throws KlvParseException {
+        this.invalidFieldEncodingStrategy.process(logger, message);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/common/LogOnInvalidDataStrategy.java
+++ b/api/src/main/java/org/jmisb/api/common/LogOnInvalidDataStrategy.java
@@ -1,0 +1,19 @@
+package org.jmisb.api.common;
+
+import org.slf4j.Logger;
+
+/**
+ * Invalid data strategy that logs a warning message on invalid data.
+ *
+ * <p>This is a good strategy to use for debugging and when handling data that is known to be
+ * non-compliant.
+ */
+public class LogOnInvalidDataStrategy implements IInvalidDataHandlerStrategy {
+
+    public LogOnInvalidDataStrategy() {}
+
+    @Override
+    public void process(Logger logger, String message) throws KlvParseException {
+        logger.error(message);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/common/ThrowOnInvalidDataStrategy.java
+++ b/api/src/main/java/org/jmisb/api/common/ThrowOnInvalidDataStrategy.java
@@ -1,0 +1,18 @@
+package org.jmisb.api.common;
+
+import org.slf4j.Logger;
+
+/**
+ * Invalid data strategy that throws an exception.
+ *
+ * <p>This is a good strategy to use for production usage.
+ */
+public class ThrowOnInvalidDataStrategy implements IInvalidDataHandlerStrategy {
+
+    public ThrowOnInvalidDataStrategy() {}
+
+    @Override
+    public void process(Logger logger, String message) throws KlvParseException {
+        throw new KlvParseException(message);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/LdsParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/LdsParser.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,9 +46,8 @@ public class LdsParser {
             int begin = lengthFieldOffset + lengthField.getLength();
             int end = begin + lengthField.getValue();
             if (end > bytes.length) {
-                // TODO: we will probably need a non-strict option to return the fields that were
-                // actually parsed
-                throw new KlvParseException("Overrun encountered while parsing LDS fields");
+                InvalidDataHandler.getInstance()
+                        .handleOverrun(logger, "Overrun encountered while parsing LDS fields");
             }
 
             byte[] value = Arrays.copyOfRange(bytes, begin, end);

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSet.java
@@ -5,6 +5,7 @@ import static org.jmisb.core.klv.ArrayUtils.arrayFromChunks;
 
 import java.time.LocalDate;
 import java.util.*;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.*;
 import org.jmisb.api.klv.st0102.*;
@@ -59,8 +60,14 @@ public class SecurityMetadataLocalSet extends SecurityMetadataMessage {
             if (key == SecurityMetadataKey.Undefined) {
                 logger.info("Unknown Security Metadata tag: {}", field.getTag());
             } else {
-                ISecurityMetadataValue value = LocalSetFactory.createValue(key, field.getData());
-                setField(key, value);
+                try {
+                    ISecurityMetadataValue value =
+                            LocalSetFactory.createValue(key, field.getData());
+                    setField(key, value);
+                } catch (IllegalArgumentException ex) {
+                    InvalidDataHandler.getInstance()
+                            .handleInvalidFieldEncoding(logger, ex.getMessage());
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0102/universalset/SecurityMetadataUniversalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/universalset/SecurityMetadataUniversalSet.java
@@ -4,12 +4,18 @@ import static org.jmisb.core.klv.ArrayUtils.arrayFromChunks;
 
 import java.time.LocalDate;
 import java.util.*;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.*;
 import org.jmisb.api.klv.st0102.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Security Metadata Universal Set message packet defined by ST 0102. */
 public class SecurityMetadataUniversalSet extends SecurityMetadataMessage {
+
+    private static Logger logger = LoggerFactory.getLogger(SecurityMetadataUniversalSet.class);
+
     /**
      * Create the message from the given key/value pairs.
      *
@@ -38,11 +44,16 @@ public class SecurityMetadataUniversalSet extends SecurityMetadataMessage {
 
         // Convert field data based on ST 0102
         for (UdsField field : fields) {
-            SecurityMetadataKey key = SecurityMetadataKey.getKey(field.getKey());
-            ISecurityMetadataValue value =
-                    UniversalSetFactory.createValue(
-                            SecurityMetadataKey.getKey(field.getKey()), field.getValue());
-            setField(key, value);
+            try {
+                SecurityMetadataKey key = SecurityMetadataKey.getKey(field.getKey());
+                ISecurityMetadataValue value =
+                        UniversalSetFactory.createValue(
+                                SecurityMetadataKey.getKey(field.getKey()), field.getValue());
+                setField(key, value);
+            } catch (IllegalArgumentException ex) {
+                InvalidDataHandler.getInstance()
+                        .handleInvalidFieldEncoding(logger, ex.getMessage());
+            }
         }
     }
 

--- a/api/src/main/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLS.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
@@ -46,8 +47,13 @@ public class AlgorithmLS {
             if (key == AlgorithmMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI Algorithm Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                } catch (KlvParseException | IllegalArgumentException ex) {
+                    InvalidDataHandler.getInstance()
+                            .handleInvalidFieldEncoding(LOGGER, ex.getMessage());
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/ontology/OntologyLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/ontology/OntologyLS.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
@@ -54,8 +55,13 @@ public class OntologyLS {
             if (key == OntologyMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI Ontology Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                } catch (KlvParseException | IllegalArgumentException ex) {
+                    InvalidDataHandler.getInstance()
+                            .handleInvalidFieldEncoding(LOGGER, ex.getMessage());
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vchip/VChipLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vchip/VChipLS.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
@@ -40,8 +41,13 @@ public class VChipLS {
             if (key == VChipMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI VChip Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                } catch (KlvParseException | IllegalArgumentException ex) {
+                    InvalidDataHandler.getInstance()
+                            .handleInvalidFieldEncoding(LOGGER, ex.getMessage());
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vfeature/VFeatureLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vfeature/VFeatureLS.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
@@ -40,8 +41,13 @@ public class VFeatureLS {
             if (key == VFeatureMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI VFeature Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                } catch (KlvParseException | IllegalArgumentException ex) {
+                    InvalidDataHandler.getInstance()
+                            .handleInvalidFieldEncoding(LOGGER, ex.getMessage());
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vmask/VMaskLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vmask/VMaskLS.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
@@ -39,8 +40,13 @@ public class VMaskLS {
             if (key == VMaskMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI VMask Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                } catch (KlvParseException | IllegalArgumentException ex) {
+                    InvalidDataHandler.getInstance()
+                            .handleInvalidFieldEncoding(LOGGER, ex.getMessage());
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vobject/VObjectLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vobject/VObjectLS.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
@@ -40,8 +41,13 @@ public class VObjectLS {
             if (key == VObjectMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI VObject Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                } catch (KlvParseException | IllegalArgumentException ex) {
+                    InvalidDataHandler.getInstance()
+                            .handleInvalidFieldEncoding(LOGGER, ex.getMessage());
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VTargetPack.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VTargetPack.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerEncoder;
@@ -43,8 +44,13 @@ public class VTargetPack {
             if (key == VTargetMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI VTarget Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                } catch (KlvParseException | IllegalArgumentException ex) {
+                    InvalidDataHandler.getInstance()
+                            .handleInvalidFieldEncoding(LOGGER, ex.getMessage());
+                }
             }
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLS.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.LdsField;
@@ -41,8 +42,13 @@ public class VTrackerLS {
             if (key == VTrackerMetadataKey.Undefined) {
                 LOGGER.info("Unknown VMTI VTracker Metadata tag: {}", field.getTag());
             } else {
-                IVmtiMetadataValue value = createValue(key, field.getData());
-                map.put(key, value);
+                try {
+                    IVmtiMetadataValue value = createValue(key, field.getData());
+                    map.put(key, value);
+                } catch (KlvParseException | IllegalArgumentException ex) {
+                    InvalidDataHandler.getInstance()
+                            .handleInvalidFieldEncoding(LOGGER, ex.getMessage());
+                }
             }
         }
     }

--- a/api/src/test/java/org/jmisb/api/common/InvalidDataHandlerTest.java
+++ b/api/src/test/java/org/jmisb/api/common/InvalidDataHandlerTest.java
@@ -1,0 +1,118 @@
+package org.jmisb.api.common;
+
+import static org.testng.Assert.*;
+
+import org.jmisb.api.klv.LoggerChecks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+/** Unit tests for InvalidDataHandler. */
+public class InvalidDataHandlerTest extends LoggerChecks {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(InvalidDataHandlerTest.class);
+
+    public InvalidDataHandlerTest() {
+        super(InvalidDataHandler.class);
+    }
+
+    class TestLoggingHandlerStrategy extends LogOnInvalidDataStrategy {
+
+        int wasCalled = 0;
+
+        @Override
+        public void process(Logger logger, String message) throws KlvParseException {
+            super.process(logger, message);
+            wasCalled++;
+        }
+    }
+
+    @Test
+    public void checkInstance() {
+        InvalidDataHandler instance = InvalidDataHandler.getInstance();
+        assertNotNull(instance);
+    }
+
+    @Test
+    public void checkBadChecksumThrow() throws KlvParseException {
+        try {
+            InvalidDataHandler.getInstance().handleInvalidChecksum(LOGGER, "Test Message");
+        } catch (KlvParseException ex) {
+            assertEquals(ex.getMessage(), "Test Message");
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void checkMissingChecksumThrow() throws KlvParseException {
+        try {
+            InvalidDataHandler.getInstance().handleMissingChecksum(LOGGER, "Test Message");
+        } catch (KlvParseException ex) {
+            assertEquals(ex.getMessage(), "Test Message");
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void checkOverrunThrow() throws KlvParseException {
+        try {
+            InvalidDataHandler.getInstance().handleOverrun(LOGGER, "Test Message");
+        } catch (KlvParseException ex) {
+            assertEquals(ex.getMessage(), "Test Message");
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void checkInvalidFieldEncodingThrow() {
+        try {
+            InvalidDataHandler.getInstance().handleInvalidFieldEncoding(LOGGER, "Test Message");
+        } catch (KlvParseException ex) {
+            assertEquals(ex.getMessage(), "Test Message");
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void checkMissingChecksumLog() throws KlvParseException {
+        TestLoggingHandlerStrategy strategy = new TestLoggingHandlerStrategy();
+        InvalidDataHandler.getInstance().setMissingChecksumStrategy(strategy);
+        InvalidDataHandler.getInstance().handleMissingChecksum(LOGGER, "Test Message");
+        assertEquals(strategy.wasCalled, 1);
+        InvalidDataHandler.getInstance()
+                .setMissingChecksumStrategy(new ThrowOnInvalidDataStrategy());
+    }
+
+    @Test
+    public void checkInvalidChecksumLog() throws KlvParseException {
+        TestLoggingHandlerStrategy strategy = new TestLoggingHandlerStrategy();
+        InvalidDataHandler.getInstance().setInvalidChecksumStrategy(strategy);
+        InvalidDataHandler.getInstance().handleInvalidChecksum(LOGGER, "Test Message");
+        assertEquals(strategy.wasCalled, 1);
+        InvalidDataHandler.getInstance()
+                .setInvalidChecksumStrategy(new ThrowOnInvalidDataStrategy());
+    }
+
+    @Test
+    public void checkInvalidFieldEncodingLog() throws KlvParseException {
+        TestLoggingHandlerStrategy strategy = new TestLoggingHandlerStrategy();
+        InvalidDataHandler.getInstance().setInvalidFieldEncodingStrategy(strategy);
+        InvalidDataHandler.getInstance().handleInvalidFieldEncoding(LOGGER, "Test Message");
+        assertEquals(strategy.wasCalled, 1);
+        InvalidDataHandler.getInstance()
+                .setInvalidFieldEncodingStrategy(new ThrowOnInvalidDataStrategy());
+    }
+
+    @Test
+    public void checkDataOverrun() throws KlvParseException {
+        TestLoggingHandlerStrategy strategy = new TestLoggingHandlerStrategy();
+        InvalidDataHandler.getInstance().setOverrunStrategy(strategy);
+        InvalidDataHandler.getInstance().handleOverrun(LOGGER, "Test Message");
+        assertEquals(strategy.wasCalled, 1);
+        InvalidDataHandler.getInstance().setOverrunStrategy(new ThrowOnInvalidDataStrategy());
+    }
+}

--- a/viewer/src/main/java/org/jmisb/viewer/MisbViewer.java
+++ b/viewer/src/main/java/org/jmisb/viewer/MisbViewer.java
@@ -12,6 +12,8 @@ import java.util.prefs.Preferences;
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import net.miginfocom.swing.MigLayout;
+import org.jmisb.api.common.InvalidDataHandler;
+import org.jmisb.api.common.LogOnInvalidDataStrategy;
 import org.jmisb.api.video.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,7 +187,10 @@ public class MisbViewer extends JFrame implements ActionListener {
     private void openFile(String filename) {
         try {
             closeVideo();
-
+            InvalidDataHandler.getInstance()
+                    .setInvalidFieldEncodingStrategy(new LogOnInvalidDataStrategy());
+            InvalidDataHandler.getInstance()
+                    .setInvalidChecksumStrategy(new LogOnInvalidDataStrategy());
             IVideoFileInput fileInput = new VideoFileInput(new VideoFileInputOptions());
             fileInput.open(filename);
 


### PR DESCRIPTION
## Motivation and Context
#143 was an earlier attempt to provide options for parsing, in the event of invalid data or other problems. It wasn't that great though. This is another approach, based on discussions with @wlfgang on gitter.

## Description
Adds singleton for invalid data handling, which delegates out to configured strategies. At the moment there are four cases - overrun, missing checksum, wrong checksum, and bad field value encoding. Adding more would be trivial.
Strategies only need to implement a one-method interface.
Viewer has been modified to log checksum and invalid values (instead of throwing).

## How Has This Been Tested?
Unit tests, plus viewer usage on some files that have issues (e.g. MISB FLI files for 0903 baseline, and the "Night Flight" that has the wrong size Target Width).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

