### PR TITLE
st0903: add support for legacy floating point encoding (ST0903.3 and prior)

### DIFF
--- a/api/checkstyle.xml
+++ b/api/checkstyle.xml
@@ -215,6 +215,8 @@
     <module name="UpperEll"/>
     -->
 
+    <!-- <module name="MissingDeprecated"/> -->
+
     <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"

--- a/api/src/main/java/org/jmisb/api/klv/st0903/VTargetSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/VTargetSeries.java
@@ -6,6 +6,7 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vtarget.VTargetPack;
 import org.jmisb.core.klv.ArrayUtils;
 
@@ -37,15 +38,34 @@ public class VTargetSeries implements IVmtiMetadataValue {
     /**
      * Create from encoded bytes.
      *
+     * <p>This constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array
      * @throws KlvParseException if there is a parsing error on the byte array.
+     * @deprecated use {@link #VTargetSeries(byte[], EncodingMode)} instead
      */
-    public VTargetSeries(byte[] bytes) throws KlvParseException {
+    @Deprecated
+    public VTargetSeries(byte[] bytes) throws org.jmisb.api.common.KlvParseException {
+        this(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>This constructor allows selection of which encoding rules (according to the ST903 version)
+     * to apply.
+     *
+     * @param bytes Encoded byte array
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     * @throws KlvParseException if there is a parsing error on the byte array.
+     */
+    public VTargetSeries(byte[] bytes, EncodingMode encodingMode) throws KlvParseException {
         int index = 0;
         while (index < bytes.length - 1) {
             BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
-            VTargetPack targetPack = new VTargetPack(bytes, index, lengthField.getValue());
+            VTargetPack targetPack =
+                    new VTargetPack(bytes, index, lengthField.getValue(), encodingMode);
             targetPacks.add(targetPack);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/VmtiHorizontalFieldOfView.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/VmtiHorizontalFieldOfView.java
@@ -1,5 +1,7 @@
 package org.jmisb.api.klv.st0903;
 
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+
 /**
  * Horizontal Field Of View (ST0903 VMTI LS Tag 11).
  *
@@ -30,10 +32,33 @@ public class VmtiHorizontalFieldOfView extends VmtiFieldOfView {
     /**
      * Create from encoded bytes.
      *
+     * <p>Note: this constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array
+     * @deprecated use {@link #VmtiHorizontalFieldOfView(byte[], EncodingMode)} instead to specify
+     *     the encoding mode
      */
+    @Deprecated
     public VmtiHorizontalFieldOfView(byte[] bytes) {
         super(bytes);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding to 2-byte IMAPB in ST0903.4. Earlier versions used a two-byte
+     * unsigned integer structure in the range [0, 2^16-1]that was then mapped into the range [0,
+     * 180.0] degrees. Which formatting applies can only be determined from the ST0903 version in
+     * this {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code compatibilityMode} parameter
+     * determines whether to parse using the legacy encoding or current encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     */
+    public VmtiHorizontalFieldOfView(byte[] bytes, EncodingMode encodingMode) {
+        super(bytes, encodingMode);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/VmtiVerticalFieldOfView.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/VmtiVerticalFieldOfView.java
@@ -1,5 +1,7 @@
 package org.jmisb.api.klv.st0903;
 
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+
 /**
  * Vertical Field Of View (ST0903 VMTI LS Tag 12).
  *
@@ -30,10 +32,33 @@ public class VmtiVerticalFieldOfView extends VmtiFieldOfView {
     /**
      * Create from encoded bytes.
      *
+     * <p>Note this constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array
+     * @deprecated use {@link #VmtiVerticalFieldOfView(byte[], EncodingMode)} instead to specify the
+     *     encoding mode
      */
+    @Deprecated
     public VmtiVerticalFieldOfView(byte[] bytes) {
-        super(bytes);
+        this(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding to 2-byte IMAPB in ST0903.4. Earlier versions used a two-byte
+     * unsigned integer structure in the range [0, 2^16-1]that was then mapped into the range [0,
+     * 180.0] degrees. Which formatting applies can only be determined from the ST0903 version in
+     * this {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code compatibilityMode} parameter
+     * determines whether to parse using the legacy encoding or current encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     */
+    public VmtiVerticalFieldOfView(byte[] bytes, EncodingMode encodingMode) {
+        super(bytes, encodingMode);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/shared/EncodingMode.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/shared/EncodingMode.java
@@ -1,0 +1,26 @@
+package org.jmisb.api.klv.st0903.shared;
+
+/**
+ * The encoding approach used for floating point data.
+ *
+ * <p>There are two incompatible encoding approaches used in ST0903. ST0903.3 and earlier (including
+ * the original EG0903 baseline version, and RP0903.2) mapped integer values to floating point
+ * values with a direct mapping. ST0903.4 and later use the ST1201 IMAPB mapping approach.
+ *
+ * <p>This enumeration specifies which encoding is being used.
+ */
+public enum EncodingMode {
+    /**
+     * IMAPB encoding.
+     *
+     * <p>This is the 0903.4 and later format.
+     */
+    IMAPB,
+
+    /**
+     * Legacy encoding.
+     *
+     * <p>This is the 0903.3 and earlier format.
+     */
+    LEGACY;
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/AbstractTargetLocationOffset.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/AbstractTargetLocationOffset.java
@@ -1,7 +1,9 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st1201.FpEncoder;
+import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
  * Shared superclass for TargetLocationOffsetLatitude (Tag 10) and TargetLocationOffsetLongitude
@@ -12,6 +14,8 @@ public abstract class AbstractTargetLocationOffset implements IVmtiMetadataValue
     protected static final double MIN_VAL = -19.2;
     protected static final double MAX_VAL = 19.2;
     protected static final int NUM_BYTES = 3;
+    private static final int LEGACY_ERROR_INDICATOR = -8388608;
+    private static final int LEGACY_INT_RANGE = 8388607; // 2^23 - 1
     protected double value;
 
     /**
@@ -30,9 +34,51 @@ public abstract class AbstractTargetLocationOffset implements IVmtiMetadataValue
     /**
      * Create from encoded bytes.
      *
+     * <p>This constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array
+     * @deprecated use {@link #AbstractTargetLocationOffset(byte[], EncodingMode)} to explicitly
+     *     specify the encoding used in {@code bytes}.
      */
+    @Deprecated
     public AbstractTargetLocationOffset(byte[] bytes) {
+        this(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding to 3-byte IMAPB in ST0903.4. Earlier versions used a variable
+     * length (1-3 bytes) byte array to represent an integer in the range [-2^23-1, 2^23-1]that was
+     * then mapped into the range [-19.2,19.2]. The three byte case could potentially represent
+     * either kind of formatting, and which formatting applies can only be determined from the
+     * version in the parent {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code
+     * compatibilityMode} parameter determines whether to parse using the legacy encoding or current
+     * encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     */
+    public AbstractTargetLocationOffset(byte[] bytes, EncodingMode encodingMode) {
+        if (encodingMode.equals(EncodingMode.LEGACY)) {
+            parseAsLegacy(bytes);
+        } else {
+            parseAsIMAPB(bytes);
+        }
+    }
+
+    private void parseAsLegacy(byte[] bytes) {
+        int v = PrimitiveConverter.toInt32(bytes);
+        if (v == LEGACY_ERROR_INDICATOR) {
+            this.value = Double.NaN;
+        } else {
+            this.value = v * MAX_VAL / LEGACY_INT_RANGE;
+        }
+    }
+
+    private void parseAsIMAPB(byte[] bytes) throws IllegalArgumentException {
         if (bytes.length != 3) {
             throw new IllegalArgumentException(
                     this.getDisplayName() + " encoding is three byte IMAPB as of ST0903.4");

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/BoundaryBottomRightLatOffset.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/BoundaryBottomRightLatOffset.java
@@ -1,5 +1,7 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+
 /**
  * Boundary Bottom Right Latitude Offset (ST0903 VTarget Pack Tag 15).
  *
@@ -33,10 +35,35 @@ public class BoundaryBottomRightLatOffset extends AbstractTargetLocationOffset {
     /**
      * Create from encoded bytes.
      *
+     * <p>Note: this constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array
+     * @deprecated use {@link #BoundaryBottomRightLatOffset(byte[], EncodingMode)} to explicitly
+     *     specify the encoding.
      */
+    @Deprecated
     public BoundaryBottomRightLatOffset(byte[] bytes) {
         super(bytes);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding to 3-byte IMAPB in ST0903.4. Earlier versions used a variable
+     * length (1-3 bytes) byte array to represent an integer in the range [-2^23-1, 2^23-1]that was
+     * then mapped into the range [-19.2,19.2]. The three byte case could potentially represent
+     * either kind of formatting, and which formatting applies can only be determined from the
+     * version in the parent {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code
+     * compatibilityMode} parameter determines whether to parse using the legacy encoding or current
+     * encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     */
+    public BoundaryBottomRightLatOffset(byte[] bytes, EncodingMode encodingMode) {
+        super(bytes, encodingMode);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/BoundaryBottomRightLonOffset.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/BoundaryBottomRightLonOffset.java
@@ -1,5 +1,7 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+
 /**
  * Boundary Bottom Right Longitude Offset (ST0903 VTarget Pack Tag 16).
  *
@@ -33,10 +35,35 @@ public class BoundaryBottomRightLonOffset extends AbstractTargetLocationOffset {
     /**
      * Create from encoded bytes.
      *
+     * <p>Note: this constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array
+     * @deprecated use {@link #BoundaryBottomRightLonOffset(byte[], EncodingMode)} to explicitly
+     *     specify the encoding.
      */
+    @Deprecated
     public BoundaryBottomRightLonOffset(byte[] bytes) {
         super(bytes);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding to 3-byte IMAPB in ST0903.4. Earlier versions used a variable
+     * length (1-3 bytes) byte array to represent an integer in the range [-2^23-1, 2^23-1]that was
+     * then mapped into the range [-19.2,19.2]. The three byte case could potentially represent
+     * either kind of formatting, and which formatting applies can only be determined from the
+     * version in the parent {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code
+     * compatibilityMode} parameter determines whether to parse using the legacy encoding or current
+     * encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     */
+    public BoundaryBottomRightLonOffset(byte[] bytes, EncodingMode encodingMode) {
+        super(bytes, encodingMode);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftLatOffset.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftLatOffset.java
@@ -1,5 +1,7 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+
 /**
  * Boundary Top Left Latitude Offset (ST0903 VTarget Pack Tag 13).
  *
@@ -34,10 +36,35 @@ public class BoundaryTopLeftLatOffset extends AbstractTargetLocationOffset {
     /**
      * Create from encoded bytes.
      *
+     * <p>Note: this constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array
+     * @deprecated use {@link #BoundaryTopLeftLatOffset(byte[], EncodingMode)} to indicate the
+     *     encoding.
      */
+    @Deprecated
     public BoundaryTopLeftLatOffset(byte[] bytes) {
         super(bytes);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding to 3-byte IMAPB in ST0903.4. Earlier versions used a variable
+     * length (1-3 bytes) byte array to represent an integer in the range [-2^23-1, 2^23-1]that was
+     * then mapped into the range [-19.2,19.2]. The three byte case could potentially represent
+     * either kind of formatting, and which formatting applies can only be determined from the
+     * version in the parent {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code
+     * compatibilityMode} parameter determines whether to parse using the legacy encoding or current
+     * encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     */
+    public BoundaryTopLeftLatOffset(byte[] bytes, EncodingMode encodingMode) {
+        super(bytes, encodingMode);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftLonOffset.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftLonOffset.java
@@ -1,5 +1,7 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+
 /**
  * Boundary Top Left Longitude Offset (ST0903 VTarget Pack Tag 14).
  *
@@ -34,10 +36,35 @@ public class BoundaryTopLeftLonOffset extends AbstractTargetLocationOffset {
     /**
      * Create from encoded bytes.
      *
+     * <p>Note: this constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array
+     * @deprecated use {@link #BoundaryTopLeftLonOffset(byte[], EncodingMode)} to specify the
+     *     encoding format.
      */
+    @Deprecated
     public BoundaryTopLeftLonOffset(byte[] bytes) {
         super(bytes);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding to 3-byte IMAPB in ST0903.4. Earlier versions used a variable
+     * length (1-3 bytes) byte array to represent an integer in the range [-2^23-1, 2^23-1]that was
+     * then mapped into the range [-19.2,19.2]. The three byte case could potentially represent
+     * either kind of formatting, and which formatting applies can only be determined from the
+     * version in the parent {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code
+     * compatibilityMode} parameter determines whether to parse using the legacy encoding or current
+     * encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     */
+    public BoundaryTopLeftLonOffset(byte[] bytes, EncodingMode encodingMode) {
+        super(bytes, encodingMode);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetBoundarySeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetBoundarySeries.java
@@ -8,6 +8,7 @@ import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.LocationPack;
 import org.jmisb.core.klv.ArrayUtils;
 
@@ -47,16 +48,40 @@ public class TargetBoundarySeries implements IVmtiMetadataValue {
     /**
      * Create from encoded bytes.
      *
+     * <p>Note this constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array comprising the TargetBoundarySeries
      * @throws KlvParseException if the byte array could not be parsed.
+     * @deprecated use {@link #TargetBoundarySeries(byte[], EncodingMode)} to explicitly specify the
+     *     encoding mode use in the embedded LocationPack floating point values.
      */
+    @Deprecated
     public TargetBoundarySeries(byte[] bytes) throws KlvParseException {
+        this(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding for the Location to 2-byte IMAPB (4-byte IMAPB for Latitude /
+     * Longitude) in ST0903.4. Earlier versions used a set of unsigned integer encoding that was
+     * then mapped into the same ranges that the IMAPB encoding uses. Which formatting applies can
+     * only be determined from the ST0903 version in the parent {@link
+     * org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code compatibilityMode} parameter determines
+     * whether to parse using the legacy encoding or current encoding.
+     *
+     * @param bytes Encoded byte array comprising the TargetBoundarySeries
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     * @throws KlvParseException if the byte array could not be parsed.
+     */
+    public TargetBoundarySeries(byte[] bytes, EncodingMode encodingMode) throws KlvParseException {
         int index = 0;
         while (index < bytes.length - 1) {
             BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
             byte[] packBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            LocationPack location = TargetLocation.targetLocationPackFromBytes(packBytes);
+            LocationPack location =
+                    TargetLocation.targetLocationPackFromBytes(packBytes, encodingMode);
             boundary.add(location);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetLocation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetLocation.java
@@ -3,9 +3,11 @@ package org.jmisb.api.klv.st0903.vtarget;
 import java.util.ArrayList;
 import java.util.List;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.LocationPack;
 import org.jmisb.api.klv.st1201.FpEncoder;
 import org.jmisb.core.klv.ArrayUtils;
+import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
  * Target Location (ST0903 VTarget Pack Tag 17).
@@ -26,15 +28,33 @@ import org.jmisb.core.klv.ArrayUtils;
  * </blockquote>
  */
 public class TargetLocation implements IVmtiMetadataValue {
+
     private LocationPack value;
     private static final int COORDINATES_GROUP_LEN = 10;
     private static final int STANDARD_DEVIATIONS_GROUP_LEN = 6;
     private static final int CORRELATION_GROUP_LEN = 6;
-    private static final FpEncoder LatEncoder = new FpEncoder(-90.0, 90.0, 4);
-    private static final FpEncoder LonEncoder = new FpEncoder(-180.0, 180.0, 4);
-    private static final FpEncoder HaeEncoder = new FpEncoder(-900.0, 19000.0, 2);
-    private static final FpEncoder SigmaEncoder = new FpEncoder(0, 650.0, 2);
-    private static final FpEncoder RhoEncoder = new FpEncoder(-1, 1, 2);
+    private static final double MIN_SIGMA_VAL = 0.0;
+    private static final double MAX_SIGMA_VAL = 650.0;
+    private static final double MIN_RHO_VAL = -1.0;
+    private static final double MAX_RHO_VAL = 1.0;
+    private static final double MIN_LAT_VAL = -90.0;
+    private static final double MAX_LAT_VAL = 90.0;
+    private static final double MIN_LON_VAL = -180.0;
+    private static final double MAX_LON_VAL = 180.0;
+    protected static final double MIN_HAE_VAL = -900;
+    protected static final double MAX_HAE_VAL = 19000;
+    private static final int LEGACY_INT_RANGE = 65535;
+    private static final long MAX_LAT_LON_INT_RANGE = 4294967295L;
+    private static final int NUM_BYTES = 2;
+    private static final int NUM_BYTES_LAT_LON = 4;
+    private static final FpEncoder LatEncoder =
+            new FpEncoder(MIN_LAT_VAL, MAX_LAT_VAL, NUM_BYTES_LAT_LON);
+    private static final FpEncoder LonEncoder =
+            new FpEncoder(MIN_LON_VAL, MAX_LON_VAL, NUM_BYTES_LAT_LON);
+    private static final FpEncoder HaeEncoder = new FpEncoder(MIN_HAE_VAL, MAX_HAE_VAL, NUM_BYTES);
+    private static final FpEncoder SigmaEncoder =
+            new FpEncoder(MIN_SIGMA_VAL, MAX_SIGMA_VAL, NUM_BYTES);
+    private static final FpEncoder RhoEncoder = new FpEncoder(MIN_RHO_VAL, MAX_RHO_VAL, NUM_BYTES);
 
     /**
      * Create from value.
@@ -48,16 +68,41 @@ public class TargetLocation implements IVmtiMetadataValue {
     /**
      * Create from encoded bytes.
      *
+     * <p>Note: this constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array.
+     * @deprecated use {@link #TargetLocation(byte[], EncodingMode)} to specify the encoding used in
+     *     {@code bytes} array.
      */
+    @Deprecated
     public TargetLocation(byte[] bytes) {
+        this(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding for each element to 2-byte IMAPB (4-byte IMAPB for Latitude /
+     * Longitude) in ST0903.4. Earlier versions used a set of unsigned integer encoding that was
+     * then mapped into the same ranges that the IMAPB encoding uses. Which formatting applies can
+     * only be determined from the ST0903 version in the parent {@link
+     * org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code compatibilityMode} parameter determines
+     * whether to parse using the legacy encoding or current encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array.
+     * @param encodingMode the encoding that is used for the floating point values in the {@code
+     *     bytes} array.
+     */
+    public TargetLocation(byte[] bytes, EncodingMode encodingMode) {
         if ((bytes.length == COORDINATES_GROUP_LEN)
                 || (bytes.length == COORDINATES_GROUP_LEN + STANDARD_DEVIATIONS_GROUP_LEN)
                 || (bytes.length
                         == COORDINATES_GROUP_LEN
                                 + STANDARD_DEVIATIONS_GROUP_LEN
                                 + CORRELATION_GROUP_LEN)) {
-            value = targetLocationPackFromBytes(bytes);
+            value = targetLocationPackFromBytes(bytes, encodingMode);
         } else {
             throw new IllegalArgumentException(
                     this.getDisplayName() + " length must match one of 10, 16 or 22");
@@ -70,10 +115,126 @@ public class TargetLocation implements IVmtiMetadataValue {
      * <p>This static utility method is provided to support Series types that embed the LocationPack
      * within other structures.
      *
+     * <p>Note: this method only support ST0903.4 and later, where the floating point values are
+     * encoded as IMAPB.
+     *
      * @param bytes the byte array to parse, length 10, 16 or 22
      * @return LocationPack data from the {@code bytes} array.
+     * @deprecated use {@link #targetLocationPackFromBytes(byte[], EncodingMode)} to specify the
+     *     encoding mode for the {@code bytes} array.
      */
+    @Deprecated
     public static LocationPack targetLocationPackFromBytes(byte[] bytes) {
+        return targetLocationPackFromBytes(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Parse a LocationPack from a byte array.
+     *
+     * <p>This static utility method is provided to support Series types that embed the LocationPack
+     * within other structures.
+     *
+     * <p>ST0903 changed the encoding for each element to 2-byte IMAPB (4-byte IMAPB for Latitude /
+     * Longitude) in ST0903.4. Earlier versions used a set of unsigned integer encoding that was
+     * then mapped into the same ranges that the IMAPB encoding uses. Which formatting applies can
+     * only be determined from the ST0903 version in this {@link
+     * org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code compatibilityMode} parameter determines
+     * whether to parse using the legacy encoding or current encoding.
+     *
+     * @param bytes the byte array to parse, length 10, 16 or 22
+     * @param encodingMode the encoding that is used for the floating point values in the {@code
+     *     bytes} array.
+     * @return LocationPack data from the {@code bytes} array.
+     */
+    public static LocationPack targetLocationPackFromBytes(
+            byte[] bytes, EncodingMode encodingMode) {
+        if (encodingMode.equals(EncodingMode.LEGACY)) {
+            return parseAsLegacy(bytes);
+        } else {
+            return parseAsIMAPB(bytes);
+        }
+    }
+
+    private static LocationPack parseAsLegacy(byte[] bytes) {
+        switch (bytes.length) {
+            case COORDINATES_GROUP_LEN:
+                {
+                    double lat = legacyLatitudeDecoder(bytes, 0);
+                    double lon = legacyLongitudeDecoder(bytes, 4);
+                    double hae = legacyHaeDecoder(bytes, 8);
+                    return new LocationPack(lat, lon, hae);
+                }
+            case COORDINATES_GROUP_LEN + STANDARD_DEVIATIONS_GROUP_LEN:
+                {
+                    double lat = legacyLatitudeDecoder(bytes, 0);
+                    double lon = legacyLongitudeDecoder(bytes, 4);
+                    double hae = legacyHaeDecoder(bytes, 8);
+                    double sigEast = legacySigmaDecoder(bytes, 10);
+                    double sigNorth = legacySigmaDecoder(bytes, 12);
+                    double sigUp = legacySigmaDecoder(bytes, 14);
+                    return new LocationPack(lat, lon, hae, sigEast, sigNorth, sigUp);
+                }
+            case COORDINATES_GROUP_LEN + STANDARD_DEVIATIONS_GROUP_LEN + CORRELATION_GROUP_LEN:
+                {
+                    double lat = legacyLatitudeDecoder(bytes, 0);
+                    double lon = legacyLongitudeDecoder(bytes, 4);
+                    double hae = legacyHaeDecoder(bytes, 8);
+                    double sigEast = legacySigmaDecoder(bytes, 10);
+                    double sigNorth = legacySigmaDecoder(bytes, 12);
+                    double sigUp = legacySigmaDecoder(bytes, 14);
+                    double rhoEastNorth = legacyRhoDecoder(bytes, 16);
+                    double rhoEastUp = legacyRhoDecoder(bytes, 18);
+                    double rhoNorthUp = legacyRhoDecoder(bytes, 20);
+                    return new LocationPack(
+                            lat,
+                            lon,
+                            hae,
+                            sigEast,
+                            sigNorth,
+                            sigUp,
+                            rhoEastNorth,
+                            rhoEastUp,
+                            rhoNorthUp);
+                }
+            default:
+                throw new IllegalArgumentException(
+                        "Target Location Pack length must match one of 10, 16 or 22");
+        }
+    }
+
+    private static double legacyLatitudeDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset =
+                new byte[] {bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]};
+        long longVal = PrimitiveConverter.toUint32(byteSubset);
+        return MIN_LAT_VAL + (longVal * (MAX_LAT_VAL - MIN_LAT_VAL) / MAX_LAT_LON_INT_RANGE);
+    }
+
+    private static double legacyLongitudeDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset =
+                new byte[] {bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3]};
+        long longVal = PrimitiveConverter.toUint32(byteSubset);
+        return MIN_LON_VAL + (longVal * (MAX_LON_VAL - MIN_LON_VAL) / MAX_LAT_LON_INT_RANGE);
+    }
+
+    private static double legacyHaeDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset = new byte[] {bytes[offset], bytes[offset + 1]};
+        int v = PrimitiveConverter.toUint16(byteSubset);
+        return MIN_HAE_VAL + (v * (MAX_HAE_VAL - MIN_HAE_VAL) / LEGACY_INT_RANGE);
+    }
+
+    private static double legacySigmaDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset = new byte[] {bytes[offset], bytes[offset + 1]};
+        int v = PrimitiveConverter.toUint16(byteSubset);
+        return MIN_SIGMA_VAL + (v * (MAX_SIGMA_VAL - MIN_SIGMA_VAL) / LEGACY_INT_RANGE);
+    }
+
+    private static double legacyRhoDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset = new byte[] {bytes[offset], bytes[offset + 1]};
+        int v = PrimitiveConverter.toUint16(byteSubset);
+        return MIN_RHO_VAL + (v * (MAX_RHO_VAL - MIN_RHO_VAL) / LEGACY_INT_RANGE);
+    }
+
+    private static LocationPack parseAsIMAPB(byte[] bytes) throws IllegalArgumentException {
         switch (bytes.length) {
             case COORDINATES_GROUP_LEN:
                 {

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetLocationOffsetLat.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetLocationOffsetLat.java
@@ -1,5 +1,7 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+
 /**
  * Target Location Offset Latitude (ST0903 VTarget Pack Tag 10).
  *
@@ -36,10 +38,35 @@ public class TargetLocationOffsetLat extends AbstractTargetLocationOffset {
     /**
      * Create from encoded bytes.
      *
+     * <p>This constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array
+     * @deprecated use {@link #TargetLocationOffsetLat(byte[], EncodingMode)} to specify the
+     *     encoding format.
      */
+    @Deprecated
     public TargetLocationOffsetLat(byte[] bytes) {
         super(bytes);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding to 3-byte IMAPB in ST0903.4. Earlier versions used a variable
+     * length (1-3 bytes) byte array to represent an integer in the range [-2^23-1, 2^23-1]that was
+     * then mapped into the range [-19.2,19.2]. The three byte case could potentially represent
+     * either kind of formatting, and which formatting applies can only be determined from the
+     * version in the parent {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code
+     * compatibilityMode} parameter determines whether to parse using the legacy encoding or current
+     * encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     */
+    public TargetLocationOffsetLat(byte[] bytes, EncodingMode encodingMode) {
+        super(bytes, encodingMode);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetLocationOffsetLon.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetLocationOffsetLon.java
@@ -1,5 +1,7 @@
 package org.jmisb.api.klv.st0903.vtarget;
 
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+
 /**
  * Target Location Offset Longitude (ST0903 VTarget Pack Tag 11).
  *
@@ -35,10 +37,35 @@ public class TargetLocationOffsetLon extends AbstractTargetLocationOffset {
     /**
      * Create from encoded bytes.
      *
+     * <p>This constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array
+     * @deprecated use {@link #TargetLocationOffsetLon(byte[], EncodingMode)} to specify the
+     *     encoding format.
      */
+    @Deprecated
     public TargetLocationOffsetLon(byte[] bytes) {
         super(bytes);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding to 3-byte IMAPB in ST0903.4. Earlier versions used a variable
+     * length (1-3 bytes) byte array to represent an integer in the range [-2^23-1, 2^23-1]that was
+     * then mapped into the range [-19.2,19.2]. The three byte case could potentially represent
+     * either kind of formatting, and which formatting applies can only be determined from the
+     * version in the parent {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code
+     * compatibilityMode} parameter determines whether to parse using the legacy encoding or current
+     * encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     */
+    public TargetLocationOffsetLon(byte[] bytes, EncodingMode encodingMode) {
+        super(bytes, encodingMode);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VTracker.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VTracker.java
@@ -2,6 +2,7 @@ package org.jmisb.api.klv.st0903.vtarget;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vtracker.VTrackerLS;
 
 /**
@@ -33,11 +34,27 @@ public class VTracker implements IVmtiMetadataValue {
     /**
      * Create from encoded bytes.
      *
+     * <p>This constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array comprising the VTracker LS
      * @throws KlvParseException if the byte array could not be parsed.
+     * @deprecated use {@link #VTracker(byte[], org.jmisb.api.klv.st0903.shared.EncodingMode)} to
+     *     specify the encoding format for nested floating point values.
      */
+    @Deprecated
     public VTracker(byte[] bytes) throws KlvParseException {
-        value = new VTrackerLS(bytes);
+        this(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * @param bytes Encoded byte array comprising the VTracker LS
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     * @throws KlvParseException if the byte array could not be parsed.
+     */
+    public VTracker(byte[] bytes, EncodingMode encodingMode) throws KlvParseException {
+        value = new VTrackerLS(bytes, encodingMode);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/Acceleration.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/Acceleration.java
@@ -3,8 +3,10 @@ package org.jmisb.api.klv.st0903.vtracker;
 import java.util.ArrayList;
 import java.util.List;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st1201.FpEncoder;
 import org.jmisb.core.klv.ArrayUtils;
+import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
  * Acceleration (ST 0903 VTracker LS Tag 11).
@@ -21,9 +23,18 @@ public class Acceleration implements IVmtiMetadataValue {
     private static final int ACCELERATION_GROUP_LEN = 6;
     private static final int STANDARD_DEVIATIONS_GROUP_LEN = 6;
     private static final int CORRELATION_GROUP_LEN = 6;
-    private static final FpEncoder AccelerationEncoder = new FpEncoder(-900.0, 900.0, 2);
-    private static final FpEncoder SigmaEncoder = new FpEncoder(0, 650.0, 2);
-    private static final FpEncoder RhoEncoder = new FpEncoder(-1, 1, 2);
+    private static final int NUM_BYTES = 2;
+    private static final double MIN_VAL = -900.0;
+    private static final double MAX_VAL = 900.0;
+    private static final double MIN_SIGMA_VAL = 0.0;
+    private static final double MAX_SIGMA_VAL = 650.0;
+    private static final double MIN_RHO_VAL = -1.0;
+    private static final double MAX_RHO_VAL = 1.0;
+    private static final int LEGACY_INT_RANGE = 65535;
+    private static final FpEncoder AccelerationEncoder = new FpEncoder(MIN_VAL, MAX_VAL, NUM_BYTES);
+    private static final FpEncoder SigmaEncoder =
+            new FpEncoder(MIN_SIGMA_VAL, MAX_SIGMA_VAL, NUM_BYTES);
+    private static final FpEncoder RhoEncoder = new FpEncoder(MIN_RHO_VAL, MAX_RHO_VAL, NUM_BYTES);
     private AccelerationPack value;
 
     /**
@@ -38,9 +49,110 @@ public class Acceleration implements IVmtiMetadataValue {
     /**
      * Create from encoded bytes.
      *
-     * @param bytes The byte array of length 1
+     * <p>Note: this constructor only supports ST0903.4 and later.
+     *
+     * @param bytes The byte array of length 6, 12 or 18.
+     * @deprecated use {@link #Acceleration(byte[], EncodingMode)} to explicitly specify the
+     *     encoding used.
      */
+    @Deprecated
     public Acceleration(byte[] bytes) {
+        this(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding for each element to 2-byte IMAPB in ST0903.4. Earlier versions
+     * used a two-byte unsigned integer structure in the range [0, 2^16-1]that was then mapped into
+     * the same ranges that the IMAPB encoding uses. Which formatting applies can only be determined
+     * from the ST0903 version in the parent {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The
+     * {@code compatibilityMode} parameter determines whether to parse using the legacy encoding or
+     * current encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes The byte array of length 6, 12 or 18.
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses
+     */
+    public Acceleration(byte[] bytes, EncodingMode encodingMode) {
+        if (encodingMode.equals(EncodingMode.LEGACY)) {
+            parseAsLegacy(bytes);
+        } else {
+            parseAsIMAPB(bytes);
+        }
+    }
+
+    private void parseAsLegacy(byte[] bytes) throws IllegalArgumentException {
+        switch (bytes.length) {
+            case ACCELERATION_GROUP_LEN:
+                {
+                    double east = legacyAccelerationDecoder(bytes, 0);
+                    double north = legacyAccelerationDecoder(bytes, 2);
+                    double up = legacyAccelerationDecoder(bytes, 4);
+                    value = new AccelerationPack(east, north, up);
+                    break;
+                }
+            case ACCELERATION_GROUP_LEN + STANDARD_DEVIATIONS_GROUP_LEN:
+                {
+                    double east = legacyAccelerationDecoder(bytes, 0);
+                    double north = legacyAccelerationDecoder(bytes, 2);
+                    double up = legacyAccelerationDecoder(bytes, 4);
+                    double sigEast = legacySigmaDecoder(bytes, 6);
+                    double sigNorth = legacySigmaDecoder(bytes, 8);
+                    double sigUp = legacySigmaDecoder(bytes, 10);
+                    value = new AccelerationPack(east, north, up, sigEast, sigNorth, sigUp);
+                    break;
+                }
+            case ACCELERATION_GROUP_LEN + STANDARD_DEVIATIONS_GROUP_LEN + CORRELATION_GROUP_LEN:
+                {
+                    double east = legacyAccelerationDecoder(bytes, 0);
+                    double north = legacyAccelerationDecoder(bytes, 2);
+                    double up = legacyAccelerationDecoder(bytes, 4);
+                    double sigEast = legacySigmaDecoder(bytes, 6);
+                    double sigNorth = legacySigmaDecoder(bytes, 8);
+                    double sigUp = legacySigmaDecoder(bytes, 10);
+                    double rhoEastNorth = legacyRhoDecoder(bytes, 12);
+                    double rhoEastUp = legacyRhoDecoder(bytes, 14);
+                    double rhoNorthUp = legacyRhoDecoder(bytes, 16);
+                    value =
+                            new AccelerationPack(
+                                    east,
+                                    north,
+                                    up,
+                                    sigEast,
+                                    sigNorth,
+                                    sigUp,
+                                    rhoEastNorth,
+                                    rhoEastUp,
+                                    rhoNorthUp);
+                    break;
+                }
+            default:
+                throw new IllegalArgumentException(
+                        this.getDisplayName() + " length must match one of 6, 12 or 18");
+        }
+    }
+
+    private double legacyAccelerationDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset = new byte[] {bytes[offset], bytes[offset + 1]};
+        int v = PrimitiveConverter.variableBytesToUint16(byteSubset);
+        return MIN_VAL + (v * (MAX_VAL - MIN_VAL) / LEGACY_INT_RANGE);
+    }
+
+    private double legacySigmaDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset = new byte[] {bytes[offset], bytes[offset + 1]};
+        int v = PrimitiveConverter.variableBytesToUint16(byteSubset);
+        return MIN_SIGMA_VAL + (v * (MAX_SIGMA_VAL - MIN_SIGMA_VAL) / LEGACY_INT_RANGE);
+    }
+
+    private double legacyRhoDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset = new byte[] {bytes[offset], bytes[offset + 1]};
+        int v = PrimitiveConverter.variableBytesToUint16(byteSubset);
+        return MIN_RHO_VAL + (v * (MAX_RHO_VAL - MIN_RHO_VAL) / LEGACY_INT_RANGE);
+    }
+
+    private void parseAsIMAPB(byte[] bytes) throws IllegalArgumentException {
         switch (bytes.length) {
             case ACCELERATION_GROUP_LEN:
                 {

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/BoundarySeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/BoundarySeries.java
@@ -8,6 +8,7 @@ import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.LocationPack;
 import org.jmisb.api.klv.st0903.vtarget.TargetLocation;
 import org.jmisb.core.klv.ArrayUtils;
@@ -44,14 +45,38 @@ public class BoundarySeries implements IVmtiMetadataValue {
      *
      * @param bytes Encoded byte array comprising the BoundarySeries
      * @throws KlvParseException if the byte array could not be parsed.
+     * @deprecated use {@link #BoundarySeries(byte[], EncodingMode)} to explicitly specify the
+     *     encoding mode use in the embedded LocationPack floating point values.
      */
+    @Deprecated
     public BoundarySeries(byte[] bytes) throws KlvParseException {
+        this(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding for the Location to 2-byte IMAPB (4-byte IMAPB for Latitude /
+     * Longitude) in ST0903.4. Earlier versions used a set of unsigned integer encoding that was
+     * then mapped into the same ranges that the IMAPB encoding uses. Which formatting applies can
+     * only be determined from the ST0903 version in the parent {@link
+     * org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code compatibilityMode} parameter determines
+     * whether to parse using the legacy encoding or current encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array comprising the BoundarySeries
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     * @throws KlvParseException if the byte array could not be parsed.
+     */
+    public BoundarySeries(byte[] bytes, EncodingMode encodingMode) throws KlvParseException {
         int index = 0;
         while (index < bytes.length - 1) {
             BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
             byte[] packBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            LocationPack location = TargetLocation.targetLocationPackFromBytes(packBytes);
+            LocationPack location =
+                    TargetLocation.targetLocationPackFromBytes(packBytes, encodingMode);
             boundary.add(location);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/TrackHistorySeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/TrackHistorySeries.java
@@ -8,6 +8,7 @@ import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.LocationPack;
 import org.jmisb.api.klv.st0903.vtarget.TargetLocation;
 import org.jmisb.core.klv.ArrayUtils;
@@ -42,16 +43,42 @@ public class TrackHistorySeries implements IVmtiMetadataValue {
     /**
      * Create from encoded bytes.
      *
+     * <p>Note this constructor only supports ST0903.4 and later.
+     *
      * @param bytes Encoded byte array comprising the Track History Series
      * @throws KlvParseException if the byte array could not be parsed.
+     * @deprecated use {@link #TrackHistorySeries(byte[], EncodingMode)} to explicitly specify the
+     *     encoding mode use in the LocationPack floating point values.
      */
+    @Deprecated
     public TrackHistorySeries(byte[] bytes) throws KlvParseException {
+        this(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding for the Location to 2-byte IMAPB (4-byte IMAPB for Latitude /
+     * Longitude) in ST0903.4. Earlier versions used a set of unsigned integer encoding that was
+     * then mapped into the same ranges that the IMAPB encoding uses. Which formatting applies can
+     * only be determined from the ST0903 version in the parent {@link
+     * org.jmisb.api.klv.st0903.VmtiLocalSet}. The {@code compatibilityMode} parameter determines
+     * whether to parse using the legacy encoding or current encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is IMAPB (ST0903.4 or later).
+     *
+     * @param bytes Encoded byte array comprising the Track History Series
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses.
+     * @throws KlvParseException if the byte array could not be parsed.
+     */
+    public TrackHistorySeries(byte[] bytes, EncodingMode encodingMode) throws KlvParseException {
         int index = 0;
         while (index < bytes.length - 1) {
             BerField lengthField = BerDecoder.decode(bytes, index, false);
             index += lengthField.getLength();
             byte[] packBytes = Arrays.copyOfRange(bytes, index, index + lengthField.getValue());
-            LocationPack location = TargetLocation.targetLocationPackFromBytes(packBytes);
+            LocationPack location =
+                    TargetLocation.targetLocationPackFromBytes(packBytes, encodingMode);
             history.add(location);
             index += lengthField.getValue();
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/Velocity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/Velocity.java
@@ -3,8 +3,10 @@ package org.jmisb.api.klv.st0903.vtracker;
 import java.util.ArrayList;
 import java.util.List;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st1201.FpEncoder;
 import org.jmisb.core.klv.ArrayUtils;
+import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
  * Velocity (ST 0903 VTracker LS Tag 10).
@@ -21,9 +23,18 @@ public class Velocity implements IVmtiMetadataValue {
     private static final int VELOCITY_GROUP_LEN = 6;
     private static final int STANDARD_DEVIATIONS_GROUP_LEN = 6;
     private static final int CORRELATION_GROUP_LEN = 6;
-    private static final FpEncoder VelocityEncoder = new FpEncoder(-900.0, 900.0, 2);
-    private static final FpEncoder SigmaEncoder = new FpEncoder(0, 650.0, 2);
-    private static final FpEncoder RhoEncoder = new FpEncoder(-1, 1, 2);
+    private static final int NUM_BYTES = 2;
+    private static final double MIN_VAL = -900.0;
+    private static final double MAX_VAL = 900.0;
+    private static final double MIN_SIGMA_VAL = 0.0;
+    private static final double MAX_SIGMA_VAL = 650.0;
+    private static final double MIN_RHO_VAL = -1.0;
+    private static final double MAX_RHO_VAL = 1.0;
+    private static final int LEGACY_INT_RANGE = 65535;
+    private static final FpEncoder VelocityEncoder = new FpEncoder(MIN_VAL, MAX_VAL, NUM_BYTES);
+    private static final FpEncoder SigmaEncoder =
+            new FpEncoder(MIN_SIGMA_VAL, MAX_SIGMA_VAL, NUM_BYTES);
+    private static final FpEncoder RhoEncoder = new FpEncoder(MIN_RHO_VAL, MAX_RHO_VAL, NUM_BYTES);
     private VelocityPack value;
 
     /**
@@ -38,9 +49,110 @@ public class Velocity implements IVmtiMetadataValue {
     /**
      * Create from encoded bytes.
      *
-     * @param bytes The byte array of length 1
+     * <p>Note: this constructor only supports ST0903.4 and later.
+     *
+     * @param bytes The byte array of length 6, 12 or 18.
+     * @deprecated use {@link #Velocity(byte[], EncodingMode)} to explicitly specify the encoding
+     *     used.
      */
+    @Deprecated
     public Velocity(byte[] bytes) {
+        this(bytes, EncodingMode.IMAPB);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * <p>ST0903 changed the encoding for each element to 2-byte IMAPB in ST0903.4. Earlier versions
+     * used a two-byte unsigned integer structure in the range [0, 2^16-1]that was then mapped into
+     * the same ranges that the IMAPB encoding uses. Which formatting applies can only be determined
+     * from the ST0903 version in the parent {@link org.jmisb.api.klv.st0903.VmtiLocalSet}. The
+     * {@code compatibilityMode} parameter determines whether to parse using the legacy encoding or
+     * current encoding.
+     *
+     * <p>Note that this only affects parsing. Output encoding is always IMAPB (ST0903.4 or later).
+     *
+     * @param bytes The byte array of length 6, 12 or 18.
+     * @param encodingMode which encoding mode the {@code bytes} parameter uses
+     */
+    public Velocity(byte[] bytes, EncodingMode encodingMode) {
+        if (encodingMode.equals(EncodingMode.LEGACY)) {
+            parseAsLegacy(bytes);
+        } else {
+            parseAsIMAP(bytes);
+        }
+    }
+
+    private void parseAsLegacy(byte[] bytes) {
+        switch (bytes.length) {
+            case VELOCITY_GROUP_LEN:
+                {
+                    double east = legacyVelocityDecoder(bytes, 0);
+                    double north = legacyVelocityDecoder(bytes, 2);
+                    double up = legacyVelocityDecoder(bytes, 4);
+                    value = new VelocityPack(east, north, up);
+                    break;
+                }
+            case VELOCITY_GROUP_LEN + STANDARD_DEVIATIONS_GROUP_LEN:
+                {
+                    double east = legacyVelocityDecoder(bytes, 0);
+                    double north = legacyVelocityDecoder(bytes, 2);
+                    double up = legacyVelocityDecoder(bytes, 4);
+                    double sigEast = legacySigmaDecoder(bytes, 6);
+                    double sigNorth = legacySigmaDecoder(bytes, 8);
+                    double sigUp = legacySigmaDecoder(bytes, 10);
+                    value = new VelocityPack(east, north, up, sigEast, sigNorth, sigUp);
+                    break;
+                }
+            case VELOCITY_GROUP_LEN + STANDARD_DEVIATIONS_GROUP_LEN + CORRELATION_GROUP_LEN:
+                {
+                    double east = legacyVelocityDecoder(bytes, 0);
+                    double north = legacyVelocityDecoder(bytes, 2);
+                    double up = legacyVelocityDecoder(bytes, 4);
+                    double sigEast = legacySigmaDecoder(bytes, 6);
+                    double sigNorth = legacySigmaDecoder(bytes, 8);
+                    double sigUp = legacySigmaDecoder(bytes, 10);
+                    double rhoEastNorth = legacyRhoDecoder(bytes, 12);
+                    double rhoEastUp = legacyRhoDecoder(bytes, 14);
+                    double rhoNorthUp = legacyRhoDecoder(bytes, 16);
+                    value =
+                            new VelocityPack(
+                                    east,
+                                    north,
+                                    up,
+                                    sigEast,
+                                    sigNorth,
+                                    sigUp,
+                                    rhoEastNorth,
+                                    rhoEastUp,
+                                    rhoNorthUp);
+                    break;
+                }
+            default:
+                throw new IllegalArgumentException(
+                        this.getDisplayName() + " length must match one of 6, 12 or 18");
+        }
+    }
+
+    private double legacyVelocityDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset = new byte[] {bytes[offset], bytes[offset + 1]};
+        int v = PrimitiveConverter.variableBytesToUint16(byteSubset);
+        return MIN_VAL + (v * (MAX_VAL - MIN_VAL) / LEGACY_INT_RANGE);
+    }
+
+    private double legacySigmaDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset = new byte[] {bytes[offset], bytes[offset + 1]};
+        int v = PrimitiveConverter.variableBytesToUint16(byteSubset);
+        return MIN_SIGMA_VAL + (v * (MAX_SIGMA_VAL - MIN_SIGMA_VAL) / LEGACY_INT_RANGE);
+    }
+
+    private double legacyRhoDecoder(byte[] bytes, int offset) {
+        byte[] byteSubset = new byte[] {bytes[offset], bytes[offset + 1]};
+        int v = PrimitiveConverter.variableBytesToUint16(byteSubset);
+        return MIN_RHO_VAL + (v * (MAX_RHO_VAL - MIN_RHO_VAL) / LEGACY_INT_RANGE);
+    }
+
+    private void parseAsIMAP(byte[] bytes) throws IllegalArgumentException {
         switch (bytes.length) {
             case VELOCITY_GROUP_LEN:
                 {

--- a/api/src/test/java/org/jmisb/api/klv/st0903/AlgorithmSeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/AlgorithmSeriesTest.java
@@ -9,6 +9,7 @@ import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.algorithm.AlgorithmLS;
 import org.jmisb.api.klv.st0903.algorithm.AlgorithmMetadataKey;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -69,7 +70,8 @@ public class AlgorithmSeriesTest {
     @Test
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
-                VmtiLocalSet.createValue(VmtiMetadataKey.AlgorithmSeries, twoAlgorithmsBytes);
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.AlgorithmSeries, twoAlgorithmsBytes, EncodingMode.IMAPB);
         assertNotNull(value);
         assertTrue(value instanceof AlgorithmSeries);
         AlgorithmSeries algorithmSeries = (AlgorithmSeries) value;

--- a/api/src/test/java/org/jmisb/api/klv/st0903/FrameHeightTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/FrameHeightTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903;
 import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for FrameHeight (ST0903 Tag 9). */
@@ -47,7 +48,9 @@ public class FrameHeightTest {
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
                 VmtiLocalSet.createValue(
-                        VmtiMetadataKey.FrameHeight, new byte[] {(byte) 0x04, (byte) 0x38});
+                        VmtiMetadataKey.FrameHeight,
+                        new byte[] {(byte) 0x04, (byte) 0x38},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof FrameHeight);
         FrameHeight height = (FrameHeight) value;
         assertEquals(height.getBytes(), new byte[] {(byte) 0x04, (byte) 0x38});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/FrameNumberTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/FrameNumberTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903;
 import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Frame Number (ST0903 Tag 7). */
@@ -48,7 +49,8 @@ public class FrameNumberTest {
         IVmtiMetadataValue value =
                 VmtiLocalSet.createValue(
                         VmtiMetadataKey.FrameNumber,
-                        new byte[] {(byte) 0x01, (byte) 0x30, (byte) 0xB0});
+                        new byte[] {(byte) 0x01, (byte) 0x30, (byte) 0xB0},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof FrameNumber);
         FrameNumber frameNum = (FrameNumber) value;
         assertEquals(frameNum.getBytes(), new byte[] {(byte) 0x01, (byte) 0x30, (byte) 0xB0});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/FrameWidthTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/FrameWidthTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903;
 import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for FrameWidth (ST0903 Tag 8). */
@@ -47,7 +48,9 @@ public class FrameWidthTest {
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
                 VmtiLocalSet.createValue(
-                        VmtiMetadataKey.FrameWidth, new byte[] {(byte) 0x07, (byte) 0x80});
+                        VmtiMetadataKey.FrameWidth,
+                        new byte[] {(byte) 0x07, (byte) 0x80},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof FrameWidth);
         FrameWidth width = (FrameWidth) value;
         assertEquals(width.getBytes(), new byte[] {(byte) 0x07, (byte) 0x80});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/MiisCoreIdentifierTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/MiisCoreIdentifierTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903;
 import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st1204.CoreIdentifier;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -73,7 +74,9 @@ public class MiisCoreIdentifierTest {
 
     @Test
     public void verifyFromFactory() throws KlvParseException {
-        IVmtiMetadataValue v = VmtiLocalSet.createValue(VmtiMetadataKey.MiisId, ST_EXAMPLE_BYTES);
+        IVmtiMetadataValue v =
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.MiisId, ST_EXAMPLE_BYTES, EncodingMode.IMAPB);
         Assert.assertTrue(v instanceof MiisCoreIdentifier);
         MiisCoreIdentifier identifier = (MiisCoreIdentifier) v;
         assertEquals(identifier.getDisplayableValue(), ST_EXAMPLE_TEXT);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/OntologySeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/OntologySeriesTest.java
@@ -9,6 +9,7 @@ import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.ontology.OntologyLS;
 import org.jmisb.api.klv.st0903.ontology.OntologyMetadataKey;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.shared.VmtiUri;
 import org.testng.annotations.BeforeMethod;
@@ -72,7 +73,8 @@ public class OntologySeriesTest {
     @Test
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
-                VmtiLocalSet.createValue(VmtiMetadataKey.OntologySeries, twoOntologysBytes);
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.OntologySeries, twoOntologysBytes, EncodingMode.IMAPB);
         assertNotNull(value);
         assertTrue(value instanceof OntologySeries);
         OntologySeries ontologySeries = (OntologySeries) value;

--- a/api/src/test/java/org/jmisb/api/klv/st0903/PrecisionTimeStampTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/PrecisionTimeStampTest.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -73,7 +74,9 @@ public class PrecisionTimeStampTest {
                     (byte) 0xCE,
                     (byte) 0x40
                 };
-        IVmtiMetadataValue v = VmtiLocalSet.createValue(VmtiMetadataKey.PrecisionTimeStamp, bytes);
+        IVmtiMetadataValue v =
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.PrecisionTimeStamp, bytes, EncodingMode.IMAPB);
         Assert.assertTrue(v instanceof PrecisionTimeStamp);
         Assert.assertEquals(v.getDisplayName(), "Precision Time Stamp");
         PrecisionTimeStamp pts = (PrecisionTimeStamp) v;

--- a/api/src/test/java/org/jmisb/api/klv/st0903/ST0903VersionTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/ST0903VersionTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903;
 import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for ST0903Version (ST0903 Tag 4). */
@@ -100,7 +101,10 @@ public class ST0903VersionTest {
     @Test
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
-                VmtiLocalSet.createValue(VmtiMetadataKey.VersionNumber, new byte[] {(byte) 0x04});
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.VersionNumber,
+                        new byte[] {(byte) 0x04},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof ST0903Version);
         ST0903Version version = (ST0903Version) value;
         assertEquals(version.getBytes(), new byte[] {(byte) 0x04});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VTargetSeriesIMAPBTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VTargetSeriesIMAPBTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vtarget.CentroidPixelColumn;
 import org.jmisb.api.klv.st0903.vtarget.CentroidPixelRow;
 import org.jmisb.api.klv.st0903.vtarget.TargetHAE;
@@ -17,7 +18,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /** Tests for VTargetSeries (Tag 101) */
-public class VTargetSeriesTest {
+public class VTargetSeriesIMAPBTest {
     private VTargetSeries vTargetSeriesFromBytes;
     private VTargetSeries vTargetSeriesFromVTargets;
 
@@ -45,9 +46,8 @@ public class VTargetSeriesTest {
             };
 
     @BeforeMethod
-    @SuppressWarnings("deprecation")
     public void setUpMethod() throws Exception {
-        vTargetSeriesFromBytes = new VTargetSeries(twoVTargetsBytes);
+        vTargetSeriesFromBytes = new VTargetSeries(twoVTargetsBytes, EncodingMode.IMAPB);
 
         List<VTargetPack> targetPacks = new ArrayList<>();
 
@@ -95,10 +95,10 @@ public class VTargetSeriesTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
-                VmtiLocalSet.createValue(VmtiMetadataKey.VTargetSeries, twoVTargetsBytes);
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.VTargetSeries, twoVTargetsBytes, EncodingMode.IMAPB);
         assertNotNull(value);
         assertTrue(value instanceof VTargetSeries);
         VTargetSeries targetSeries = (VTargetSeries) value;

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VTargetSeriesLegacyTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VTargetSeriesLegacyTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vtarget.CentroidPixelColumn;
 import org.jmisb.api.klv.st0903.vtarget.CentroidPixelRow;
 import org.jmisb.api.klv.st0903.vtarget.TargetHAE;
@@ -17,7 +18,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /** Tests for VTargetSeries (Tag 101) */
-public class VTargetSeriesTest {
+public class VTargetSeriesLegacyTest {
     private VTargetSeries vTargetSeriesFromBytes;
     private VTargetSeries vTargetSeriesFromVTargets;
 
@@ -32,8 +33,8 @@ public class VTargetSeriesTest {
                 0x02, // Target ID 2
                 0x0C, // Target HAE Tag
                 0x02, // Target HAE Length
-                0x2a,
-                (byte) 0x94, // Target HAE Value
+                (byte) 0x8C,
+                (byte) 0x38, // Target HAE Value (two bytes, legacy encoding)
                 0x13, // Centroid Pix Row Tag
                 0x02, // Centroid Pix Row Length
                 0x03,
@@ -45,9 +46,8 @@ public class VTargetSeriesTest {
             };
 
     @BeforeMethod
-    @SuppressWarnings("deprecation")
     public void setUpMethod() throws Exception {
-        vTargetSeriesFromBytes = new VTargetSeries(twoVTargetsBytes);
+        vTargetSeriesFromBytes = new VTargetSeries(twoVTargetsBytes, EncodingMode.LEGACY);
 
         List<VTargetPack> targetPacks = new ArrayList<>();
 
@@ -95,10 +95,10 @@ public class VTargetSeriesTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
-                VmtiLocalSet.createValue(VmtiMetadataKey.VTargetSeries, twoVTargetsBytes);
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.VTargetSeries, twoVTargetsBytes, EncodingMode.LEGACY);
         assertNotNull(value);
         assertTrue(value instanceof VTargetSeries);
         VTargetSeries targetSeries = (VTargetSeries) value;
@@ -108,17 +108,6 @@ public class VTargetSeriesTest {
         assertEquals(vtarget1.getTargetIdentifier(), 1);
         VTargetPack vtarget2 = vtargets.get(1);
         assertEquals(vtarget2.getTargetIdentifier(), 2);
-    }
-
-    /** Test of getBytes method, of class VTargetSeries. */
-    @Test
-    public void testGetBytesFromSeriesFromBytes() {
-        assertEquals(vTargetSeriesFromBytes.getBytes(), twoVTargetsBytes);
-    }
-
-    @Test
-    public void testGetBytesFromSeriesFromVTargets() {
-        assertEquals(vTargetSeriesFromVTargets.getBytes(), twoVTargetsBytes);
     }
 
     /** Test of getDisplayableValue method, of class VTargetSeries. */

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiHorizontalFieldOfViewTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiHorizontalFieldOfViewTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903;
 import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for VMTI Horizontal FoV (Tag 11) */
@@ -17,6 +18,7 @@ public class VmtiHorizontalFieldOfViewTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() {
         VmtiHorizontalFieldOfView fov =
                 new VmtiHorizontalFieldOfView(new byte[] {(byte) 0x06, (byte) 0x40});
@@ -27,6 +29,29 @@ public class VmtiHorizontalFieldOfViewTest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() {
+        VmtiHorizontalFieldOfView fov =
+                new VmtiHorizontalFieldOfView(
+                        new byte[] {(byte) 0x06, (byte) 0x40}, EncodingMode.IMAPB);
+        assertEquals(fov.getBytes(), new byte[] {(byte) 0x06, (byte) 0x40});
+        assertEquals(fov.getDisplayName(), "Horizontal Field of View");
+        assertEquals(fov.getDisplayableValue(), "12.5\u00B0");
+        assertEquals(fov.getFieldOfView(), 12.5);
+    }
+
+    @Test
+    public void testConstructFromEncodedBytesExplicitEncodingLegacy() {
+        // ST0903.3 Section 7.10.11
+        VmtiHorizontalFieldOfView fov =
+                new VmtiHorizontalFieldOfView(
+                        new byte[] {(byte) 0x11, (byte) 0xC7}, EncodingMode.LEGACY);
+        assertEquals(fov.getDisplayName(), "Horizontal Field of View");
+        assertEquals(fov.getDisplayableValue(), "12.5\u00B0");
+        assertEquals(fov.getFieldOfView(), 12.5, 0.003);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VmtiLocalSet.createValue(
@@ -38,6 +63,36 @@ public class VmtiHorizontalFieldOfViewTest {
         assertEquals(fov.getDisplayName(), "Horizontal Field of View");
         assertEquals(fov.getDisplayableValue(), "12.5\u00B0");
         assertEquals(fov.getFieldOfView(), 12.5);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.HorizontalFieldOfView,
+                        new byte[] {(byte) 0x06, (byte) 0x40},
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof VmtiHorizontalFieldOfView);
+        VmtiHorizontalFieldOfView fov = (VmtiHorizontalFieldOfView) value;
+        assertEquals(fov.getBytes(), new byte[] {(byte) 0x06, (byte) 0x40});
+        assertEquals(fov.getDisplayName(), "Horizontal Field of View");
+        assertEquals(fov.getDisplayableValue(), "12.5\u00B0");
+        assertEquals(fov.getFieldOfView(), 12.5);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingLegacy() throws KlvParseException {
+        // ST0903.3 Section 7.10.11
+        IVmtiMetadataValue value =
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.HorizontalFieldOfView,
+                        new byte[] {(byte) 0x11, (byte) 0xC7},
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof VmtiHorizontalFieldOfView);
+        VmtiHorizontalFieldOfView fov = (VmtiHorizontalFieldOfView) value;
+        assertEquals(fov.getDisplayName(), "Horizontal Field of View");
+        assertEquals(fov.getDisplayableValue(), "12.5\u00B0");
+        assertEquals(fov.getFieldOfView(), 12.5, 0.003);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -52,6 +107,6 @@ public class VmtiHorizontalFieldOfViewTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
-        new VmtiHorizontalFieldOfView(new byte[] {0x01, 0x02, 0x03});
+        new VmtiHorizontalFieldOfView(new byte[] {0x01, 0x02, 0x03}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetOneWithTheLotLegacyModeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetOneWithTheLotLegacyModeTest.java
@@ -29,9 +29,16 @@ import org.jmisb.api.klv.st0903.vtarget.VTracker;
 import org.jmisb.api.klv.st0903.vtracker.VTrackerMetadataKey;
 import org.testng.annotations.Test;
 
-/** Tests for the ST0903 VMTI Local Set including nested parts */
-public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks {
-    VmtiLocalSetOneWithTheLotTest() {
+/**
+ * Tests for the ST0903 VMTI Local Set including nested parts.
+ *
+ * <p>This is very similar to VmtiLocalSetOneWithTheLotTest, but uses legacy encoding for floating
+ * point values, per ST0903.3.
+ *
+ * <p>Some of the fields here may not be valid in ST0903.3, and are used for testing purposes only.
+ */
+public class VmtiLocalSetOneWithTheLotLegacyModeTest extends LoggerChecks {
+    VmtiLocalSetOneWithTheLotLegacyModeTest() {
         super(VmtiLocalSet.class);
     }
 
@@ -65,9 +72,9 @@ public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks {
                     0x4D,
                     0x54,
                     0x49,
-                    0x04,
+                    0x04, // Version Tag
                     0x01,
-                    0x05,
+                    0x03,
                     0x05,
                     0x01,
                     0x1C,
@@ -96,14 +103,14 @@ public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks {
                     0x6F,
                     0x73,
                     0x65,
-                    0x0B,
+                    0x0B, // Horizontal FOV
                     0x02,
-                    0x06,
-                    0x40,
-                    0x0C,
+                    0x11,
+                    (byte) 0xC7,
+                    0x0C, // Vertical FOV
                     0x02,
-                    0x05,
-                    0x00,
+                    0x0E,
+                    0x39,
                     0x0D,
                     0x22,
                     (byte) 0x01,
@@ -143,10 +150,10 @@ public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks {
                     0x65,
                     (byte) 0x82,
                     (byte) 0x03,
-                    (byte) 0x86, // Key + length
+                    (byte) 0x90, // Key + length
                     (byte) 0x82,
                     (byte) 0x02,
-                    (byte) 0xE1, // Length of first VTarget LS
+                    (byte) 0xEB, // Length of first VTarget LS
                     0x01, // Target identifier
                     0x01,
                     0x03,
@@ -171,22 +178,35 @@ public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks {
                     (byte) 0xDA,
                     (byte) 0xA5,
                     0x20, // target colour
+                    0x0A,
+                    0x03,
+                    (byte) 0x42,
+                    (byte) 0xAA,
+                    (byte) 0xAA, // Target location offset lat
+                    0x0B,
+                    0x03,
+                    (byte) 0x42,
+                    (byte) 0xAA,
+                    (byte) 0xAA, // Target location offset lon
                     0x0C,
                     0x02,
-                    0x2A,
-                    (byte) 0x94,
+                    (byte) 0x8C,
+                    (byte) 0x38, // target height (HAE)
                     0x11,
                     0x0A,
+                    // ST0903.3 B.2.1
+                    (byte) 0xBD,
                     (byte) 0x27,
-                    (byte) 0xba,
-                    (byte) 0x93,
-                    (byte) 0x02,
-                    (byte) 0x34,
-                    (byte) 0x4a,
-                    (byte) 0x1a,
-                    (byte) 0xdf,
-                    (byte) 0x10,
-                    (byte) 0x14, // Target location, basic form
+                    (byte) 0xD2,
+                    (byte) 0x7C,
+                    // ST0903.3 B.2.2
+                    (byte) 0xCE,
+                    (byte) 0x38,
+                    (byte) 0xE3,
+                    (byte) 0x8D,
+                    // ST0903.3 B.2.3
+                    (byte) 0x8C,
+                    (byte) 0x38, // Target location, legacy form
                     0x13,
                     0x02,
                     0x03,
@@ -1205,11 +1225,7 @@ public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks {
                     0x69,
                     0x63,
                     0x61,
-                    0x6e,
-                    0x01,
-                    0x02,
-                    (byte) 0x1d,
-                    (byte) 0xf5 // checksum
+                    0x6e
                 };
         VmtiLocalSet localSet = new VmtiLocalSet(bytes);
         assertNotNull(localSet);
@@ -1224,7 +1240,7 @@ public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks {
                 localSet.getField(VmtiMetadataKey.VersionNumber).getDisplayName(),
                 "Version Number");
         assertEquals(
-                localSet.getField(VmtiMetadataKey.VersionNumber).getDisplayableValue(), "ST0903.5");
+                localSet.getField(VmtiMetadataKey.VersionNumber).getDisplayableValue(), "ST0903.3");
         assertEquals(
                 localSet.getField(VmtiMetadataKey.SystemName).getDisplayName(),
                 "System Name/Description");
@@ -1336,9 +1352,9 @@ public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks {
         TargetLocation targetLocation =
                 (TargetLocation) targetPack1.getField(VTargetMetadataKey.TargetLocation);
         assertEquals(targetLocation.getDisplayableValue(), "[Location]");
-        assertEquals(targetLocation.getTargetLocation().getLat(), -10.5423886331461, 0.0001);
-        assertEquals(targetLocation.getTargetLocation().getLon(), 29.157890122923, 0.0001);
-        assertEquals(targetLocation.getTargetLocation().getHae(), 3216.0, 0.02);
+        assertEquals(targetLocation.getTargetLocation().getLat(), 43.0, 0.0001);
+        assertEquals(targetLocation.getTargetLocation().getLon(), 110.0, 0.0001);
+        assertEquals(targetLocation.getTargetLocation().getHae(), 10000.0, 0.02);
         assertEquals(
                 targetPack1.getField(VTargetMetadataKey.CentroidPixRow).getDisplayName(),
                 "Centroid Pixel Row");
@@ -1356,6 +1372,22 @@ public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks {
         assertEquals(
                 targetPack1.getField(VTargetMetadataKey.FPAIndex).getDisplayableValue(),
                 "Row 2, Col 3");
+        assertEquals(
+                targetPack1.getField(VTargetMetadataKey.TargetLocationOffsetLat).getDisplayName(),
+                "Target Location Offset Latitude");
+        assertEquals(
+                targetPack1
+                        .getField(VTargetMetadataKey.TargetLocationOffsetLat)
+                        .getDisplayableValue(),
+                "10.00000\u00B0");
+        assertEquals(
+                targetPack1.getField(VTargetMetadataKey.TargetLocationOffsetLon).getDisplayName(),
+                "Target Location Offset Longitude");
+        assertEquals(
+                targetPack1
+                        .getField(VTargetMetadataKey.TargetLocationOffsetLon)
+                        .getDisplayableValue(),
+                "10.00000\u00B0");
         assertEquals(
                 targetPack1.getField(VTargetMetadataKey.AlgorithmId).getDisplayName(),
                 "Algorithm Id");

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiReportedTargetCountTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiReportedTargetCountTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903;
 import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for numTargetsReported (ST0903 Tag 6). */
@@ -47,7 +48,9 @@ public class VmtiReportedTargetCountTest {
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
                 VmtiLocalSet.createValue(
-                        VmtiMetadataKey.NumberOfReportedTargets, new byte[] {(byte) 0x0E});
+                        VmtiMetadataKey.NumberOfReportedTargets,
+                        new byte[] {(byte) 0x0E},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof VmtiReportedTargetCount);
         VmtiReportedTargetCount count = (VmtiReportedTargetCount) value;
         assertEquals(count.getBytes(), new byte[] {(byte) 0x0E});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiTextStringTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiTextStringTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903;
 import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.testng.annotations.Test;
 
@@ -99,7 +100,8 @@ public class VmtiTextStringTest {
                             (byte) 0x4D,
                             (byte) 0x54,
                             (byte) 0x49
-                        });
+                        },
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof VmtiTextString);
         VmtiTextString systemName = (VmtiTextString) value;
         assertEquals(
@@ -187,7 +189,8 @@ public class VmtiTextStringTest {
                             (byte) 0x6F,
                             (byte) 0x73,
                             (byte) 0x65
-                        });
+                        },
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof VmtiTextString);
         VmtiTextString sourceSensor = (VmtiTextString) value;
         assertEquals(

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiTotalTargetCountTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiTotalTargetCountTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903;
 import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for totalNumTargetsDetected (ST0903 Tag 5). */
@@ -47,7 +48,9 @@ public class VmtiTotalTargetCountTest {
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
                 VmtiLocalSet.createValue(
-                        VmtiMetadataKey.TotalTargetsInFrame, new byte[] {(byte) 0x1C});
+                        VmtiMetadataKey.TotalTargetsInFrame,
+                        new byte[] {(byte) 0x1C},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof VmtiTotalTargetCount);
         VmtiTotalTargetCount count = (VmtiTotalTargetCount) value;
         assertEquals(count.getBytes(), new byte[] {(byte) 0x1C});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiVerticalFieldOfViewTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiVerticalFieldOfViewTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903;
 import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for VMTI Vertical FoV (Tag 12) */
@@ -17,6 +18,7 @@ public class VmtiVerticalFieldOfViewTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() {
         VmtiVerticalFieldOfView fov =
                 new VmtiVerticalFieldOfView(new byte[] {(byte) 0x05, (byte) 0x00});
@@ -27,6 +29,30 @@ public class VmtiVerticalFieldOfViewTest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitIMAP() {
+        VmtiVerticalFieldOfView fov =
+                new VmtiVerticalFieldOfView(
+                        new byte[] {(byte) 0x05, (byte) 0x00}, EncodingMode.IMAPB);
+        assertEquals(fov.getBytes(), new byte[] {(byte) 0x05, (byte) 0x00});
+        assertEquals(fov.getDisplayName(), "Vertical Field of View");
+        assertEquals(fov.getDisplayableValue(), "10.0\u00B0");
+        assertEquals(fov.getFieldOfView(), 10.0);
+    }
+
+    @Test
+    public void testConstructFromEncodedBytesExplicitLegacy() {
+        // ST0903.3 Section 7.10.12
+        VmtiVerticalFieldOfView fov =
+                new VmtiVerticalFieldOfView(
+                        new byte[] {(byte) 0x0e, (byte) 0x39}, EncodingMode.LEGACY);
+        assertEquals(fov.getBytes(), new byte[] {(byte) 0x05, (byte) 0x00});
+        assertEquals(fov.getDisplayName(), "Vertical Field of View");
+        assertEquals(fov.getDisplayableValue(), "10.0\u00B0");
+        assertEquals(fov.getFieldOfView(), 10.0, 0.003);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VmtiLocalSet.createValue(
@@ -37,6 +63,36 @@ public class VmtiVerticalFieldOfViewTest {
         assertEquals(fov.getDisplayName(), "Vertical Field of View");
         assertEquals(fov.getDisplayableValue(), "10.0\u00B0");
         assertEquals(fov.getFieldOfView(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.VerticalFieldOfView,
+                        new byte[] {(byte) 0x05, (byte) 0x00},
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof VmtiVerticalFieldOfView);
+        VmtiVerticalFieldOfView fov = (VmtiVerticalFieldOfView) value;
+        assertEquals(fov.getBytes(), new byte[] {(byte) 0x05, (byte) 0x00});
+        assertEquals(fov.getDisplayName(), "Vertical Field of View");
+        assertEquals(fov.getDisplayableValue(), "10.0\u00B0");
+        assertEquals(fov.getFieldOfView(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingLegacy() throws KlvParseException {
+        // See ST0903 Section 7.10.12
+        IVmtiMetadataValue value =
+                VmtiLocalSet.createValue(
+                        VmtiMetadataKey.VerticalFieldOfView,
+                        new byte[] {(byte) 0x0e, (byte) 0x39},
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof VmtiVerticalFieldOfView);
+        VmtiVerticalFieldOfView fov = (VmtiVerticalFieldOfView) value;
+        assertEquals(fov.getDisplayName(), "Vertical Field of View");
+        assertEquals(fov.getDisplayableValue(), "10.0\u00B0");
+        assertEquals(fov.getFieldOfView(), 10.0, 0.003);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -51,6 +107,6 @@ public class VmtiVerticalFieldOfViewTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
-        new VmtiVerticalFieldOfView(new byte[] {0x01});
+        new VmtiVerticalFieldOfView(new byte[] {0x01}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryBottomRightLatOffsetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryBottomRightLatOffsetTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Boundary Bottom Right Latitude Offset (Tag 15) */
@@ -21,6 +22,7 @@ public class BoundaryBottomRightLatOffsetTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() {
         BoundaryBottomRightLatOffset offset =
                 new BoundaryBottomRightLatOffset(
@@ -32,6 +34,30 @@ public class BoundaryBottomRightLatOffsetTest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() {
+        BoundaryBottomRightLatOffset offset =
+                new BoundaryBottomRightLatOffset(
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67}, EncodingMode.IMAPB);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Boundary Bottom Right Lat Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testConstructFromEncodedBytesExplicitEncodingLegacy() {
+        // ST0903.3 Section 7.11.16
+        BoundaryBottomRightLatOffset offset =
+                new BoundaryBottomRightLatOffset(
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA}, EncodingMode.LEGACY);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Boundary Bottom Right Lat Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.003);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
@@ -43,6 +69,37 @@ public class BoundaryBottomRightLatOffsetTest {
         assertEquals(offset.getDisplayName(), "Boundary Bottom Right Lat Offset");
         assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
         assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.BoundaryBottomRightLatOffset,
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67},
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof BoundaryBottomRightLatOffset);
+        BoundaryBottomRightLatOffset offset = (BoundaryBottomRightLatOffset) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Boundary Bottom Right Lat Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingLegacy() throws KlvParseException {
+        // ST0903.3 Section 7.11.16
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.BoundaryBottomRightLatOffset,
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA},
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof BoundaryBottomRightLatOffset);
+        BoundaryBottomRightLatOffset offset = (BoundaryBottomRightLatOffset) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Boundary Bottom Right Lat Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.003);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -57,6 +114,6 @@ public class BoundaryBottomRightLatOffsetTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
-        new BoundaryBottomRightLatOffset(new byte[] {0x01, 0x02, 0x03, 0x04});
+        new BoundaryBottomRightLatOffset(new byte[] {0x01, 0x02, 0x03, 0x04}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryBottomRightLonOffsetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryBottomRightLonOffsetTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Boundary Bottom Right Longitude Offset (Tag 16) */
@@ -21,6 +22,7 @@ public class BoundaryBottomRightLonOffsetTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() {
         BoundaryBottomRightLonOffset offset =
                 new BoundaryBottomRightLonOffset(
@@ -32,6 +34,30 @@ public class BoundaryBottomRightLonOffsetTest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() {
+        BoundaryBottomRightLonOffset offset =
+                new BoundaryBottomRightLonOffset(
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67}, EncodingMode.IMAPB);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Boundary Bottom Right Lon Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testConstructFromEncodedBytesExplicitEncodingLegacy() {
+        // ST0903.3 Section 7.11.17
+        BoundaryBottomRightLonOffset offset =
+                new BoundaryBottomRightLonOffset(
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA}, EncodingMode.LEGACY);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Boundary Bottom Right Lon Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.003);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
@@ -43,6 +69,37 @@ public class BoundaryBottomRightLonOffsetTest {
         assertEquals(offset.getDisplayName(), "Boundary Bottom Right Lon Offset");
         assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
         assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.BoundaryBottomRightLonOffset,
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67},
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof BoundaryBottomRightLonOffset);
+        BoundaryBottomRightLonOffset offset = (BoundaryBottomRightLonOffset) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Boundary Bottom Right Lon Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingLegacy() throws KlvParseException {
+        // ST0903.3 Section 7.11.17
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.BoundaryBottomRightLonOffset,
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA},
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof BoundaryBottomRightLonOffset);
+        BoundaryBottomRightLonOffset offset = (BoundaryBottomRightLonOffset) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Boundary Bottom Right Lon Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.003);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -57,6 +114,6 @@ public class BoundaryBottomRightLonOffsetTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
-        new BoundaryBottomRightLonOffset(new byte[] {0x01, 0x02, 0x03, 0x04});
+        new BoundaryBottomRightLonOffset(new byte[] {0x01, 0x02, 0x03, 0x04}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryBottomRightTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryBottomRightTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Boundary Bottom Right (Tag 3). */
@@ -33,7 +34,8 @@ public class BoundaryBottomRightTest {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
                         VTargetMetadataKey.BoundaryBottomRight,
-                        new byte[] {(byte) 0x06, (byte) 0x40, (byte) 0x00});
+                        new byte[] {(byte) 0x06, (byte) 0x40, (byte) 0x00},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof BoundaryBottomRight);
         BoundaryBottomRight index = (BoundaryBottomRight) value;
         assertEquals(index.getBytes(), new byte[] {(byte) 0x06, (byte) 0x40, (byte) 0x00});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftLatOffsetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftLatOffsetTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Boundary Top Left Latitude Offset (Tag 13) */
@@ -21,6 +22,7 @@ public class BoundaryTopLeftLatOffsetTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() {
         BoundaryTopLeftLatOffset offset =
                 new BoundaryTopLeftLatOffset(new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
@@ -31,6 +33,30 @@ public class BoundaryTopLeftLatOffsetTest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() {
+        BoundaryTopLeftLatOffset offset =
+                new BoundaryTopLeftLatOffset(
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67}, EncodingMode.IMAPB);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Boundary Top Left Lat Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testConstructFromEncodedBytesExplicitEncodingLegacy() {
+        // ST0903.3 Section 7.11.14
+        BoundaryTopLeftLatOffset offset =
+                new BoundaryTopLeftLatOffset(
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA}, EncodingMode.LEGACY);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Boundary Top Left Lat Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.003);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
@@ -42,6 +68,37 @@ public class BoundaryTopLeftLatOffsetTest {
         assertEquals(offset.getDisplayName(), "Boundary Top Left Lat Offset");
         assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
         assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.BoundaryTopLeftLatOffset,
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67},
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof BoundaryTopLeftLatOffset);
+        BoundaryTopLeftLatOffset offset = (BoundaryTopLeftLatOffset) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Boundary Top Left Lat Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingLegacy() throws KlvParseException {
+        // ST0903.3 Section 7.11.14
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.BoundaryTopLeftLatOffset,
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA},
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof BoundaryTopLeftLatOffset);
+        BoundaryTopLeftLatOffset offset = (BoundaryTopLeftLatOffset) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Boundary Top Left Lat Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.003);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -56,6 +113,6 @@ public class BoundaryTopLeftLatOffsetTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
-        new BoundaryTopLeftLatOffset(new byte[] {0x01, 0x02, 0x03, 0x04});
+        new BoundaryTopLeftLatOffset(new byte[] {0x01, 0x02, 0x03, 0x04}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftLonOffsetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftLonOffsetTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Boundary Top Left Longitude Offset (Tag 14) */
@@ -21,6 +22,7 @@ public class BoundaryTopLeftLonOffsetTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() {
         BoundaryTopLeftLonOffset offset =
                 new BoundaryTopLeftLonOffset(new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
@@ -31,6 +33,30 @@ public class BoundaryTopLeftLonOffsetTest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() {
+        BoundaryTopLeftLonOffset offset =
+                new BoundaryTopLeftLonOffset(
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67}, EncodingMode.IMAPB);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Boundary Top Left Lon Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testConstructFromEncodedBytesExplicitEncodingLegacy() {
+        // ST0903.3 Section 7.11.15
+        BoundaryTopLeftLonOffset offset =
+                new BoundaryTopLeftLonOffset(
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA}, EncodingMode.LEGACY);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Boundary Top Left Lon Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.003);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
@@ -42,6 +68,37 @@ public class BoundaryTopLeftLonOffsetTest {
         assertEquals(offset.getDisplayName(), "Boundary Top Left Lon Offset");
         assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
         assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.BoundaryTopLeftLonOffset,
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67},
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof BoundaryTopLeftLonOffset);
+        BoundaryTopLeftLonOffset offset = (BoundaryTopLeftLonOffset) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Boundary Top Left Lon Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingLegacy() throws KlvParseException {
+        // ST0903.3 Section 7.11.15
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.BoundaryTopLeftLonOffset,
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA},
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof BoundaryTopLeftLonOffset);
+        BoundaryTopLeftLonOffset offset = (BoundaryTopLeftLonOffset) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Boundary Top Left Lon Offset");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.003);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -56,6 +113,6 @@ public class BoundaryTopLeftLonOffsetTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
-        new BoundaryTopLeftLonOffset(new byte[] {0x01, 0x02, 0x03, 0x04});
+        new BoundaryTopLeftLonOffset(new byte[] {0x01, 0x02, 0x03, 0x04}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/BoundaryTopLeftTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Boundary Top Left (Tag 2). */
@@ -33,7 +34,8 @@ public class BoundaryTopLeftTest {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
                         VTargetMetadataKey.BoundaryTopLeft,
-                        new byte[] {(byte) 0x06, (byte) 0x40, (byte) 0x00});
+                        new byte[] {(byte) 0x06, (byte) 0x40, (byte) 0x00},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof BoundaryTopLeft);
         BoundaryTopLeft index = (BoundaryTopLeft) value;
         assertEquals(index.getBytes(), new byte[] {(byte) 0x06, (byte) 0x40, (byte) 0x00});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/CentroidPixelColumnTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/CentroidPixelColumnTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Centroid Pixel Column (Tag 20) */
@@ -34,7 +35,8 @@ public class CentroidPixelColumnTest {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
                         VTargetMetadataKey.CentroidPixColumn,
-                        new byte[] {(byte) 0x04, (byte) 0x71});
+                        new byte[] {(byte) 0x04, (byte) 0x71},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof CentroidPixelColumn);
         CentroidPixelColumn index = (CentroidPixelColumn) value;
         assertEquals(index.getBytes(), new byte[] {(byte) 0x04, (byte) 0x71});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/CentroidPixelRowTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/CentroidPixelRowTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Centroid Pixel Row (Tag 19) */
@@ -33,7 +34,9 @@ public class CentroidPixelRowTest {
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
-                        VTargetMetadataKey.CentroidPixRow, new byte[] {(byte) 0x03, (byte) 0x68});
+                        VTargetMetadataKey.CentroidPixRow,
+                        new byte[] {(byte) 0x03, (byte) 0x68},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof CentroidPixelRow);
         CentroidPixelRow index = (CentroidPixelRow) value;
         assertEquals(index.getBytes(), new byte[] {(byte) 0x03, (byte) 0x68});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/FpaIndexTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/FpaIndexTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for FPA Index (Tag 21) */
@@ -35,7 +36,9 @@ public class FpaIndexTest {
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
-                        VTargetMetadataKey.FPAIndex, new byte[] {(byte) 0x02, (byte) 0x03});
+                        VTargetMetadataKey.FPAIndex,
+                        new byte[] {(byte) 0x02, (byte) 0x03},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof FpaIndex);
         FpaIndex fpaIndex = (FpaIndex) value;
         assertEquals(fpaIndex.getDisplayName(), "FPA Index");

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/PercentageOfTargetPixelsTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/PercentageOfTargetPixelsTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Percentage of Target Pixels (Tag 7) */
@@ -34,7 +35,9 @@ public class PercentageOfTargetPixelsTest {
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
-                        VTargetMetadataKey.PercentageOfTargetPixels, new byte[] {(byte) 0x32});
+                        VTargetMetadataKey.PercentageOfTargetPixels,
+                        new byte[] {(byte) 0x32},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof PercentageOfTargetPixels);
         PercentageOfTargetPixels percentage = (PercentageOfTargetPixels) value;
         assertEquals(percentage.getBytes(), new byte[] {(byte) 0x32});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetBoundarySeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetBoundarySeriesTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.LocationPack;
 import org.testng.annotations.Test;
 
@@ -39,15 +40,36 @@ public class TargetBoundarySeriesTest {
             };
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() throws KlvParseException {
         TargetBoundarySeries boundarySeries = new TargetBoundarySeries(bytesTwoLocations);
         verifyTwoLocations(boundarySeries);
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAPB() throws KlvParseException {
+        TargetBoundarySeries boundarySeries =
+                new TargetBoundarySeries(bytesTwoLocations, EncodingMode.IMAPB);
+        verifyTwoLocations(boundarySeries);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(VTargetMetadataKey.TargetBoundarySeries, bytesTwoLocations);
+        assertTrue(value instanceof TargetBoundarySeries);
+        TargetBoundarySeries targetBoundarySeries = (TargetBoundarySeries) value;
+        verifyTwoLocations(targetBoundarySeries);
+    }
+
+    @Test
+    public void testFactoryEncodedBytesExplicitEncodingIMAPB() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.TargetBoundarySeries,
+                        bytesTwoLocations,
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TargetBoundarySeries);
         TargetBoundarySeries targetBoundarySeries = (TargetBoundarySeries) value;
         verifyTwoLocations(targetBoundarySeries);
@@ -79,6 +101,6 @@ public class TargetBoundarySeriesTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() throws KlvParseException {
-        new TargetBoundarySeries(new byte[] {0x01, 0x02, 0x03});
+        new TargetBoundarySeries(new byte[] {0x01, 0x02, 0x03}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetCentroidTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetCentroidTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /**
@@ -37,7 +38,8 @@ public class TargetCentroidTest {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
                         VTargetMetadataKey.TargetCentroid,
-                        new byte[] {(byte) 0x06, (byte) 0x40, (byte) 0x00});
+                        new byte[] {(byte) 0x06, (byte) 0x40, (byte) 0x00},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TargetCentroid);
         TargetCentroid index = (TargetCentroid) value;
         assertEquals(index.getBytes(), new byte[] {(byte) 0x06, (byte) 0x40, (byte) 0x00});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetColorTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetColorTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Target Color (Tag 8) */
@@ -35,7 +36,8 @@ public class TargetColorTest {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
                         VTargetMetadataKey.TargetColor,
-                        new byte[] {(byte) 0x55, (byte) 0x88, (byte) 0x33});
+                        new byte[] {(byte) 0x55, (byte) 0x88, (byte) 0x33},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TargetColor);
         TargetColor color = (TargetColor) value;
         assertEquals(color.getBytes(), new byte[] {(byte) 0x55, (byte) 0x88, (byte) 0x33});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetConfidenceLevelTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetConfidenceLevelTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Target Confidence Level (Tag 5) */
@@ -33,7 +34,9 @@ public class TargetConfidenceLevelTest {
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
-                        VTargetMetadataKey.TargetConfidenceLevel, new byte[] {(byte) 0x50});
+                        VTargetMetadataKey.TargetConfidenceLevel,
+                        new byte[] {(byte) 0x50},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TargetConfidenceLevel);
         TargetConfidenceLevel confidence = (TargetConfidenceLevel) value;
         assertEquals(confidence.getBytes(), new byte[] {(byte) 0x50});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetHAETest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetHAETest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Target HAE (Tag 12) */
@@ -18,6 +19,7 @@ public class TargetHAETest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() {
         TargetHAE hae = new TargetHAE(new byte[] {(byte) 0x2a, (byte) 0x94});
         assertEquals(hae.getBytes(), new byte[] {(byte) 0x2a, (byte) 0x94});
@@ -27,6 +29,26 @@ public class TargetHAETest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() {
+        TargetHAE hae = new TargetHAE(new byte[] {(byte) 0x2a, (byte) 0x94}, EncodingMode.IMAPB);
+        assertEquals(hae.getBytes(), new byte[] {(byte) 0x2a, (byte) 0x94});
+        assertEquals(hae.getDisplayName(), "Target HAE");
+        assertEquals(hae.getDisplayableValue(), "10000.0");
+        assertEquals(hae.getHAE(), 10000);
+    }
+
+    @Test
+    public void testConstructFromEncodedBytesExplicitEncodingLegacy() {
+        // ST0903.3 Section 7.11.13
+        TargetHAE hae = new TargetHAE(new byte[] {(byte) 0x8C, (byte) 0x38}, EncodingMode.LEGACY);
+        assertEquals(hae.getBytes(), new byte[] {(byte) 0x2a, (byte) 0x93});
+        assertEquals(hae.getDisplayName(), "Target HAE");
+        assertEquals(hae.getDisplayableValue(), "10000.0");
+        assertEquals(hae.getHAE(), 10000, 0.3);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
@@ -37,6 +59,37 @@ public class TargetHAETest {
         assertEquals(hae.getDisplayName(), "Target HAE");
         assertEquals(hae.getDisplayableValue(), "10000.0");
         assertEquals(hae.getHAE(), 10000);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.TargetHAE,
+                        new byte[] {(byte) 0x2a, (byte) 0x94},
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof TargetHAE);
+        TargetHAE hae = (TargetHAE) value;
+        assertEquals(hae.getBytes(), new byte[] {(byte) 0x2a, (byte) 0x94});
+        assertEquals(hae.getDisplayName(), "Target HAE");
+        assertEquals(hae.getDisplayableValue(), "10000.0");
+        assertEquals(hae.getHAE(), 10000);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingLegacy() throws KlvParseException {
+        // ST0903.3 Section 7.11.13
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.TargetHAE,
+                        new byte[] {(byte) 0x8C, (byte) 0x38},
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof TargetHAE);
+        TargetHAE hae = (TargetHAE) value;
+        assertEquals(hae.getBytes(), new byte[] {(byte) 0x2a, (byte) 0x93});
+        assertEquals(hae.getDisplayName(), "Target HAE");
+        assertEquals(hae.getDisplayableValue(), "10000.0");
+        assertEquals(hae.getHAE(), 10000, 0.3);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -51,6 +104,6 @@ public class TargetHAETest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
-        new TargetHAE(new byte[] {0x01, 0x02, 0x03});
+        new TargetHAE(new byte[] {0x01, 0x02, 0x03}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetHistoryTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetHistoryTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Target History (Tag 6) */
@@ -42,7 +43,9 @@ public class TargetHistoryTest {
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
-                        VTargetMetadataKey.TargetHistory, new byte[] {(byte) 0x0A, (byte) 0xCD});
+                        VTargetMetadataKey.TargetHistory,
+                        new byte[] {(byte) 0x0A, (byte) 0xCD},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TargetHistory);
         TargetHistory history = (TargetHistory) value;
         assertEquals(history.getBytes(), new byte[] {(byte) 0x0A, (byte) 0xCD});
@@ -54,7 +57,10 @@ public class TargetHistoryTest {
     @Test
     public void testFactory0() throws KlvParseException {
         IVmtiMetadataValue value =
-                VTargetPack.createValue(VTargetMetadataKey.TargetHistory, new byte[] {(byte) 0x00});
+                VTargetPack.createValue(
+                        VTargetMetadataKey.TargetHistory,
+                        new byte[] {(byte) 0x00},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TargetHistory);
         TargetHistory history = (TargetHistory) value;
         assertEquals(history.getBytes(), new byte[] {(byte) 0x00});
@@ -67,7 +73,9 @@ public class TargetHistoryTest {
     public void testFactoryMax() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
-                        VTargetMetadataKey.TargetHistory, new byte[] {(byte) 0xFF, (byte) 0xFF});
+                        VTargetMetadataKey.TargetHistory,
+                        new byte[] {(byte) 0xFF, (byte) 0xFF},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TargetHistory);
         TargetHistory history = (TargetHistory) value;
         assertEquals(history.getBytes(), new byte[] {(byte) 0xFF, (byte) 0xFF});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetIntensityTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetIntensityTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.*;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Target Intensity (ST0903 VTarget Tag 9). */
@@ -48,7 +49,9 @@ public class TargetIntensityTest {
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
-                        VTargetMetadataKey.TargetIntensity, new byte[] {(byte) 0x33, (byte) 0x54});
+                        VTargetMetadataKey.TargetIntensity,
+                        new byte[] {(byte) 0x33, (byte) 0x54},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TargetIntensity);
         TargetIntensity intensity = (TargetIntensity) value;
         assertEquals(intensity.getBytes(), new byte[] {(byte) 0x33, (byte) 0x54});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetLocationOffsetLatTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetLocationOffsetLatTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Target Location Offset Latitude (Tag 10) */
@@ -21,6 +22,7 @@ public class TargetLocationOffsetLatTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() {
         TargetLocationOffsetLat offset =
                 new TargetLocationOffsetLat(new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
@@ -31,6 +33,29 @@ public class TargetLocationOffsetLatTest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() {
+        TargetLocationOffsetLat offset =
+                new TargetLocationOffsetLat(
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67}, EncodingMode.IMAPB);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Target Location Offset Latitude");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testConstructFromEncodedBytesExplicitEncodingLegacy() {
+        TargetLocationOffsetLat offset =
+                new TargetLocationOffsetLat(
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA}, EncodingMode.LEGACY);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Target Location Offset Latitude");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.000003);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
@@ -42,6 +67,36 @@ public class TargetLocationOffsetLatTest {
         assertEquals(offset.getDisplayName(), "Target Location Offset Latitude");
         assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
         assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.TargetLocationOffsetLat,
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67},
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof TargetLocationOffsetLat);
+        TargetLocationOffsetLat offset = (TargetLocationOffsetLat) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Target Location Offset Latitude");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingLegacy() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.TargetLocationOffsetLat,
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA},
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof TargetLocationOffsetLat);
+        TargetLocationOffsetLat offset = (TargetLocationOffsetLat) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Target Location Offset Latitude");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.000003);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -56,6 +111,6 @@ public class TargetLocationOffsetLatTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
-        new TargetLocationOffsetLat(new byte[] {0x01, 0x02, 0x03, 0x04});
+        new TargetLocationOffsetLat(new byte[] {0x01, 0x02, 0x03, 0x04}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetLocationOffsetLonTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetLocationOffsetLonTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Target Location Offset Longitude (Tag 11) */
@@ -21,6 +22,7 @@ public class TargetLocationOffsetLonTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() {
         TargetLocationOffsetLon offset =
                 new TargetLocationOffsetLon(new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
@@ -31,6 +33,29 @@ public class TargetLocationOffsetLonTest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() {
+        TargetLocationOffsetLon offset =
+                new TargetLocationOffsetLon(
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67}, EncodingMode.IMAPB);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Target Location Offset Longitude");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testConstructFromEncodedBytesExplicitEncodingLegacy() {
+        TargetLocationOffsetLon offset =
+                new TargetLocationOffsetLon(
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA}, EncodingMode.LEGACY);
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Target Location Offset Longitude");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.000003);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
@@ -42,6 +67,50 @@ public class TargetLocationOffsetLonTest {
         assertEquals(offset.getDisplayName(), "Target Location Offset Longitude");
         assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
         assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.TargetLocationOffsetLon,
+                        new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67},
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof TargetLocationOffsetLon);
+        TargetLocationOffsetLon offset = (TargetLocationOffsetLon) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x67});
+        assertEquals(offset.getDisplayName(), "Target Location Offset Longitude");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingLegacy() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.TargetLocationOffsetLon,
+                        new byte[] {(byte) 0x42, (byte) 0xAA, (byte) 0xAA},
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof TargetLocationOffsetLon);
+        TargetLocationOffsetLon offset = (TargetLocationOffsetLon) value;
+        assertEquals(offset.getBytes(), new byte[] {(byte) 0x3A, (byte) 0x66, (byte) 0x66});
+        assertEquals(offset.getDisplayName(), "Target Location Offset Longitude");
+        assertEquals(offset.getDisplayableValue(), "10.00000\u00B0");
+        assertEquals(offset.getValue(), 10.0, 0.000003);
+    }
+
+    @Test
+    public void testFactoryExplicitEncodingLegacyErrorIndicator() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(
+                        VTargetMetadataKey.TargetLocationOffsetLon,
+                        new byte[] {(byte) 0x80, (byte) 0x00, (byte) 0x00},
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof TargetLocationOffsetLon);
+        TargetLocationOffsetLon offset = (TargetLocationOffsetLon) value;
+        assertEquals(offset.getDisplayName(), "Target Location Offset Longitude");
+        assertEquals(offset.getDisplayableValue(), "NaN\u00B0");
+        assertEquals(offset.getValue(), Double.NaN);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -56,6 +125,6 @@ public class TargetLocationOffsetLonTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
-        new TargetLocationOffsetLon(new byte[] {0x01, 0x02, 0x03, 0x04});
+        new TargetLocationOffsetLon(new byte[] {0x01, 0x02, 0x03, 0x04}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetPriorityTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetPriorityTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Target Priority (Tag 4) */
@@ -33,7 +34,9 @@ public class TargetPriorityTest {
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
-                        VTargetMetadataKey.TargetPriority, new byte[] {(byte) 0x1B});
+                        VTargetMetadataKey.TargetPriority,
+                        new byte[] {(byte) 0x1B},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TargetPriority);
         TargetPriority priority = (TargetPriority) value;
         assertEquals(priority.getBytes(), new byte[] {(byte) 0x1B});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VChipSeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VChipSeriesTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vchip.VChipLS;
 import org.jmisb.api.klv.st0903.vchip.VChipMetadataKey;
 import org.testng.annotations.Test;
@@ -199,7 +200,8 @@ public class VChipSeriesTest {
     @Test
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
-                VTargetPack.createValue(VTargetMetadataKey.VChipSeries, bytesOneChip);
+                VTargetPack.createValue(
+                        VTargetMetadataKey.VChipSeries, bytesOneChip, EncodingMode.IMAPB);
         assertTrue(value instanceof VChipSeries);
         VChipSeries chipSeries = (VChipSeries) value;
         // Content can vary, but length should be OK.
@@ -238,7 +240,8 @@ public class VChipSeriesTest {
     @Test
     public void testFactoryEncodedBytesTwoChips() throws KlvParseException {
         IVmtiMetadataValue value =
-                VTargetPack.createValue(VTargetMetadataKey.VChipSeries, bytesTwoChips);
+                VTargetPack.createValue(
+                        VTargetMetadataKey.VChipSeries, bytesTwoChips, EncodingMode.IMAPB);
         assertTrue(value instanceof VChipSeries);
         VChipSeries chipSeries = (VChipSeries) value;
         // Content can vary, but length should be OK.

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VChipTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VChipTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vchip.VChipLS;
 import org.jmisb.api.klv.st0903.vchip.VChipMetadataKey;
 import org.testng.annotations.Test;
@@ -106,7 +107,8 @@ public class VChipTest {
 
     @Test
     public void testFactoryEncodedBytes() throws KlvParseException {
-        IVmtiMetadataValue value = VTargetPack.createValue(VTargetMetadataKey.VChip, bytes);
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(VTargetMetadataKey.VChip, bytes, EncodingMode.IMAPB);
         assertTrue(value instanceof VChip);
         VChip chip = (VChip) value;
         // Content can vary, but length should be OK.

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VFeatureTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VFeatureTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vfeature.VFeatureLS;
 import org.jmisb.api.klv.st0903.vfeature.VFeatureMetadataKey;
 import org.testng.annotations.Test;
@@ -32,7 +33,8 @@ public class VFeatureTest {
     @Test
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
-                VTargetPack.createValue(VTargetMetadataKey.VFeature, featureBytes);
+                VTargetPack.createValue(
+                        VTargetMetadataKey.VFeature, featureBytes, EncodingMode.IMAPB);
         assertTrue(value instanceof VFeature);
         VFeature vFeature = (VFeature) value;
         assertEquals(vFeature.getBytes(), featureBytes);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VMaskTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VMaskTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vmask.BitMaskSeries;
 import org.jmisb.api.klv.st0903.vmask.PixelPolygon;
 import org.jmisb.api.klv.st0903.vmask.PixelRunPair;
@@ -172,7 +173,8 @@ public class VMaskTest {
                             0x01,
                             0x6A,
                             0x02 // (106, 2)
-                        });
+                        },
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof VMask);
         VMask mask = (VMask) value;
         assertEquals(

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VObjectSeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VObjectSeriesTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vobject.VObjectLS;
 import org.jmisb.api.klv.st0903.vobject.VObjectMetadataKey;
 import org.testng.annotations.Test;
@@ -55,7 +56,8 @@ public class VObjectSeriesTest {
     @Test
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
-                VTargetPack.createValue(VTargetMetadataKey.VObjectSeries, bytesOneObject);
+                VTargetPack.createValue(
+                        VTargetMetadataKey.VObjectSeries, bytesOneObject, EncodingMode.IMAPB);
         assertTrue(value instanceof VObjectSeries);
         VObjectSeries objectSeries = (VObjectSeries) value;
         assertEquals(objectSeries.getBytes(), bytesOneObject);
@@ -100,7 +102,8 @@ public class VObjectSeriesTest {
     @Test
     public void testFactoryEncodedBytesTwoObjects() throws KlvParseException {
         IVmtiMetadataValue value =
-                VTargetPack.createValue(VTargetMetadataKey.VObjectSeries, bytesTwoObjects);
+                VTargetPack.createValue(
+                        VTargetMetadataKey.VObjectSeries, bytesTwoObjects, EncodingMode.IMAPB);
         assertTrue(value instanceof VObjectSeries);
         VObjectSeries objectSeries = (VObjectSeries) value;
         assertEquals(objectSeries.getBytes(), bytesTwoObjects);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VObjectTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VObjectTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vobject.VObjectLS;
 import org.jmisb.api.klv.st0903.vobject.VObjectMetadataKey;
 import org.testng.annotations.Test;
@@ -34,7 +35,8 @@ public class VObjectTest {
     @Test
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
-                VTargetPack.createValue(VTargetMetadataKey.VObject, ontologyBytes);
+                VTargetPack.createValue(
+                        VTargetMetadataKey.VObject, ontologyBytes, EncodingMode.IMAPB);
         assertTrue(value instanceof VObject);
         VObject vObject = (VObject) value;
         assertEquals(vObject.getBytes(), ontologyBytes);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTargetPackTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTargetPackTest.java
@@ -6,10 +6,22 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.LoggerChecks;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.AlgorithmId;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for VTarget Pack */
 public class VTargetPackTest extends LoggerChecks {
+
+    private static final byte[] TEST_BYTES =
+            new byte[] {
+                0x01, // Target Id
+                0x16,
+                0x03,
+                0x01,
+                0x03,
+                (byte) 0x98 // Tag 22 - Algorithm Id.
+            };
+
     public VTargetPackTest() {
         super(VTargetPack.class);
     }
@@ -19,23 +31,35 @@ public class VTargetPackTest extends LoggerChecks {
         verifyNoLoggerMessages();
         IVmtiMetadataValue value =
                 VTargetPack.createValue(
-                        VTargetMetadataKey.Undefined, new byte[] {(byte) 0x2a, (byte) 0x94});
+                        VTargetMetadataKey.Undefined,
+                        new byte[] {(byte) 0x2a, (byte) 0x94},
+                        EncodingMode.IMAPB);
         verifySingleLoggerMessage("Unrecognized VTarget tag: Undefined");
         assertNull(value);
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void parseAlgorithmId() throws KlvParseException {
-        final byte[] bytes =
-                new byte[] {
-                    0x01, // Target Id
-                    0x16,
-                    0x03,
-                    0x01,
-                    0x03,
-                    (byte) 0x98 // Tag 22 - Algorithm Id.
-                };
-        VTargetPack localSet = new VTargetPack(bytes, 0, bytes.length);
+        VTargetPack localSet = new VTargetPack(TEST_BYTES, 0, TEST_BYTES.length);
+        checkVTargetPackWithAlgorithmId(localSet);
+    }
+
+    @Test
+    public void parseAlgorithmIdExplicitIMAPB() throws KlvParseException {
+        VTargetPack localSet =
+                new VTargetPack(TEST_BYTES, 0, TEST_BYTES.length, EncodingMode.IMAPB);
+        checkVTargetPackWithAlgorithmId(localSet);
+    }
+
+    @Test
+    public void parseAlgorithmIdExplicitLegacy() throws KlvParseException {
+        VTargetPack localSet =
+                new VTargetPack(TEST_BYTES, 0, TEST_BYTES.length, EncodingMode.LEGACY);
+        checkVTargetPackWithAlgorithmId(localSet);
+    }
+
+    private void checkVTargetPackWithAlgorithmId(VTargetPack localSet) {
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);
         assertTrue(localSet.getTags().contains(VTargetMetadataKey.AlgorithmId));
@@ -64,7 +88,7 @@ public class VTargetPackTest extends LoggerChecks {
                     (byte) 0x98 // Tag 22 - Algorithm Id.
                 };
         verifyNoLoggerMessages();
-        VTargetPack localSet = new VTargetPack(bytes, 0, bytes.length);
+        VTargetPack localSet = new VTargetPack(bytes, 0, bytes.length, EncodingMode.IMAPB);
         verifySingleLoggerMessage("Unknown VMTI VTarget Metadata tag: 55");
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTrackerTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTrackerTest.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.jmisb.api.klv.st0903.vtracker.DetectionStatus;
 import org.jmisb.api.klv.st0903.vtracker.VTrackerLS;
@@ -28,6 +29,7 @@ public class VTrackerTest {
             };
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() throws KlvParseException {
         VTracker tracker = new VTracker(bytes);
         assertEquals(tracker.getBytes(), bytes);
@@ -36,8 +38,29 @@ public class VTrackerTest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() throws KlvParseException {
+        VTracker tracker = new VTracker(bytes, EncodingMode.IMAPB);
+        assertEquals(tracker.getBytes(), bytes);
+        assertEquals(tracker.getDisplayName(), "VTracker");
+        assertEquals(tracker.getDisplayableValue(), "[VTracker]");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value = VTargetPack.createValue(VTargetMetadataKey.VTracker, bytes);
+        assertTrue(value instanceof VTracker);
+        VTracker tracker = (VTracker) value;
+        assertEquals(tracker.getBytes().length, bytes.length);
+        assertEquals(tracker.getDisplayName(), "VTracker");
+        assertEquals(tracker.getDisplayableValue(), "[VTracker]");
+        assertEquals(tracker.getTracker().getTags().size(), 2);
+    }
+
+    @Test
+    public void testFactoryEncodedBytesExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTargetPack.createValue(VTargetMetadataKey.VTracker, bytes, EncodingMode.IMAPB);
         assertTrue(value instanceof VTracker);
         VTracker tracker = (VTracker) value;
         assertEquals(tracker.getBytes().length, bytes.length);
@@ -65,7 +88,8 @@ public class VTrackerTest {
                     0x74 // Tag 6 - algorithm
                 };
         IVmtiMetadataValue value =
-                VTargetPack.createValue(VTargetMetadataKey.VTracker, bytesWithUnknownTag);
+                VTargetPack.createValue(
+                        VTargetMetadataKey.VTracker, bytesWithUnknownTag, EncodingMode.IMAPB);
         assertTrue(value instanceof VTracker);
         VTracker tracker = (VTracker) value;
         assertEquals(tracker.getBytes().length, bytes.length);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/AccelerationTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/AccelerationTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Acceleration (Tag 11) */
@@ -15,6 +16,22 @@ public class AccelerationTest {
                 (byte) 0x3E, (byte) 0x80
             };
 
+    private final byte[] accelerationBytesLegacyForm =
+            // From ST0903.3 B.4.1
+            new byte[] {
+                (byte) 0xAA, (byte) 0xAA,
+                (byte) 0x9C, (byte) 0x71,
+                (byte) 0x8E, (byte) 0x38
+            };
+
+    private final byte[] accelerationBytesFromLegacyBytes =
+            // Some rounding vs truncation differences
+            new byte[] {
+                (byte) 0x4B, (byte) 0x00,
+                (byte) 0x44, (byte) 0xBF,
+                (byte) 0x3E, (byte) 0x7F
+            };
+
     private final byte[] accelerationPlusSigmaBytes =
             new byte[] {
                 (byte) 0x4B, (byte) 0x00,
@@ -23,6 +40,28 @@ public class AccelerationTest {
                 (byte) 0x25, (byte) 0x80,
                 (byte) 0x19, (byte) 0x00,
                 (byte) 0x0C, (byte) 0x80
+            };
+
+    private final byte[] accelerationPlusSigmaBytesLegacyForm =
+            // From ST0903.3 B.4.1 and B.4.2
+            new byte[] {
+                (byte) 0xAA, (byte) 0xAA,
+                (byte) 0x9C, (byte) 0x71,
+                (byte) 0x8E, (byte) 0x38,
+                (byte) 0x76, (byte) 0x27,
+                (byte) 0x4E, (byte) 0xC5,
+                (byte) 0x27, (byte) 0x67
+            };
+
+    private final byte[] accelerationPlusSigmaBytesFromLegacyBytes =
+            // Some rounding vs truncation differences
+            new byte[] {
+                (byte) 0x4B, (byte) 0x00,
+                (byte) 0x44, (byte) 0xBF,
+                (byte) 0x3E, (byte) 0x7F,
+                (byte) 0x25, (byte) 0x80,
+                (byte) 0x19, (byte) 0x00,
+                (byte) 0x0C, (byte) 0x81
             };
 
     private final byte[] accelerationPlusSigmaAndRhoBytes =
@@ -36,6 +75,34 @@ public class AccelerationTest {
                 (byte) 0x70, (byte) 0x00,
                 (byte) 0x60, (byte) 0x00,
                 (byte) 0x50, (byte) 0x00
+            };
+
+    private final byte[] accelerationPlusSigmaAndRhoBytesLegacyForm =
+            // From ST0903.3 B.4.1, B.4.2 and B.4.3
+            new byte[] {
+                (byte) 0xAA, (byte) 0xAA,
+                (byte) 0x9C, (byte) 0x71,
+                (byte) 0x8E, (byte) 0x38,
+                (byte) 0x76, (byte) 0x27,
+                (byte) 0x4E, (byte) 0xC5,
+                (byte) 0x27, (byte) 0x67,
+                (byte) 0xDF, (byte) 0xFF,
+                (byte) 0xBF, (byte) 0xFF,
+                (byte) 0x9F, (byte) 0xFF
+            };
+
+    private final byte[] accelerationPlusSigmaAndRhoBytesFromLegacyBytes =
+            // Some rounding vs truncation differences
+            new byte[] {
+                (byte) 0x4B, (byte) 0x00,
+                (byte) 0x44, (byte) 0xBF,
+                (byte) 0x3E, (byte) 0x7F,
+                (byte) 0x25, (byte) 0x80,
+                (byte) 0x19, (byte) 0x00,
+                (byte) 0x0C, (byte) 0x81,
+                (byte) 0x6F, (byte) 0xFF,
+                (byte) 0x5F, (byte) 0xFF,
+                (byte) 0x4F, (byte) 0xFF
             };
 
     @Test
@@ -95,6 +162,7 @@ public class AccelerationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() {
         Acceleration acceleration = new Acceleration(accelerationBytes);
         assertEquals(acceleration.getBytes(), accelerationBytes);
@@ -112,6 +180,42 @@ public class AccelerationTest {
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() {
+        Acceleration acceleration = new Acceleration(accelerationBytes, EncodingMode.IMAPB);
+        assertEquals(acceleration.getBytes(), accelerationBytes);
+        assertEquals(acceleration.getDisplayName(), "Acceleration");
+        assertEquals(acceleration.getDisplayableValue(), "[Acceleration]");
+        assertEquals(acceleration.getAcceleration().getEast(), 300, 0.1);
+        assertEquals(acceleration.getAcceleration().getNorth(), 200, 0.1);
+        assertEquals(acceleration.getAcceleration().getUp(), 100, 0.1);
+        assertNull(acceleration.getAcceleration().getSigEast());
+        assertNull(acceleration.getAcceleration().getSigNorth());
+        assertNull(acceleration.getAcceleration().getSigUp());
+        assertNull(acceleration.getAcceleration().getRhoEastNorth());
+        assertNull(acceleration.getAcceleration().getRhoEastUp());
+        assertNull(acceleration.getAcceleration().getRhoNorthUp());
+    }
+
+    @Test
+    public void testConstructFromEncodedBytesExplicitEncodingLegacy() {
+        Acceleration acceleration =
+                new Acceleration(accelerationBytesLegacyForm, EncodingMode.LEGACY);
+        assertEquals(acceleration.getDisplayName(), "Acceleration");
+        assertEquals(acceleration.getDisplayableValue(), "[Acceleration]");
+        assertEquals(acceleration.getAcceleration().getEast(), 300, 0.1);
+        assertEquals(acceleration.getAcceleration().getNorth(), 200, 0.1);
+        assertEquals(acceleration.getAcceleration().getUp(), 100, 0.1);
+        assertNull(acceleration.getAcceleration().getSigEast());
+        assertNull(acceleration.getAcceleration().getSigNorth());
+        assertNull(acceleration.getAcceleration().getSigUp());
+        assertNull(acceleration.getAcceleration().getRhoEastNorth());
+        assertNull(acceleration.getAcceleration().getRhoEastUp());
+        assertNull(acceleration.getAcceleration().getRhoNorthUp());
+        assertEquals(acceleration.getBytes(), accelerationBytesFromLegacyBytes);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTrackerLS.createValue(VTrackerMetadataKey.acceleration, accelerationBytes);
@@ -132,6 +236,51 @@ public class AccelerationTest {
     }
 
     @Test
+    public void testFactoryWithExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTrackerLS.createValue(
+                        VTrackerMetadataKey.acceleration, accelerationBytes, EncodingMode.IMAPB);
+        assertTrue(value instanceof Acceleration);
+        Acceleration acceleration = (Acceleration) value;
+        assertEquals(acceleration.getBytes(), accelerationBytes);
+        assertEquals(acceleration.getAcceleration().getEast(), 300, 0.1);
+        assertEquals(acceleration.getAcceleration().getNorth(), 200, 0.1);
+        assertEquals(acceleration.getAcceleration().getUp(), 100, 0.1);
+        assertNull(acceleration.getAcceleration().getSigEast());
+        assertNull(acceleration.getAcceleration().getSigNorth());
+        assertNull(acceleration.getAcceleration().getSigUp());
+        assertNull(acceleration.getAcceleration().getRhoEastNorth());
+        assertNull(acceleration.getAcceleration().getRhoEastUp());
+        assertNull(acceleration.getAcceleration().getRhoNorthUp());
+        assertEquals(acceleration.getDisplayName(), "Acceleration");
+        assertEquals(acceleration.getDisplayableValue(), "[Acceleration]");
+    }
+
+    @Test
+    public void testFactoryWithExplicitEncodingLegacy() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTrackerLS.createValue(
+                        VTrackerMetadataKey.acceleration,
+                        accelerationBytesLegacyForm,
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof Acceleration);
+        Acceleration acceleration = (Acceleration) value;
+        assertEquals(acceleration.getBytes(), accelerationBytesFromLegacyBytes);
+        assertEquals(acceleration.getAcceleration().getEast(), 300, 0.1);
+        assertEquals(acceleration.getAcceleration().getNorth(), 200, 0.1);
+        assertEquals(acceleration.getAcceleration().getUp(), 100, 0.1);
+        assertNull(acceleration.getAcceleration().getSigEast());
+        assertNull(acceleration.getAcceleration().getSigNorth());
+        assertNull(acceleration.getAcceleration().getSigUp());
+        assertNull(acceleration.getAcceleration().getRhoEastNorth());
+        assertNull(acceleration.getAcceleration().getRhoEastUp());
+        assertNull(acceleration.getAcceleration().getRhoNorthUp());
+        assertEquals(acceleration.getDisplayName(), "Acceleration");
+        assertEquals(acceleration.getDisplayableValue(), "[Acceleration]");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactoryWithSigma() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTrackerLS.createValue(
@@ -153,6 +302,53 @@ public class AccelerationTest {
     }
 
     @Test
+    public void testFactoryWithSigmaWithExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTrackerLS.createValue(
+                        VTrackerMetadataKey.acceleration,
+                        accelerationPlusSigmaBytes,
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof Acceleration);
+        Acceleration acceleration = (Acceleration) value;
+        assertEquals(acceleration.getBytes(), accelerationPlusSigmaBytes);
+        assertEquals(acceleration.getAcceleration().getEast(), 300, 0.1);
+        assertEquals(acceleration.getAcceleration().getNorth(), 200, 0.1);
+        assertEquals(acceleration.getAcceleration().getUp(), 100, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigEast(), 300.0, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigNorth(), 200.0, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigUp(), 100.0, 0.1);
+        assertNull(acceleration.getAcceleration().getRhoEastNorth());
+        assertNull(acceleration.getAcceleration().getRhoEastUp());
+        assertNull(acceleration.getAcceleration().getRhoNorthUp());
+        assertEquals(acceleration.getDisplayName(), "Acceleration");
+        assertEquals(acceleration.getDisplayableValue(), "[Acceleration]");
+    }
+
+    @Test
+    public void testFactoryWithSigmaWithExplicitEncodingLegacy() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTrackerLS.createValue(
+                        VTrackerMetadataKey.acceleration,
+                        accelerationPlusSigmaBytesLegacyForm,
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof Acceleration);
+        Acceleration acceleration = (Acceleration) value;
+        assertEquals(acceleration.getBytes(), accelerationPlusSigmaBytesFromLegacyBytes);
+        assertEquals(acceleration.getAcceleration().getEast(), 300, 0.1);
+        assertEquals(acceleration.getAcceleration().getNorth(), 200, 0.1);
+        assertEquals(acceleration.getAcceleration().getUp(), 100, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigEast(), 300.0, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigNorth(), 200.0, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigUp(), 100.0, 0.1);
+        assertNull(acceleration.getAcceleration().getRhoEastNorth());
+        assertNull(acceleration.getAcceleration().getRhoEastUp());
+        assertNull(acceleration.getAcceleration().getRhoNorthUp());
+        assertEquals(acceleration.getDisplayName(), "Acceleration");
+        assertEquals(acceleration.getDisplayableValue(), "[Acceleration]");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactoryWithSigmaAndRho() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTrackerLS.createValue(
@@ -173,9 +369,60 @@ public class AccelerationTest {
         assertEquals(acceleration.getDisplayableValue(), "[Acceleration]");
     }
 
+    @Test
+    public void testFactoryWithSigmaAndRhoWithExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTrackerLS.createValue(
+                        VTrackerMetadataKey.acceleration,
+                        accelerationPlusSigmaAndRhoBytes,
+                        EncodingMode.IMAPB);
+        assertTrue(value instanceof Acceleration);
+        Acceleration acceleration = (Acceleration) value;
+        assertEquals(acceleration.getBytes(), accelerationPlusSigmaAndRhoBytes);
+        assertEquals(acceleration.getAcceleration().getEast(), 300, 0.1);
+        assertEquals(acceleration.getAcceleration().getNorth(), 200, 0.1);
+        assertEquals(acceleration.getAcceleration().getUp(), 100, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigEast(), 300.0, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigNorth(), 200.0, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigUp(), 100.0, 0.1);
+        assertEquals(acceleration.getAcceleration().getRhoEastNorth(), 0.75, 0.01);
+        assertEquals(acceleration.getAcceleration().getRhoEastUp(), 0.50, 0.01);
+        assertEquals(acceleration.getAcceleration().getRhoNorthUp(), 0.25, 0.01);
+        assertEquals(acceleration.getDisplayName(), "Acceleration");
+        assertEquals(acceleration.getDisplayableValue(), "[Acceleration]");
+    }
+
+    @Test
+    public void testFactoryWithSigmaAndRhoWithExplicitEncodingLegacy() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTrackerLS.createValue(
+                        VTrackerMetadataKey.acceleration,
+                        accelerationPlusSigmaAndRhoBytesLegacyForm,
+                        EncodingMode.LEGACY);
+        assertTrue(value instanceof Acceleration);
+        Acceleration acceleration = (Acceleration) value;
+        assertEquals(acceleration.getBytes(), accelerationPlusSigmaAndRhoBytesFromLegacyBytes);
+        assertEquals(acceleration.getAcceleration().getEast(), 300, 0.1);
+        assertEquals(acceleration.getAcceleration().getNorth(), 200, 0.1);
+        assertEquals(acceleration.getAcceleration().getUp(), 100, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigEast(), 300.0, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigNorth(), 200.0, 0.1);
+        assertEquals(acceleration.getAcceleration().getSigUp(), 100.0, 0.1);
+        assertEquals(acceleration.getAcceleration().getRhoEastNorth(), 0.75, 0.01);
+        assertEquals(acceleration.getAcceleration().getRhoEastUp(), 0.50, 0.01);
+        assertEquals(acceleration.getAcceleration().getRhoNorthUp(), 0.25, 0.01);
+        assertEquals(acceleration.getDisplayName(), "Acceleration");
+        assertEquals(acceleration.getDisplayableValue(), "[Acceleration]");
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() {
-        new Acceleration(new byte[] {0x01, 0x02, 0x03});
+        new Acceleration(new byte[] {0x01, 0x02, 0x03}, EncodingMode.IMAPB);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLengthLegacy() {
+        new Acceleration(new byte[] {0x01, 0x02, 0x03}, EncodingMode.LEGACY);
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/AlgorithmTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/AlgorithmTest.java
@@ -2,6 +2,7 @@ package org.jmisb.api.klv.st0903.vtracker;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.VmtiTextString;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -27,7 +28,8 @@ public class AlgorithmTest {
     @Test
     public void testFactoryAlgorithm() throws KlvParseException {
         byte[] bytes = new byte[] {0x74, 0x65, 0x73, 0x74};
-        IVmtiMetadataValue v = VTrackerLS.createValue(VTrackerMetadataKey.algorithm, bytes);
+        IVmtiMetadataValue v =
+                VTrackerLS.createValue(VTrackerMetadataKey.algorithm, bytes, EncodingMode.IMAPB);
         Assert.assertTrue(v instanceof VmtiTextString);
         VmtiTextString string = (VmtiTextString) v;
         Assert.assertEquals(string.getDisplayName(), VmtiTextString.ALGORITHM);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/BoundarySeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/BoundarySeriesTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.LocationPack;
 import org.testng.annotations.Test;
 
@@ -39,15 +40,33 @@ public class BoundarySeriesTest {
             };
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() throws KlvParseException {
         BoundarySeries boundarySeries = new BoundarySeries(bytesTwoLocations);
         verifyTwoLocations(boundarySeries);
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() throws KlvParseException {
+        BoundarySeries boundarySeries = new BoundarySeries(bytesTwoLocations, EncodingMode.IMAPB);
+        verifyTwoLocations(boundarySeries);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTrackerLS.createValue(VTrackerMetadataKey.boundarySeries, bytesTwoLocations);
+        assertTrue(value instanceof BoundarySeries);
+        BoundarySeries targetBoundarySeries = (BoundarySeries) value;
+        verifyTwoLocations(targetBoundarySeries);
+    }
+
+    @Test
+    public void testFactoryEncodedBytesExplicitEncodingIMAP() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTrackerLS.createValue(
+                        VTrackerMetadataKey.boundarySeries, bytesTwoLocations, EncodingMode.IMAPB);
         assertTrue(value instanceof BoundarySeries);
         BoundarySeries targetBoundarySeries = (BoundarySeries) value;
         verifyTwoLocations(targetBoundarySeries);
@@ -79,6 +98,6 @@ public class BoundarySeriesTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void badArrayLength() throws KlvParseException {
-        new BoundarySeries(new byte[] {0x01, 0x02, 0x03});
+        new BoundarySeries(new byte[] {0x01, 0x02, 0x03}, EncodingMode.IMAPB);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/ConfidenceTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/ConfidenceTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Confidence (VTracker LS Tag 7) */
@@ -30,7 +31,10 @@ public class ConfidenceTest {
     @Test
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
-                VTrackerLS.createValue(VTrackerMetadataKey.confidence, new byte[] {(byte) 0x32});
+                VTrackerLS.createValue(
+                        VTrackerMetadataKey.confidence,
+                        new byte[] {(byte) 0x32},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TrackConfidence);
         TrackConfidence confidence = (TrackConfidence) value;
         assertEquals(confidence.getBytes(), new byte[] {(byte) 0x32});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/DetectionStatusTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/DetectionStatusTest.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.assertTrue;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -84,7 +85,9 @@ public class DetectionStatusTest {
     @Test
     public void testFactory() throws KlvParseException {
         byte[] bytes = new byte[] {(byte) 0x00};
-        IVmtiMetadataValue v = VTrackerLS.createValue(VTrackerMetadataKey.detectionStatus, bytes);
+        IVmtiMetadataValue v =
+                VTrackerLS.createValue(
+                        VTrackerMetadataKey.detectionStatus, bytes, EncodingMode.IMAPB);
         Assert.assertEquals(v.getDisplayName(), "Detection Status");
         Assert.assertTrue(v instanceof DetectionStatus);
         DetectionStatus detectionStatus = (DetectionStatus) v;
@@ -94,7 +97,7 @@ public class DetectionStatusTest {
         Assert.assertEquals(detectionStatus, DetectionStatus.INACTIVE);
 
         bytes = new byte[] {(byte) 0x01};
-        v = VTrackerLS.createValue(VTrackerMetadataKey.detectionStatus, bytes);
+        v = VTrackerLS.createValue(VTrackerMetadataKey.detectionStatus, bytes, EncodingMode.IMAPB);
         Assert.assertEquals(v.getDisplayName(), "Detection Status");
         Assert.assertTrue(v instanceof DetectionStatus);
         detectionStatus = (DetectionStatus) v;
@@ -104,7 +107,7 @@ public class DetectionStatusTest {
         Assert.assertEquals(detectionStatus, DetectionStatus.ACTIVE);
 
         bytes = new byte[] {(byte) 0x02};
-        v = VTrackerLS.createValue(VTrackerMetadataKey.detectionStatus, bytes);
+        v = VTrackerLS.createValue(VTrackerMetadataKey.detectionStatus, bytes, EncodingMode.IMAPB);
         Assert.assertTrue(v instanceof DetectionStatus);
         Assert.assertEquals(v.getDisplayName(), "Detection Status");
         detectionStatus = (DetectionStatus) v;
@@ -114,7 +117,7 @@ public class DetectionStatusTest {
         Assert.assertEquals(detectionStatus, DetectionStatus.DROPPED);
 
         bytes = new byte[] {(byte) 0x03};
-        v = VTrackerLS.createValue(VTrackerMetadataKey.detectionStatus, bytes);
+        v = VTrackerLS.createValue(VTrackerMetadataKey.detectionStatus, bytes, EncodingMode.IMAPB);
         Assert.assertTrue(v instanceof DetectionStatus);
         Assert.assertEquals(v.getDisplayName(), "Detection Status");
         detectionStatus = (DetectionStatus) v;

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/EndTimeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/EndTimeTest.java
@@ -8,6 +8,7 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.*;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -74,7 +75,8 @@ public class EndTimeTest {
                     (byte) 0xCE,
                     (byte) 0x40
                 };
-        IVmtiMetadataValue v = VTrackerLS.createValue(VTrackerMetadataKey.endTime, bytes);
+        IVmtiMetadataValue v =
+                VTrackerLS.createValue(VTrackerMetadataKey.endTime, bytes, EncodingMode.IMAPB);
         Assert.assertTrue(v instanceof EndTime);
         Assert.assertEquals(v.getDisplayName(), "End Time");
         EndTime pts = (EndTime) v;

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/NumTrackPointsTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/NumTrackPointsTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.*;
 
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for Number of Track Points (VTracker LS Tag 8) */
@@ -49,7 +50,9 @@ public class NumTrackPointsTest {
     public void testFactory() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTrackerLS.createValue(
-                        VTrackerMetadataKey.numTrackPoints, new byte[] {(byte) 0x1B});
+                        VTrackerMetadataKey.numTrackPoints,
+                        new byte[] {(byte) 0x1B},
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof NumTrackPoints);
         NumTrackPoints num = (NumTrackPoints) value;
         assertEquals(num.getBytes(), new byte[] {(byte) 0x1B});

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/StartTimeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/StartTimeTest.java
@@ -8,6 +8,7 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.*;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -74,7 +75,8 @@ public class StartTimeTest {
                     (byte) 0xCE,
                     (byte) 0x40
                 };
-        IVmtiMetadataValue v = VTrackerLS.createValue(VTrackerMetadataKey.startTime, bytes);
+        IVmtiMetadataValue v =
+                VTrackerLS.createValue(VTrackerMetadataKey.startTime, bytes, EncodingMode.IMAPB);
         Assert.assertTrue(v instanceof StartTime);
         Assert.assertEquals(v.getDisplayName(), "Start Time");
         StartTime pts = (StartTime) v;

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/TrackHistorySeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/TrackHistorySeriesTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.shared.LocationPack;
 import org.testng.annotations.Test;
 
@@ -40,15 +41,36 @@ public class TrackHistorySeriesTest {
             };
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testConstructFromEncodedBytes() throws KlvParseException {
         TrackHistorySeries trackHistorySeries = new TrackHistorySeries(bytesTwoLocations);
         verifyTwoLocations(trackHistorySeries);
     }
 
     @Test
+    public void testConstructFromEncodedBytesExplicitEncodingIMAP() throws KlvParseException {
+        TrackHistorySeries trackHistorySeries =
+                new TrackHistorySeries(bytesTwoLocations, EncodingMode.IMAPB);
+        verifyTwoLocations(trackHistorySeries);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void testFactoryEncodedBytes() throws KlvParseException {
         IVmtiMetadataValue value =
                 VTrackerLS.createValue(VTrackerMetadataKey.trackHistorySeries, bytesTwoLocations);
+        assertTrue(value instanceof TrackHistorySeries);
+        TrackHistorySeries targetTrackHistorySeries = (TrackHistorySeries) value;
+        verifyTwoLocations(targetTrackHistorySeries);
+    }
+
+    @Test
+    public void testFactoryEncodedBytesExplicitEncodingIMAPB() throws KlvParseException {
+        IVmtiMetadataValue value =
+                VTrackerLS.createValue(
+                        VTrackerMetadataKey.trackHistorySeries,
+                        bytesTwoLocations,
+                        EncodingMode.IMAPB);
         assertTrue(value instanceof TrackHistorySeries);
         TrackHistorySeries targetTrackHistorySeries = (TrackHistorySeries) value;
         verifyTwoLocations(targetTrackHistorySeries);
@@ -79,7 +101,18 @@ public class TrackHistorySeriesTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
+    @SuppressWarnings("deprecation")
     public void badArrayLength() throws KlvParseException {
         new TrackHistorySeries(new byte[] {0x01, 0x02, 0x03});
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLengthIMAP() throws KlvParseException {
+        new TrackHistorySeries(new byte[] {0x01, 0x02, 0x03}, EncodingMode.IMAPB);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void badArrayLengthLegacy() throws KlvParseException {
+        new TrackHistorySeries(new byte[] {0x01, 0x02, 0x03}, EncodingMode.LEGACY);
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/TrackIdTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/TrackIdTest.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0903.vtracker;
 import java.util.UUID;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -39,7 +40,8 @@ public class TrackIdTest {
 
     @Test
     public void testFactoryAlgorithm() throws KlvParseException {
-        IVmtiMetadataValue v = VTrackerLS.createValue(VTrackerMetadataKey.trackId, bytes);
+        IVmtiMetadataValue v =
+                VTrackerLS.createValue(VTrackerMetadataKey.trackId, bytes, EncodingMode.IMAPB);
         Assert.assertTrue(v instanceof TrackId);
         TrackId id = (TrackId) v;
         Assert.assertEquals(id.getDisplayName(), "Track ID");

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLSTest.java
@@ -6,6 +6,7 @@ import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.LoggerChecks;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.AlgorithmId;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.testng.annotations.Test;
 
 /** Tests for the ST0903 VTracker LS. */
@@ -18,15 +19,31 @@ public class VTrackerLSTest extends LoggerChecks {
     public void createUnknownTag() throws KlvParseException {
         final byte[] bytes = new byte[] {0x6A, 0x70};
         this.verifyNoLoggerMessages();
-        IVmtiMetadataValue value = VTrackerLS.createValue(VTrackerMetadataKey.Undefined, bytes);
+        IVmtiMetadataValue value =
+                VTrackerLS.createValue(VTrackerMetadataKey.Undefined, bytes, EncodingMode.IMAPB);
         this.verifySingleLoggerMessage("Unrecognized VTracker tag: Undefined");
         assertNull(value);
     }
 
     @Test
+    public void createUnknownTagLegacy() throws KlvParseException {
+        final byte[] bytes = new byte[] {0x6A, 0x70};
+        this.verifyNoLoggerMessages();
+        IVmtiMetadataValue value =
+                VTrackerLS.createValue(VTrackerMetadataKey.Undefined, bytes, EncodingMode.LEGACY);
+        this.verifySingleLoggerMessage("Unrecognized VTracker tag: Undefined");
+        assertNull(value);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
     public void parseAlgorithmId() throws KlvParseException {
         final byte[] bytes = new byte[] {0x0C, 0x01, 0x03};
         VTrackerLS localSet = new VTrackerLS(bytes);
+        checkLocalSetWithAlgorithmId(localSet);
+    }
+
+    private void checkLocalSetWithAlgorithmId(VTrackerLS localSet) {
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);
         assertTrue(localSet.getTags().contains(VTrackerMetadataKey.algorithmId));
@@ -37,5 +54,19 @@ public class VTrackerLSTest extends LoggerChecks {
         AlgorithmId id = (AlgorithmId) localSet.getField(VTrackerMetadataKey.algorithmId);
         assertEquals(id.getValue(), 3);
         assertEquals(id.getBytes(), new byte[] {0x03});
+    }
+
+    @Test
+    public void parseAlgorithmIdLegacyModeSelected() throws KlvParseException {
+        final byte[] bytes = new byte[] {0x0C, 0x01, 0x03};
+        VTrackerLS localSet = new VTrackerLS(bytes, EncodingMode.LEGACY);
+        checkLocalSetWithAlgorithmId(localSet);
+    }
+
+    @Test
+    public void parseAlgorithmIdIMAPBModeSelected() throws KlvParseException {
+        final byte[] bytes = new byte[] {0x0C, 0x01, 0x03};
+        VTrackerLS localSet = new VTrackerLS(bytes, EncodingMode.IMAPB);
+        checkLocalSetWithAlgorithmId(localSet);
     }
 }

--- a/api/src/test/java/org/jmisb/api/video/VideoSystemTest.java
+++ b/api/src/test/java/org/jmisb/api/video/VideoSystemTest.java
@@ -6,11 +6,13 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class VideoSystemTest extends LoggerChecks {
+    @SuppressWarnings("deprecation")
     public VideoSystemTest() {
         super(VideoSystem.class);
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void createStream() {
         try (IVideoStreamInput stream = VideoSystem.createInputStream()) {
             Assert.assertFalse(stream.isOpen());

--- a/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
+++ b/core/src/main/java/org/jmisb/core/klv/PrimitiveConverter.java
@@ -261,6 +261,23 @@ public class PrimitiveConverter {
     }
 
     /**
+     * Convert a variable length byte array to an unsigned 16-bit integer (int with range of uint16)
+     *
+     * @param bytes The array of length 1-2
+     * @return The unsigned 16-bit integer as a int
+     */
+    public static int variableBytesToUint16(byte[] bytes) {
+        switch (bytes.length) {
+            case 2:
+                return PrimitiveConverter.toUint16(bytes);
+            case 1:
+                return PrimitiveConverter.toUint8(bytes);
+            default:
+                throw new IllegalArgumentException("Invalid buffer length");
+        }
+    }
+
+    /**
      * Convert an unsigned 32-bit unsigned integer (long with range of uint32) to a byte array
      *
      * @param val The unsigned 32-bit integer as long

--- a/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/PrimitiveConverterTest.java
@@ -250,6 +250,25 @@ public class PrimitiveConverterTest {
     }
 
     @Test
+    public void testVariableBytesToUint16_1() {
+        int intVal = PrimitiveConverter.variableBytesToUint16(new byte[] {(byte) 0xff});
+        Assert.assertEquals(intVal, Math.pow(2, 8) - 1);
+    }
+
+    @Test
+    public void testVariableBytesToUint16_2() {
+        int intVal =
+                PrimitiveConverter.variableBytesToUint16(new byte[] {(byte) 0xff, (byte) 0xff});
+        Assert.assertEquals(intVal, Math.pow(2, 16) - 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testVariableBytesToUint16BadLength() {
+        PrimitiveConverter.variableBytesToUint16(
+                new byte[] {(byte) 0xff, (byte) 0xff, (byte) 0x00});
+    }
+
+    @Test
     public void checkUintInternalVsStandard_1() {
         byte[] bytes = new byte[] {(byte) 0x9c};
         long standard = PrimitiveConverter.toUint8(bytes);
@@ -1272,6 +1291,7 @@ public class PrimitiveConverterTest {
                 });
     }
 
+    @Test
     public void testToUint24() {
         long val = PrimitiveConverter.toUint24(new byte[] {0x00, 0x00, 0x00});
         Assert.assertEquals(val, 0);


### PR DESCRIPTION
## Motivation and Context
The current ST0903 (VMTI) implementation only supports ST0903.4 and later. The reason is that ST0903.3 and prior used a different encoding for floating point values (basically a fairly direct integer to float map in earlier versions, and IMAPB in ST0903.4 and later). That causes exceptions in some cases (because lengths are changed), and bad values in most cases.

## Description
This adds support for parsing the older floating point format, based on version specified. Its a bit involved because the top level VMTI local set is the only place that has the version, but most of the floating point values are nested within other local sets / series.
I've maintained backwards compatibility and added deprecation markings on the old methods / constructors that only work on ST0903.4+.
There is no support for generating the older formats. That wouldn't be that hard to do, just (a lot more) unit testing.

## How Has This Been Tested?
Unit tests.
Ran a couple of MISB FLI files in the viewer (including the one with with EG0903.0 data), and they don't throw exceptions. Ran a couple of other files in viewer. Mostly looks OK. I expect to do more testing (and possibly fixing) when I do the nest view merge work. That should make it easier to check actual values.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

