### PR TITLE
st0806: javadoc cleanups

### DIFF
--- a/api/checkstyle_suppressions.xml
+++ b/api/checkstyle_suppressions.xml
@@ -7,6 +7,5 @@
     <suppress files="[\\/]api[\\/]klv[\\/]eg0104[\\/]" checks="[a-zA-Z0-9]*"/>
     <suppress files="[\\/]api[\\/]klv[\\/]st0601[\\/]" checks="[a-zA-Z0-9]*"/>
     <suppress files="[\\/]api[\\/]klv[\\/]st0805[\\/]" checks="[a-zA-Z0-9]*"/>
-    <suppress files="[\\/]api[\\/]klv[\\/]st0806[\\/]" checks="[a-zA-Z0-9]*"/>
     <suppress files="[\\/]api[\\/]video[\\/]" checks="[a-zA-Z0-9]*"/>
 </suppressions>

--- a/api/src/main/java/org/jmisb/api/klv/st0806/FragCircleRadius.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/FragCircleRadius.java
@@ -19,7 +19,7 @@ public class FragCircleRadius implements IRvtMetadataValue {
     private static final int REQUIRED_BYTE_LENGTH = 2;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param radius radius in meters/second. Legal values are in [0, 65535].
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/FrameCode.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/FrameCode.java
@@ -15,7 +15,7 @@ public class FrameCode implements IRvtMetadataValue {
     private static final int REQUIRED_BYTE_LENGTH = 4;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param frameCode frameCode.
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/IRvtMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/IRvtMetadataValue.java
@@ -2,21 +2,21 @@ package org.jmisb.api.klv.st0806;
 
 public interface IRvtMetadataValue {
     /**
-     * Get the encoded bytes
+     * Get the encoded bytes.
      *
      * @return The encoded byte array
      */
     byte[] getBytes();
 
     /**
-     * Return a string of the displayable value
+     * Return a string of the displayable value.
      *
      * @return String representing the value
      */
     String getDisplayableValue();
 
     /**
-     * Get the human-readable name for the value
+     * Get the human-readable name for the value.
      *
      * @return The name of the type
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/RvtLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/RvtLocalSet.java
@@ -32,7 +32,7 @@ public class RvtLocalSet implements IMisbMessage {
     private static final Logger LOGGER = LoggerFactory.getLogger(RvtLocalSet.class);
 
     /**
-     * Create a {@link IRvtMetadataValue} instance from encoded bytes
+     * Create a {@link IRvtMetadataValue} instance from encoded bytes.
      *
      * @param tag The tag defining the value type
      * @param bytes Encoded bytes
@@ -90,20 +90,20 @@ public class RvtLocalSet implements IMisbMessage {
         return null;
     }
 
-    /** Map containing all non-repeating elements in the message */
+    /** Map containing all non-repeating elements in the message. */
     private final SortedMap<RvtMetadataKey, IRvtMetadataValue> map = new TreeMap<>();
 
-    /** Map containing User Defined Local sets */
+    /** Map containing User Defined Local sets. */
     private final Map<Integer, RvtUserDefinedLocalSet> userDefined = new TreeMap<>();
 
-    /** Map containing POI Local sets */
+    /** Map containing POI Local sets. */
     private final Map<Integer, RvtPoiLocalSet> pois = new TreeMap<>();
 
-    /** Map containing AOI Local sets */
+    /** Map containing AOI Local sets. */
     private final Map<Integer, RvtAoiLocalSet> aois = new TreeMap<>();
 
     /**
-     * Create the local set from the given key/value pairs
+     * Create the local set from the given key/value pairs.
      *
      * @param values Tag/value pairs to be included in the local set
      */
@@ -290,6 +290,16 @@ public class RvtLocalSet implements IMisbMessage {
         return "ST0806 Remote Video Terminal";
     }
 
+    /**
+     * Add a user defined local set to this {@code RvtLocalSet}.
+     *
+     * <p>The user defined local set must contain a {@link
+     * org.jmisb.api.klv.st0806.userdefined.RvtUserDefinedMetadataKey#NumericId}. This is required
+     * by ST0806, and is used to differentiate between the various user defined local sets nested
+     * within this RVT local set.
+     *
+     * @param localset the user defined local set to add
+     */
     public void addUserDefinedLocalSet(RvtUserDefinedLocalSet localset) {
         if (localset == null) {
             throw new IllegalArgumentException(
@@ -322,6 +332,16 @@ public class RvtLocalSet implements IMisbMessage {
         return userDefined.get(index);
     }
 
+    /**
+     * Add a Point of Interest (POI) local set to this {@code RvtLocalSet}.
+     *
+     * <p>The POI local set must contain a {@link
+     * org.jmisb.api.klv.st0806.poiaoi.RvtPoiMetadataKey#PoiAoiNumber}. This is required by ST0806,
+     * and is used to differentiate between the various POI local sets nested within this RVT local
+     * set.
+     *
+     * @param localset the POI local set to add
+     */
     public void addPointOfInterestLocalSet(RvtPoiLocalSet localset) {
         if (localset == null) {
             throw new IllegalArgumentException("Cannot add null POI local set to RVT parent");
@@ -352,6 +372,16 @@ public class RvtLocalSet implements IMisbMessage {
         return pois.get(index);
     }
 
+    /**
+     * Add an Area of Interest (AOI) local set to this {@code RvtLocalSet}.
+     *
+     * <p>The AOI local set must contain a {@link
+     * org.jmisb.api.klv.st0806.poiaoi.RvtAoiMetadataKey#PoiAoiNumber}. This is required by ST0806,
+     * and is used to differentiate between the various AOI local sets nested within this RVT local
+     * set.
+     *
+     * @param localset the AOI local set to add
+     */
     public void addAreaOfInterestLocalSet(RvtAoiLocalSet localset) {
         if (localset == null) {
             throw new IllegalArgumentException("Cannot add null AOI local set to RVT parent");

--- a/api/src/main/java/org/jmisb/api/klv/st0806/RvtMetadataConstants.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/RvtMetadataConstants.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st0806;
 
 class RvtMetadataConstants {
-    /** The currently-supported revision is 0806.4 */
+    /** The currently-supported revision is 0806.4. */
     public static final short ST_VERSION_NUMBER = 4;
 
     private RvtMetadataConstants() {}

--- a/api/src/main/java/org/jmisb/api/klv/st0806/RvtMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/RvtMetadataKey.java
@@ -43,10 +43,21 @@ public enum RvtMetadataKey {
         this.tag = tag;
     }
 
+    /**
+     * Get the tag value associated with this enumeration value.
+     *
+     * @return integer tag value for the metadata key
+     */
     public int getTag() {
         return tag;
     }
 
+    /**
+     * Look up the metadata key by tag identifier.
+     *
+     * @param tag the integer tag value to look up
+     * @return corresponding metadata key
+     */
     public static RvtMetadataKey getKey(int tag) {
         return tagTable.containsKey(tag) ? tagTable.get(tag) : Undefined;
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0806/RvtPlatformIndicatedAirspeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/RvtPlatformIndicatedAirspeed.java
@@ -19,7 +19,7 @@ public class RvtPlatformIndicatedAirspeed implements IRvtMetadataValue {
     private static final int REQUIRED_BYTE_LENGTH = 2;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param speed airspeed in meters/second. Legal values are in [0, 65535].
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/RvtPlatformTrueAirspeed.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/RvtPlatformTrueAirspeed.java
@@ -19,7 +19,7 @@ public class RvtPlatformTrueAirspeed implements IRvtMetadataValue {
     private static final int REQUIRED_BYTE_LENGTH = 2;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param speed airspeed in meters/second. Legal values are in [0, 65535].
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/RvtString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/RvtString.java
@@ -8,7 +8,7 @@ public abstract class RvtString implements IRvtMetadataValue {
     protected final String stringValue;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param name The display name for the string
      * @param value The string value
@@ -19,7 +19,7 @@ public abstract class RvtString implements IRvtMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param name The display name for the string
      * @param bytes Encoded byte array

--- a/api/src/main/java/org/jmisb/api/klv/st0806/ST0806Version.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/ST0806Version.java
@@ -21,7 +21,7 @@ public class ST0806Version implements IRvtMetadataValue {
     private static final int REQUIRED_BYTES = 1;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param version The version number
      */
@@ -34,7 +34,7 @@ public class ST0806Version implements IRvtMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes Byte array of length 1 byte.
      */
@@ -47,7 +47,7 @@ public class ST0806Version implements IRvtMetadataValue {
     }
 
     /**
-     * Get the version number
+     * Get the version number.
      *
      * @return The version number
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/TelemetryAccuracyIndicator.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/TelemetryAccuracyIndicator.java
@@ -20,7 +20,7 @@ public class TelemetryAccuracyIndicator implements IRvtMetadataValue {
     private static final int REQUIRED_BYTES = 1;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param value the value
      */
@@ -33,7 +33,7 @@ public class TelemetryAccuracyIndicator implements IRvtMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes Byte array of length 1
      */
@@ -46,7 +46,7 @@ public class TelemetryAccuracyIndicator implements IRvtMetadataValue {
     }
 
     /**
-     * Get the value
+     * Get the value.
      *
      * @return The value
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/UserDefinedTimeStampMicroseconds.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/UserDefinedTimeStampMicroseconds.java
@@ -33,7 +33,7 @@ public class UserDefinedTimeStampMicroseconds extends ST0603TimeStamp implements
     }
 
     /**
-     * Create from {@code LocalDateTime}
+     * Create from {@code LocalDateTime}.
      *
      * @param dateTime The date and time
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/VideoDataRate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/VideoDataRate.java
@@ -17,7 +17,7 @@ public class VideoDataRate implements IRvtMetadataValue {
     private static final int REQUIRED_BYTE_LENGTH = 4;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param rate Data Rate (bps or Hz).
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/AbstractRvtPoiAoiLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/AbstractRvtPoiAoiLatitude.java
@@ -42,7 +42,7 @@ public abstract class AbstractRvtPoiAoiLatitude implements IRvtPoiAoiMetadataVal
     }
 
     /**
-     * Get the latitude in degrees
+     * Get the latitude in degrees.
      *
      * @return Latitude, in range [-90,90], or Double.POSITIVE_INFINITY if error condition was
      *     specified.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/AbstractRvtPoiAoiLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/AbstractRvtPoiAoiLongitude.java
@@ -45,7 +45,7 @@ public abstract class AbstractRvtPoiAoiLongitude implements IRvtPoiAoiMetadataVa
     }
 
     /**
-     * Get the longitude in degrees
+     * Get the longitude in degrees.
      *
      * @return Degrees in range [-180,180], or Double.POSITIVE_INFINITY if error condition was
      *     specified.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/IRvtPoiAoiMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/IRvtPoiAoiMetadataValue.java
@@ -2,21 +2,21 @@ package org.jmisb.api.klv.st0806.poiaoi;
 
 public interface IRvtPoiAoiMetadataValue {
     /**
-     * Get the encoded bytes
+     * Get the encoded bytes.
      *
      * @return The encoded byte array
      */
     byte[] getBytes();
 
     /**
-     * Return a string of the displayable value
+     * Return a string of the displayable value.
      *
      * @return String representing the value
      */
     String getDisplayableValue();
 
     /**
-     * Get the human-readable name for the value
+     * Get the human-readable name for the value.
      *
      * @return The name of the type
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/PoiAltitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/PoiAltitude.java
@@ -3,7 +3,7 @@ package org.jmisb.api.klv.st0806.poiaoi;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
- * POI Altitude (ST 0806 POI tag 4)
+ * POI Altitude (ST 0806 POI tag 4).
  *
  * <p>Altitude of POI as measured from Mean Sea Level (MSL).
  *
@@ -19,7 +19,7 @@ public class PoiAltitude implements IRvtPoiAoiMetadataValue {
     private static final double MAXINT = 65535.0; // 2^16 - 1
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param meters Altitude in meters. Legal values are in [-900,19000].
      */
@@ -31,7 +31,7 @@ public class PoiAltitude implements IRvtPoiAoiMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes The byte array of length 2
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/PoiAoiNumber.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/PoiAoiNumber.java
@@ -13,7 +13,7 @@ public class PoiAoiNumber implements IRvtPoiAoiMetadataValue {
     private static final int REQUIRED_BYTE_LENGTH = 2;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param poiaoi the point of interest or area of interest number, in the range [0, 65535].
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/PoiAoiType.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/PoiAoiType.java
@@ -40,7 +40,7 @@ public class PoiAoiType implements IRvtPoiAoiMetadataValue {
     protected byte value;
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param type The value of the POI / AOI type enumeration.
      */
@@ -59,7 +59,7 @@ public class PoiAoiType implements IRvtPoiAoiMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param bytes The byte array of length 1
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtAoiLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtAoiLocalSet.java
@@ -25,11 +25,11 @@ public class RvtAoiLocalSet implements IRvtMetadataValue {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RvtAoiLocalSet.class);
 
-    /** Map containing all data elements in the message */
+    /** Map containing all data elements in the message. */
     private final SortedMap<RvtAoiMetadataKey, IRvtPoiAoiMetadataValue> map = new TreeMap<>();
 
     /**
-     * Create the message from the given key/value pairs
+     * Create the message from the given key/value pairs.
      *
      * @param values Tag/value pairs to be included in the local set/
      */
@@ -38,7 +38,7 @@ public class RvtAoiLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Parse {@link LdsField}s from a byte array
+     * Parse {@link LdsField}s from a byte array.
      *
      * @param bytes Byte array to parse
      * @param start Index of the first byte to parse
@@ -59,7 +59,7 @@ public class RvtAoiLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Create a {@link IRvtPoiAoiMetadataValue} instance from encoded bytes
+     * Create a {@link IRvtPoiAoiMetadataValue} instance from encoded bytes.
      *
      * @param tag The tag defining the value type
      * @param bytes Encoded bytes
@@ -96,7 +96,7 @@ public class RvtAoiLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Get the set of tags with populated values
+     * Get the set of tags with populated values.
      *
      * @return The set of tags for which values have been set
      */
@@ -105,7 +105,7 @@ public class RvtAoiLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Get the value of a given tag
+     * Get the value of a given tag.
      *
      * @param tag Tag of the value to retrieve
      * @return The value, or null if no value was set

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtAoiMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtAoiMetadataKey.java
@@ -28,14 +28,32 @@ public enum RvtAoiMetadataKey {
         }
     }
 
+    /**
+     * Constructor.
+     *
+     * <p>Internal use only.
+     *
+     * @param tag the tag value to initialise the enumeration value.
+     */
     RvtAoiMetadataKey(int tag) {
         this.tag = tag;
     }
 
+    /**
+     * Get the tag value associated with this enumeration value.
+     *
+     * @return integer tag value for the metadata key
+     */
     public int getTag() {
         return tag;
     }
 
+    /**
+     * Look up the metadata key by tag identifier.
+     *
+     * @param tag the integer tag value to look up
+     * @return corresponding metadata key
+     */
     public static RvtAoiMetadataKey getKey(int tag) {
         return tagTable.containsKey(tag) ? tagTable.get(tag) : Undefined;
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtPoiAoiTextString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtPoiAoiTextString.java
@@ -49,7 +49,7 @@ public class RvtPoiAoiTextString implements IRvtPoiAoiMetadataValue {
     public static final String OPERATION_ID = "Operation ID";
 
     /**
-     * Create from value
+     * Create from value.
      *
      * @param name The display name for the string
      * @param value The string value
@@ -60,7 +60,7 @@ public class RvtPoiAoiTextString implements IRvtPoiAoiMetadataValue {
     }
 
     /**
-     * Create from encoded bytes
+     * Create from encoded bytes.
      *
      * @param name The display name for the string
      * @param bytes Encoded byte array
@@ -71,7 +71,7 @@ public class RvtPoiAoiTextString implements IRvtPoiAoiMetadataValue {
     }
 
     /**
-     * Get the value
+     * Get the value.
      *
      * @return The string value
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtPoiLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtPoiLocalSet.java
@@ -25,11 +25,11 @@ public class RvtPoiLocalSet implements IRvtMetadataValue {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RvtPoiLocalSet.class);
 
-    /** Map containing all data elements in the message */
+    /** Map containing all data elements in the message. */
     private final SortedMap<RvtPoiMetadataKey, IRvtPoiAoiMetadataValue> map = new TreeMap<>();
 
     /**
-     * Create the message from the given key/value pairs
+     * Create the message from the given key/value pairs.
      *
      * @param values Tag/value pairs to be included in the local set/
      */
@@ -38,7 +38,7 @@ public class RvtPoiLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Parse {@link LdsField}s from a byte array
+     * Parse {@link LdsField}s from a byte array.
      *
      * @param bytes Byte array to parse
      * @param start Index of the first byte to parse
@@ -59,7 +59,7 @@ public class RvtPoiLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Create a {@link IRvtPoiAoiMetadataValue} instance from encoded bytes
+     * Create a {@link IRvtPoiAoiMetadataValue} instance from encoded bytes.
      *
      * @param tag The tag defining the value type
      * @param bytes Encoded bytes
@@ -96,7 +96,7 @@ public class RvtPoiLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Get the set of tags with populated values
+     * Get the set of tags with populated values.
      *
      * @return The set of tags for which values have been set
      */
@@ -105,7 +105,7 @@ public class RvtPoiLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Get the value of a given tag
+     * Get the value of a given tag.
      *
      * @param tag Tag of the value to retrieve
      * @return The value, or null if no value was set

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtPoiMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtPoiMetadataKey.java
@@ -28,14 +28,32 @@ public enum RvtPoiMetadataKey {
         }
     }
 
+    /**
+     * Constructor.
+     *
+     * <p>Internal use only.
+     *
+     * @param tag the tag value to initialise the enumeration value.
+     */
     RvtPoiMetadataKey(int tag) {
         this.tag = tag;
     }
 
+    /**
+     * Get the tag value associated with this enumeration value.
+     *
+     * @return integer tag value for the metadata key
+     */
     public int getTag() {
         return tag;
     }
 
+    /**
+     * Look up the metadata key by tag identifier.
+     *
+     * @param tag the integer tag value to look up
+     * @return corresponding metadata key
+     */
     public static RvtPoiMetadataKey getKey(int tag) {
         return tagTable.containsKey(tag) ? tagTable.get(tag) : Undefined;
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/IRvtUserDefinedMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/IRvtUserDefinedMetadataValue.java
@@ -2,21 +2,21 @@ package org.jmisb.api.klv.st0806.userdefined;
 
 public interface IRvtUserDefinedMetadataValue {
     /**
-     * Get the encoded bytes
+     * Get the encoded bytes.
      *
      * @return The encoded byte array
      */
     byte[] getBytes();
 
     /**
-     * Return a string of the displayable value
+     * Return a string of the displayable value.
      *
      * @return String representing the value
      */
     String getDisplayableValue();
 
     /**
-     * Get the human-readable name for the value
+     * Get the human-readable name for the value.
      *
      * @return The name of the type
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/RvtUserDefinedLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/RvtUserDefinedLocalSet.java
@@ -25,12 +25,12 @@ public class RvtUserDefinedLocalSet implements IRvtMetadataValue {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RvtUserDefinedLocalSet.class);
 
-    /** Map containing all data elements in the message */
+    /** Map containing all data elements in the message. */
     private final SortedMap<RvtUserDefinedMetadataKey, IRvtUserDefinedMetadataValue> map =
             new TreeMap<>();
 
     /**
-     * Create the message from the given key/value pairs
+     * Create the message from the given key/value pairs.
      *
      * @param values Tag/value pairs to be included in the local set/
      */
@@ -40,7 +40,7 @@ public class RvtUserDefinedLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Parse {@link LdsField}s from a byte array
+     * Parse {@link LdsField}s from a byte array.
      *
      * @param bytes Byte array to parse
      * @param start Index of the first byte to parse
@@ -61,7 +61,7 @@ public class RvtUserDefinedLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Create a {@link IRvtUserDefinedMetadataValue} instance from encoded bytes
+     * Create a {@link IRvtUserDefinedMetadataValue} instance from encoded bytes.
      *
      * @param tag The tag defining the value type
      * @param bytes Encoded bytes
@@ -82,7 +82,7 @@ public class RvtUserDefinedLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Get the set of tags with populated values
+     * Get the set of tags with populated values.
      *
      * @return The set of tags for which values have been set
      */
@@ -91,7 +91,7 @@ public class RvtUserDefinedLocalSet implements IRvtMetadataValue {
     }
 
     /**
-     * Get the value of a given tag
+     * Get the value of a given tag.
      *
      * @param tag Tag of the value to retrieve
      * @return The value, or null if no value was set

--- a/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/RvtUserDefinedMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/RvtUserDefinedMetadataKey.java
@@ -20,14 +20,32 @@ public enum RvtUserDefinedMetadataKey {
         }
     }
 
+    /**
+     * Constructor.
+     *
+     * <p>Internal use only.
+     *
+     * @param tag the tag value to initialise the enumeration value.
+     */
     RvtUserDefinedMetadataKey(int tag) {
         this.tag = tag;
     }
 
+    /**
+     * Get the tag value associated with this enumeration value.
+     *
+     * @return integer tag value for the metadata key
+     */
     public int getTag() {
         return tag;
     }
 
+    /**
+     * Look up the metadata key by tag identifier.
+     *
+     * @param tag the integer tag value to look up
+     * @return corresponding metadata key
+     */
     public static RvtUserDefinedMetadataKey getKey(int tag) {
         return tagTable.containsKey(tag) ? tagTable.get(tag) : Undefined;
     }


### PR DESCRIPTION
## Motivation and Context
Fixes javadoc warnings reported by checkstyle in ST0806.

Resolves #191. 

## Description
Removes suppression for these packages.
Fixes the style warnings and adds missing javadoc on methods.
No code changes.

## How Has This Been Tested?
Full build with unit test runs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

