### PR TITLE
video: fix javadoc style issues

### DIFF
--- a/api/checkstyle_suppressions.xml
+++ b/api/checkstyle_suppressions.xml
@@ -7,5 +7,4 @@
     <suppress files="[\\/]api[\\/]klv[\\/]eg0104[\\/]" checks="[a-zA-Z0-9]*"/>
     <suppress files="[\\/]api[\\/]klv[\\/]st0601[\\/]" checks="[a-zA-Z0-9]*"/>
     <suppress files="[\\/]api[\\/]klv[\\/]st0805[\\/]" checks="[a-zA-Z0-9]*"/>
-    <suppress files="[\\/]api[\\/]video[\\/]" checks="[a-zA-Z0-9]*"/>
 </suppressions>

--- a/api/src/main/java/org/jmisb/api/video/CodecUtils.java
+++ b/api/src/main/java/org/jmisb/api/video/CodecUtils.java
@@ -2,10 +2,10 @@ package org.jmisb.api.video;
 
 import org.bytedeco.ffmpeg.avcodec.AVCodecContext;
 
-/** Utility methods for encoding/decoding */
+/** Utility methods for encoding/decoding. */
 public class CodecUtils {
     /**
-     * Get codec parameters as a string
+     * Get codec parameters as a string.
      *
      * @param context The AVCodecContext
      * @return String containing codec parameters

--- a/api/src/main/java/org/jmisb/api/video/DemuxReturnValue.java
+++ b/api/src/main/java/org/jmisb/api/video/DemuxReturnValue.java
@@ -6,7 +6,7 @@ enum DemuxReturnValue {
     SUCCESS,
     /** End of file. */
     EOF,
-    /** Operation needs to be tried again */
+    /** Operation needs to be tried again. */
     EAGAIN,
     /** Some other failure. */
     ERROR

--- a/api/src/main/java/org/jmisb/api/video/Demuxer.java
+++ b/api/src/main/java/org/jmisb/api/video/Demuxer.java
@@ -4,7 +4,7 @@ import org.bytedeco.ffmpeg.avcodec.AVPacket;
 import org.bytedeco.ffmpeg.avformat.AVFormatContext;
 import org.jmisb.core.video.FfmpegUtils;
 
-/** Abstract base class for Demuxers */
+/** Abstract base class for Demuxers. */
 abstract class Demuxer extends ProcessingThread {
     final AVFormatContext avFormatContext;
     VideoDecodeThread videoDecodeThread;

--- a/api/src/main/java/org/jmisb/api/video/DemuxerUtils.java
+++ b/api/src/main/java/org/jmisb/api/video/DemuxerUtils.java
@@ -15,14 +15,14 @@ import org.jmisb.core.video.FfmpegUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Utility methods for demuxing */
+/** Utility methods for demuxing. */
 class DemuxerUtils {
     private static Logger logger = LoggerFactory.getLogger(DemuxerUtils.class);
 
     private DemuxerUtils() {}
 
     /**
-     * Create a VideoDecodeThread
+     * Create a VideoDecodeThread.
      *
      * @param videoStreamIndex Index of the video stream
      * @param avFormatContext The format context
@@ -47,7 +47,7 @@ class DemuxerUtils {
     }
 
     /**
-     * Read the next packet
+     * Read the next packet.
      *
      * @param avFormatContext The format context
      * @param packet The packet
@@ -71,7 +71,7 @@ class DemuxerUtils {
     }
 
     /**
-     * Seek to the specified position
+     * Seek to the specified position.
      *
      * @param avFormatContext The format context
      * @param seekPosition The position

--- a/api/src/main/java/org/jmisb/api/video/FfmpegLog.java
+++ b/api/src/main/java/org/jmisb/api/video/FfmpegLog.java
@@ -14,7 +14,7 @@ import org.bytedeco.javacpp.BytePointer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Singleton class to redirect FFmpeg's logging to SLF4J */
+/** Singleton class to redirect FFmpeg's logging to SLF4J. */
 class FfmpegLog extends LogCallback {
     private static final Logger logger = LoggerFactory.getLogger(FfmpegLog.class);
     static final FfmpegLog INSTANCE = new FfmpegLog();
@@ -46,7 +46,7 @@ class FfmpegLog extends LogCallback {
     }
 
     /**
-     * Adjust the FFmpeg logging level based on heuristics
+     * Adjust the FFmpeg logging level based on heuristics.
      *
      * @param origLevel The original FFmpeg log level
      * @param message The message string

--- a/api/src/main/java/org/jmisb/api/video/FileDemuxer.java
+++ b/api/src/main/java/org/jmisb/api/video/FileDemuxer.java
@@ -9,7 +9,7 @@ import org.jmisb.core.video.FfmpegUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Demux video/metadata contained in a file */
+/** Demux video/metadata contained in a file. */
 class FileDemuxer extends Demuxer {
     private static Logger logger = LoggerFactory.getLogger(FileDemuxer.class);
     private final VideoInput inputStream;
@@ -139,7 +139,7 @@ class FileDemuxer extends Demuxer {
     }
 
     /**
-     * Get the video frame rate
+     * Get the video frame rate.
      *
      * @return The video frame rate, in frames/second
      */

--- a/api/src/main/java/org/jmisb/api/video/IMetadataListener.java
+++ b/api/src/main/java/org/jmisb/api/video/IMetadataListener.java
@@ -1,9 +1,9 @@
 package org.jmisb.api.video;
 
-/** Interface for metadata arrival notifications */
+/** Interface for metadata arrival notifications. */
 public interface IMetadataListener {
     /**
-     * Notification that new metadata has been received
+     * Notification that new metadata has been received.
      *
      * @param metadataFrame The metadata frame
      */

--- a/api/src/main/java/org/jmisb/api/video/IVideoFileInput.java
+++ b/api/src/main/java/org/jmisb/api/video/IVideoFileInput.java
@@ -1,19 +1,19 @@
 package org.jmisb.api.video;
 
-/** Interface for reading video/metadata from a file */
+/** Interface for reading video/metadata from a file. */
 public interface IVideoFileInput extends IVideoInput {
-    /** Play the video file */
+    /** Play the video file. */
     void play();
 
     /**
-     * Check if the video file is playing
+     * Check if the video file is playing.
      *
      * @return True if currently playing
      */
     boolean isPlaying();
 
     /**
-     * Set the playback speed
+     * Set the playback speed.
      *
      * @param multiplier The rate multiplier (e.g., 2.0 for 2x rate); Double.MAX_VALUE to read file
      *     as fast as possible
@@ -21,38 +21,38 @@ public interface IVideoFileInput extends IVideoInput {
     void setPlaybackSpeed(double multiplier);
 
     /**
-     * Get the current playback speed
+     * Get the current playback speed.
      *
      * @return The rate multiplier (e.g., 2.0 for 2x rate)
      */
     double getPlaybackSpeed();
 
-    /** Pause video file playback */
+    /** Pause video file playback. */
     void pause();
 
     /**
-     * Get the total video file duration
+     * Get the total video file duration.
      *
      * @return The duration, in seconds
      */
     double getDuration();
 
     /**
-     * Get the current playback position
+     * Get the current playback position.
      *
      * @return The current position, in seconds
      */
     double getPosition();
 
     /**
-     * Seek to a specified position in the file
+     * Seek to a specified position in the file.
      *
      * @param position The desired position, in seconds
      */
     void seek(double position);
 
     /**
-     * Get the number of video frames
+     * Get the number of video frames.
      *
      * @return The total number of video frames in the file
      */

--- a/api/src/main/java/org/jmisb/api/video/IVideoFileOutput.java
+++ b/api/src/main/java/org/jmisb/api/video/IVideoFileOutput.java
@@ -2,10 +2,10 @@ package org.jmisb.api.video;
 
 import java.io.IOException;
 
-/** Interface for writing video/metadata to a file */
+/** Interface for writing video/metadata to a file. */
 public interface IVideoFileOutput extends AutoCloseable {
     /**
-     * Open a new file for writing
+     * Open a new file for writing.
      *
      * @param filename The file name
      * @throws IOException if the file could not be opened
@@ -13,14 +13,14 @@ public interface IVideoFileOutput extends AutoCloseable {
     void open(String filename) throws IOException;
 
     /**
-     * Check if a file is open
+     * Check if a file is open.
      *
      * @return True if a file is open
      */
     boolean isOpen();
 
     /**
-     * Close the file
+     * Close the file.
      *
      * @throws IOException if an error occurs while closing the file
      */
@@ -28,7 +28,7 @@ public interface IVideoFileOutput extends AutoCloseable {
     void close() throws IOException;
 
     /**
-     * Append a {@link VideoFrame} to the file
+     * Append a {@link VideoFrame} to the file.
      *
      * @param frame The video frame to add
      * @throws IllegalArgumentException if the input frame is invalid
@@ -37,7 +37,7 @@ public interface IVideoFileOutput extends AutoCloseable {
     void addVideoFrame(VideoFrame frame) throws IOException;
 
     /**
-     * Append a {@link MetadataFrame} to the file
+     * Append a {@link MetadataFrame} to the file.
      *
      * @param frame The metadata frame to add
      * @throws IOException if the file could not be written

--- a/api/src/main/java/org/jmisb/api/video/IVideoInput.java
+++ b/api/src/main/java/org/jmisb/api/video/IVideoInput.java
@@ -3,10 +3,10 @@ package org.jmisb.api.video;
 import java.io.IOException;
 import java.util.List;
 
-/** Base interface for reading video and metadata */
+/** Base interface for reading video and metadata. */
 public interface IVideoInput extends AutoCloseable {
     /**
-     * Open video for reading
+     * Open video for reading.
      *
      * @param url URL of the video to open
      * @throws IOException if the video was not successfully opened
@@ -14,14 +14,14 @@ public interface IVideoInput extends AutoCloseable {
     void open(String url) throws IOException;
 
     /**
-     * Check if the video is open
+     * Check if the video is open.
      *
      * @return True if the video is open
      */
     boolean isOpen();
 
     /**
-     * Close the video
+     * Close the video.
      *
      * @throws IOException if an error occurs while closing the file
      */
@@ -29,42 +29,42 @@ public interface IVideoInput extends AutoCloseable {
     void close() throws IOException;
 
     /**
-     * Get the URL
+     * Get the URL.
      *
      * @return URL string
      */
     String getUrl();
 
     /**
-     * Get packetized elementary stream (PES) info
+     * Get packetized elementary stream (PES) info.
      *
      * @return A list containing {@link PesInfo} for each elementary stream
      */
     List<PesInfo> getPesInfo();
 
     /**
-     * Add a video frame listener
+     * Add a video frame listener.
      *
      * @param listener Listener to add
      */
     void addFrameListener(IVideoListener listener);
 
     /**
-     * Remove a video frame listener
+     * Remove a video frame listener.
      *
      * @param listener Listener to remove
      */
     void removeFrameListener(IVideoListener listener);
 
     /**
-     * Add a metadata listener
+     * Add a metadata listener.
      *
      * @param listener Listener to add
      */
     void addMetadataListener(IMetadataListener listener);
 
     /**
-     * Remove a metadata listener
+     * Remove a metadata listener.
      *
      * @param listener Listener to remove
      */

--- a/api/src/main/java/org/jmisb/api/video/IVideoListener.java
+++ b/api/src/main/java/org/jmisb/api/video/IVideoListener.java
@@ -1,9 +1,9 @@
 package org.jmisb.api.video;
 
-/** Interface for video frame arrival notifications */
+/** Interface for video frame arrival notifications. */
 public interface IVideoListener {
     /**
-     * Notification that a video frame has been received
+     * Notification that a video frame has been received.
      *
      * @param image The video frame
      */

--- a/api/src/main/java/org/jmisb/api/video/IVideoStreamInput.java
+++ b/api/src/main/java/org/jmisb/api/video/IVideoStreamInput.java
@@ -1,9 +1,9 @@
 package org.jmisb.api.video;
 
-/** Interface for reading video/metadata from a network stream */
+/** Interface for reading video/metadata from a network stream. */
 public interface IVideoStreamInput extends IVideoInput {
     /**
-     * Get the input stream options
+     * Get the input stream options.
      *
      * @return The options
      */

--- a/api/src/main/java/org/jmisb/api/video/IVideoStreamOutput.java
+++ b/api/src/main/java/org/jmisb/api/video/IVideoStreamOutput.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import org.jmisb.api.common.Beta;
 
 /**
- * Interface for writing video/metadata to a UDP/IP network stream
+ * Interface for writing video/metadata to a UDP/IP network stream.
  *
  * <p>It is the caller's responsibility to enqueue frames at a rate on average equal to the frame
  * rate specified in the stream's {@link VideoOutputOptions}, and set the PTS values of the frames
@@ -14,7 +14,7 @@ import org.jmisb.api.common.Beta;
 @Beta
 public interface IVideoStreamOutput extends AutoCloseable {
     /**
-     * Open a stream for writing
+     * Open a stream for writing.
      *
      * <p>The required syntax for the URL is <code>udp://hostname:port</code>.
      *
@@ -25,14 +25,14 @@ public interface IVideoStreamOutput extends AutoCloseable {
     void open(String url) throws IOException;
 
     /**
-     * Check if the stream is open
+     * Check if the stream is open.
      *
      * @return True if the stream is open
      */
     boolean isOpen();
 
     /**
-     * Close the stream
+     * Close the stream.
      *
      * @throws IOException if an error occurs while closing the stream
      */
@@ -40,7 +40,7 @@ public interface IVideoStreamOutput extends AutoCloseable {
     void close() throws IOException;
 
     /**
-     * Queue a {@link VideoFrame} for output
+     * Queue a {@link VideoFrame} for output.
      *
      * @param frame The video frame to send
      * @throws IllegalArgumentException if the input frame is invalid
@@ -49,7 +49,7 @@ public interface IVideoStreamOutput extends AutoCloseable {
     void queueVideoFrame(VideoFrame frame) throws IOException;
 
     /**
-     * Queue a {@link MetadataFrame} for output
+     * Queue a {@link MetadataFrame} for output.
      *
      * <p>Note that metadata frames will be buffered internally based pts values. Queued metadata
      * frames will be sent once a video frame with greater or equal pts has been sent.
@@ -60,7 +60,7 @@ public interface IVideoStreamOutput extends AutoCloseable {
     void queueMetadataFrame(MetadataFrame frame) throws IOException;
 
     /**
-     * Get output statistics
+     * Get output statistics.
      *
      * @return The output statistics
      */

--- a/api/src/main/java/org/jmisb/api/video/MetadataDecodeThread.java
+++ b/api/src/main/java/org/jmisb/api/video/MetadataDecodeThread.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Metadata decoding thread
+ * Metadata decoding thread.
  *
  * <p>This thread decodes KLV metadata and sends {@link IMisbMessage}s up to the {@link VideoInput}.
  */
@@ -34,7 +34,7 @@ class MetadataDecodeThread extends ProcessingThread {
     private BlockingQueue<AVPacket> packetQueue = new LinkedBlockingDeque<>(INPUT_QUEUE_SIZE);
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param inputStream The {@link VideoInput}
      * @param dataStream The metadata stream
@@ -46,7 +46,7 @@ class MetadataDecodeThread extends ProcessingThread {
     }
 
     /**
-     * Enqueue an incoming packet for decoding
+     * Enqueue an incoming packet for decoding.
      *
      * @param packet The packet to queue
      * @return True if the packet was queued, false if the queue is currently full

--- a/api/src/main/java/org/jmisb/api/video/MetadataFrame.java
+++ b/api/src/main/java/org/jmisb/api/video/MetadataFrame.java
@@ -2,13 +2,13 @@ package org.jmisb.api.video;
 
 import org.jmisb.api.klv.IMisbMessage;
 
-/** A timestamped metadata packet containing one {@link IMisbMessage} */
+/** A timestamped metadata packet containing one {@link IMisbMessage}. */
 public class MetadataFrame {
     private final IMisbMessage misbMessage;
     private final double pts;
 
     /**
-     * Create a metadata frame
+     * Create a metadata frame.
      *
      * @param misbMessage The message packet
      * @param pts The presentation timestamp, in seconds
@@ -19,7 +19,7 @@ public class MetadataFrame {
     }
 
     /**
-     * Get the message packet
+     * Get the message packet.
      *
      * @return The message packet
      */
@@ -28,7 +28,7 @@ public class MetadataFrame {
     }
 
     /**
-     * Get the presentation timestamp
+     * Get the presentation timestamp.
      *
      * @return The presentation timestamp, in seconds
      */

--- a/api/src/main/java/org/jmisb/api/video/OutputStatistics.java
+++ b/api/src/main/java/org/jmisb/api/video/OutputStatistics.java
@@ -1,6 +1,6 @@
 package org.jmisb.api.video;
 
-/** Statistics reported by {@link VideoStreamOutput} */
+/** Statistics reported by {@link VideoStreamOutput}. */
 public class OutputStatistics {
     private long numVideoFramesSent;
     private long numVideoFramesQueued;
@@ -10,7 +10,7 @@ public class OutputStatistics {
     private long numMetadataFramesQueued;
 
     /**
-     * Get the total number of video frames sent since opening the stream
+     * Get the total number of video frames sent since opening the stream.
      *
      * @return The total number of video frames
      */
@@ -19,7 +19,7 @@ public class OutputStatistics {
     }
 
     /**
-     * Get the total number of video frames queued since opening the stream
+     * Get the total number of video frames queued since opening the stream.
      *
      * @return The total number of video frames
      */
@@ -28,7 +28,7 @@ public class OutputStatistics {
     }
 
     /**
-     * Get the total number of video frames encoded since opening the stream
+     * Get the total number of video frames encoded since opening the stream.
      *
      * @return The total number of video frames
      */
@@ -37,7 +37,7 @@ public class OutputStatistics {
     }
 
     /**
-     * Get the total number of metadata frames sent since opening the stream
+     * Get the total number of metadata frames sent since opening the stream.
      *
      * @return The total number of metadata frames
      */
@@ -46,7 +46,7 @@ public class OutputStatistics {
     }
 
     /**
-     * Get the total number of metadata frames queued since opening the stream
+     * Get the total number of metadata frames queued since opening the stream.
      *
      * @return The total number of metadata frames
      */
@@ -54,7 +54,7 @@ public class OutputStatistics {
         return numMetadataFramesQueued;
     }
 
-    /** Reset the statistics to zero */
+    /** Reset the statistics to zero. */
     void reset() {
         numVideoFramesSent = 0;
         numVideoFramesQueued = 0;
@@ -62,27 +62,27 @@ public class OutputStatistics {
         numMetadataFramesQueued = 0;
     }
 
-    /** Increment the total number of video frames queued */
+    /** Increment the total number of video frames queued. */
     void videoFrameQueued() {
         numVideoFramesQueued++;
     }
 
-    /** Increment the total number of video frames sent */
+    /** Increment the total number of video frames sent. */
     void videoFrameSent() {
         numVideoFramesSent++;
     }
 
-    /** Increment the total number of frames encoded */
+    /** Increment the total number of frames encoded. */
     void videoFrameEncoded() {
         numVideoFramesEncoded++;
     }
 
-    /** Increment the total number of metadata frames queued */
+    /** Increment the total number of metadata frames queued. */
     void metadataFrameQueued() {
         numMetadataFramesQueued++;
     }
 
-    /** Increment the total number of metadata frames sent */
+    /** Increment the total number of metadata frames sent. */
     void metadataFrameSent() {
         numMetadataFramesSent++;
     }

--- a/api/src/main/java/org/jmisb/api/video/PesInfo.java
+++ b/api/src/main/java/org/jmisb/api/video/PesInfo.java
@@ -2,14 +2,14 @@ package org.jmisb.api.video;
 
 import java.util.List;
 
-/** Packetized Elementary Stream (PES) information */
+/** Packetized Elementary Stream (PES) information. */
 public class PesInfo {
     private final int index;
     private final PesType type;
     private final String codecName;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param index The stream index
      * @param type The type
@@ -22,7 +22,7 @@ public class PesInfo {
     }
 
     /**
-     * Get the stream index
+     * Get the stream index.
      *
      * @return The stream index
      */
@@ -31,7 +31,7 @@ public class PesInfo {
     }
 
     /**
-     * Get the type
+     * Get the type.
      *
      * @return The type
      */
@@ -40,7 +40,7 @@ public class PesInfo {
     }
 
     /**
-     * Get the codec name
+     * Get the codec name.
      *
      * @return The codec name
      */
@@ -49,7 +49,7 @@ public class PesInfo {
     }
 
     /**
-     * Return a JSON string representing the value
+     * Return a JSON string representing the value.
      *
      * @return The JSON string
      */
@@ -71,7 +71,7 @@ public class PesInfo {
     }
 
     /**
-     * Return a JSON string containing a list of PesInfo objects
+     * Return a JSON string containing a list of PesInfo objects.
      *
      * @param list The list
      * @return The JSON string

--- a/api/src/main/java/org/jmisb/api/video/PesType.java
+++ b/api/src/main/java/org/jmisb/api/video/PesType.java
@@ -3,7 +3,7 @@ package org.jmisb.api.video;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Packetized Elementary Stream (PES) type */
+/** Packetized Elementary Stream (PES) type. */
 public enum PesType {
     UNKNOWN(-1),
     VIDEO(0),

--- a/api/src/main/java/org/jmisb/api/video/PesType.java
+++ b/api/src/main/java/org/jmisb/api/video/PesType.java
@@ -3,7 +3,12 @@ package org.jmisb.api.video;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Packetized Elementary Stream (PES) type. */
+/**
+ * Packetized Elementary Stream (PES) type.
+ *
+ * <p>A transport stream can contain different types (kinds) of elementary streams. This enumeration
+ * provides the known PES types.
+ */
 public enum PesType {
     UNKNOWN(-1),
     VIDEO(0),
@@ -26,10 +31,21 @@ public enum PesType {
         code = c;
     }
 
+    /**
+     * Get the identifier code for the given PES type.
+     *
+     * @return PES identifier as an integer value.
+     */
     public int getCode() {
         return code;
     }
 
+    /**
+     * Look up an PES type for a given identifier code.
+     *
+     * @param typeCode the integer PES identifier
+     * @return the corresponding PES type.
+     */
     public static PesType getType(int typeCode) {
         return lookupTable.containsKey(typeCode) ? lookupTable.get(typeCode) : UNKNOWN;
     }

--- a/api/src/main/java/org/jmisb/api/video/ProcessingThread.java
+++ b/api/src/main/java/org/jmisb/api/video/ProcessingThread.java
@@ -2,7 +2,7 @@ package org.jmisb.api.video;
 
 import org.jmisb.core.video.TimingUtils;
 
-/** Thread allowing itself to be paused and unpaused */
+/** Thread allowing itself to be paused and unpaused. */
 class ProcessingThread extends Thread {
     private final Object pauseLock = new Object();
     private boolean shutdown = false;
@@ -10,7 +10,7 @@ class ProcessingThread extends Thread {
     private boolean pauseRequested = false;
 
     /**
-     * Pause if requested and check whether to shut down
+     * Pause if requested and check whether to shut down.
      *
      * @return True if the thread should shut down
      */
@@ -43,7 +43,11 @@ class ProcessingThread extends Thread {
         return shutdown;
     }
 
-    /** Pause the thread. This method blocks until the processing thread is paused. */
+    /**
+     * Pause the thread.
+     *
+     * <p>This method blocks until the processing thread is paused.
+     */
     protected void pause() {
         requestPause();
         while (!isPaused()) {
@@ -55,7 +59,11 @@ class ProcessingThread extends Thread {
         return paused;
     }
 
-    /** Request the thread be paused. This is a non-blocking call. */
+    /**
+     * Request the thread be paused.
+     *
+     * <p>This is a non-blocking call.
+     */
     protected void requestPause() {
         pauseRequested = true;
     }

--- a/api/src/main/java/org/jmisb/api/video/StreamDemuxer.java
+++ b/api/src/main/java/org/jmisb/api/video/StreamDemuxer.java
@@ -8,7 +8,7 @@ import org.bytedeco.ffmpeg.avformat.AVFormatContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Demux video/metadata contained in a network stream */
+/** Demux video/metadata contained in a network stream. */
 class StreamDemuxer extends Demuxer {
     private static Logger logger = LoggerFactory.getLogger(StreamDemuxer.class);
     private final VideoInput inputStream;

--- a/api/src/main/java/org/jmisb/api/video/VideoDecodeThread.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoDecodeThread.java
@@ -39,7 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Video decoding thread
+ * Video decoding thread.
  *
  * <p>This thread buffers and decodes video data, and sends uncompressed images in BGR24 format back
  * up to the {@link VideoInput}.
@@ -52,10 +52,10 @@ class VideoDecodeThread extends ProcessingThread {
     private AVCodecContext codecContext;
     private BlockingQueue<AVPacket> packetQueue = new LinkedBlockingDeque<>(INPUT_QUEUE_SIZE);
 
-    /** Image buffer in native stream format */
+    /** Image buffer in native stream format. */
     private AVFrame nativeFrame;
 
-    /** Image buffer in BGR24 format */
+    /** Image buffer in BGR24 format. */
     private AVFrame bgrFrame;
 
     private final FrameConverter frameConverter = new FrameConverter();
@@ -67,7 +67,7 @@ class VideoDecodeThread extends ProcessingThread {
     }
 
     /**
-     * Enqueue an incoming packet for decoding
+     * Enqueue an incoming packet for decoding.
      *
      * @param packet The packet to queue
      * @return True if the packet was queued, false if the queue is currently full
@@ -80,7 +80,7 @@ class VideoDecodeThread extends ProcessingThread {
         }
     }
 
-    /** Clear the queue of packets to be decoded and flush codec buffers */
+    /** Clear the queue of packets to be decoded and flush codec buffers. */
     public void clear() {
         packetQueue.clear();
         avcodec_flush_buffers(codecContext);

--- a/api/src/main/java/org/jmisb/api/video/VideoFileInput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoFileInput.java
@@ -22,7 +22,7 @@ import org.jmisb.core.video.FfmpegUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Read video/metadata from a file */
+/** Read video/metadata from a file. */
 public class VideoFileInput extends VideoInput implements IVideoFileInput {
     private static final Logger logger = LoggerFactory.getLogger(VideoFileInput.class);
     private final VideoFileInputOptions options;
@@ -41,13 +41,13 @@ public class VideoFileInput extends VideoInput implements IVideoFileInput {
     private double prevVideoPts;
     private long videoDelay;
 
-    /** Construct with default options */
+    /** Construct with default options. */
     public VideoFileInput() {
         this(new VideoFileInputOptions());
     }
 
     /**
-     * Construct with options
+     * Construct with options.
      *
      * @param options Options for video input
      */
@@ -289,7 +289,7 @@ public class VideoFileInput extends VideoInput implements IVideoFileInput {
         }
     }
 
-    /** Stop the demuxer thread */
+    /** Stop the demuxer thread. */
     private void stopFileDemuxer() {
         demuxer.shutdown();
         try {

--- a/api/src/main/java/org/jmisb/api/video/VideoFileInputOptions.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoFileInputOptions.java
@@ -1,17 +1,17 @@
 package org.jmisb.api.video;
 
-/** Options to be specified when opening an input file */
+/** Options to be specified when opening an input file. */
 public class VideoFileInputOptions extends VideoInputOptions {
-    /** Indicates playback will be paused when the file is first opened */
+    /** Indicates playback will be paused when the file is first opened. */
     private boolean initiallyPaused;
 
-    /** Constructor specifying default options */
+    /** Constructor specifying default options. */
     public VideoFileInputOptions() {
         this.initiallyPaused = false;
     }
 
     /**
-     * Constructor specifying custom options
+     * Constructor specifying custom options.
      *
      * @param decodeAudio True to decode audio (currently unsupported)
      * @param decodeMetadata True to decode metadata
@@ -28,7 +28,7 @@ public class VideoFileInputOptions extends VideoInputOptions {
     }
 
     /**
-     * Indicates whether playback will be initially paused
+     * Indicates whether playback will be initially paused.
      *
      * @return True if playback should be initially paused
      */

--- a/api/src/main/java/org/jmisb/api/video/VideoFileOutput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoFileOutput.java
@@ -28,7 +28,7 @@ import org.jmisb.core.video.FfmpegUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Write video/metadata to a file */
+/** Write video/metadata to a file. */
 public class VideoFileOutput extends VideoOutput implements IVideoFileOutput {
     private static Logger logger = LoggerFactory.getLogger(VideoFileOutput.class);
     private String filename;
@@ -36,7 +36,7 @@ public class VideoFileOutput extends VideoOutput implements IVideoFileOutput {
     protected static final byte ASYNC_STREAM_ID = (byte) 0xBD;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param options Options for video output
      */
@@ -150,7 +150,7 @@ public class VideoFileOutput extends VideoOutput implements IVideoFileOutput {
 
     /**
      * Takes all available packets out of the encoder's internal buffer, then writes them to the
-     * output
+     * output.
      *
      * @param eof If true, expect EOF and throw exception if not found
      * @throws IOException if expected EOF packet is not found
@@ -186,7 +186,7 @@ public class VideoFileOutput extends VideoOutput implements IVideoFileOutput {
     }
 
     /**
-     * Write all available data to the output before closing
+     * Write all available data to the output before closing.
      *
      * @throws IOException if the data could not be written
      */

--- a/api/src/main/java/org/jmisb/api/video/VideoFrame.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoFrame.java
@@ -2,13 +2,13 @@ package org.jmisb.api.video;
 
 import java.awt.image.BufferedImage;
 
-/** An uncompressed video frame */
+/** An uncompressed video frame. */
 public class VideoFrame {
     private final BufferedImage bufferedImage;
     private final double pts;
 
     /**
-     * Create a video frame
+     * Create a video frame.
      *
      * @param image The image
      * @param pts The presentation timestamp, in seconds
@@ -19,7 +19,7 @@ public class VideoFrame {
     }
 
     /**
-     * Get the image
+     * Get the image.
      *
      * @return The image
      */
@@ -28,7 +28,7 @@ public class VideoFrame {
     }
 
     /**
-     * Get the presentation timestamp
+     * Get the presentation timestamp.
      *
      * @return The presentation timestamp, in seconds
      */

--- a/api/src/main/java/org/jmisb/api/video/VideoInput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoInput.java
@@ -20,16 +20,16 @@ import org.jmisb.core.video.FfmpegUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Abstract base class for video input */
+/** Abstract base class for video input. */
 public abstract class VideoInput extends VideoIO implements IVideoInput {
     private static Logger logger = LoggerFactory.getLogger(VideoInput.class);
     private Set<IVideoListener> videoListeners = new HashSet<>();
     private Set<IMetadataListener> metadataListeners = new HashSet<>();
 
-    /** Queue of decoded video frames ready to be sent to listeners */
+    /** Queue of decoded video frames ready to be sent to listeners. */
     private BlockingQueue<VideoFrame> decodedVideo = new LinkedBlockingQueue<>(QUEUE_SIZE);
 
-    /** Queue of metadata frames ready to be sent to listeners */
+    /** Queue of metadata frames ready to be sent to listeners. */
     private BlockingQueue<MetadataFrame> decodedMetadata = new LinkedBlockingQueue<>(QUEUE_SIZE);
 
     VideoNotifier videoNotifier;
@@ -50,14 +50,14 @@ public abstract class VideoInput extends VideoIO implements IVideoInput {
     public abstract void close();
 
     /**
-     * Insert a sleep to control playback rate prior to notifying clients
+     * Insert a sleep to control playback rate prior to notifying clients.
      *
      * @param pts PTS of the video frame to be delivered
      */
     protected abstract void delayVideo(double pts);
 
     /**
-     * Insert a sleep to control playback rate prior to notifying clients
+     * Insert a sleep to control playback rate prior to notifying clients.
      *
      * @param pts PTS of the metadata frame to be delivered
      * @throws InterruptedException If the thread is interrupted while waiting
@@ -104,7 +104,7 @@ public abstract class VideoInput extends VideoIO implements IVideoInput {
     }
 
     /**
-     * Attempt to queue a newly decoded video frame for client notification
+     * Attempt to queue a newly decoded video frame for client notification.
      *
      * @param frame The video frame
      * @param timeout Milliseconds to wait for the queue to become available before failing
@@ -121,7 +121,7 @@ public abstract class VideoInput extends VideoIO implements IVideoInput {
     }
 
     /**
-     * Attempt to queue a newly decoded metadata frame for client notification
+     * Attempt to queue a newly decoded metadata frame for client notification.
      *
      * @param frame The metadata frame
      * @param timeout Milliseconds to wait for the queue to become available before failing
@@ -137,7 +137,7 @@ public abstract class VideoInput extends VideoIO implements IVideoInput {
     }
 
     /**
-     * Start up the notifier threads
+     * Start up the notifier threads.
      *
      * @param startPaused True to begin in a paused state
      */
@@ -173,7 +173,7 @@ public abstract class VideoInput extends VideoIO implements IVideoInput {
         decodedMetadata.clear();
     }
 
-    /** Thread to notify clients of new video frames */
+    /** Thread to notify clients of new video frames. */
     protected class VideoNotifier extends Thread {
         private volatile boolean shutdown = false;
         private boolean paused = false;
@@ -230,7 +230,7 @@ public abstract class VideoInput extends VideoIO implements IVideoInput {
         }
     }
 
-    /** Thread to notify clients of new metadata */
+    /** Thread to notify clients of new metadata. */
     protected class MetadataNotifier extends Thread {
         private volatile boolean shutdown = false;
         private boolean paused = false;
@@ -280,7 +280,7 @@ public abstract class VideoInput extends VideoIO implements IVideoInput {
     }
 
     /**
-     * Copy a VideoFrame
+     * Copy a VideoFrame.
      *
      * @param frame The frame to copy
      * @return The newly allocated frame
@@ -293,7 +293,7 @@ public abstract class VideoInput extends VideoIO implements IVideoInput {
                 new BufferedImage(cm, raster, isAlphaPremultiplied, null), frame.getPts());
     }
 
-    /** Free the format context */
+    /** Free the format context. */
     void freeContext() {
         if (formatContext != null) {
             avformat_close_input(formatContext);

--- a/api/src/main/java/org/jmisb/api/video/VideoInputOptions.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoInputOptions.java
@@ -1,12 +1,12 @@
 package org.jmisb.api.video;
 
-/** Options to be be specified when opening an input file or stream */
+/** Options to be be specified when opening an input file or stream. */
 public class VideoInputOptions {
     private final boolean decodeAudio;
     private final boolean decodeMetadata;
     private final boolean decodeVideo;
 
-    /** Construct with default values */
+    /** Construct with default values. */
     public VideoInputOptions() {
         decodeAudio = false;
         decodeMetadata = true;
@@ -14,7 +14,7 @@ public class VideoInputOptions {
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param decodeAudio True to decode audio (currently unsupported)
      * @param decodeMetadata True to decode metadata

--- a/api/src/main/java/org/jmisb/api/video/VideoInputOptions.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoInputOptions.java
@@ -26,14 +26,29 @@ public class VideoInputOptions {
         this.decodeVideo = decodeVideo;
     }
 
+    /**
+     * Whether to decode audio elementary streams.
+     *
+     * @return true to decode audio, false to ignore audio
+     */
     public boolean isDecodeAudio() {
         return decodeAudio;
     }
 
+    /**
+     * Whether to decode metadata elementary streams.
+     *
+     * @return true to decode metadata, false to ignore metadata
+     */
     public boolean isDecodeMetadata() {
         return decodeMetadata;
     }
 
+    /**
+     * Whether to decode video elementary streams.
+     *
+     * @return true to decode video, false to ignore video
+     */
     public boolean isDecodeVideo() {
         return decodeVideo;
     }

--- a/api/src/main/java/org/jmisb/api/video/VideoOutput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoOutput.java
@@ -55,7 +55,7 @@ import org.jmisb.core.video.FfmpegUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Abstract base class for video output */
+/** Abstract base class for video output. */
 public abstract class VideoOutput extends VideoIO {
     private static Logger logger = LoggerFactory.getLogger(VideoOutput.class);
     protected VideoOutputOptions options;
@@ -88,7 +88,7 @@ public abstract class VideoOutput extends VideoIO {
     int framesWritten = 0;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param options The output options
      */
@@ -97,7 +97,7 @@ public abstract class VideoOutput extends VideoIO {
     }
 
     /**
-     * Initialize the video and metadata codecs
+     * Initialize the video and metadata codecs.
      *
      * @throws IOException if an error occurs
      */
@@ -159,7 +159,7 @@ public abstract class VideoOutput extends VideoIO {
     }
 
     /**
-     * Allocate the format context
+     * Allocate the format context.
      *
      * @throws IOException if the format context could not be allocated
      */
@@ -175,7 +175,7 @@ public abstract class VideoOutput extends VideoIO {
     }
 
     /**
-     * Open the video codec
+     * Open the video codec.
      *
      * @return false if the codec could not be opened (e.g., unsupported by the OS/hardware)
      */
@@ -217,7 +217,7 @@ public abstract class VideoOutput extends VideoIO {
     }
 
     /**
-     * Create the video AVStream
+     * Create the video AVStream.
      *
      * @throws IOException if the AVStream could not be created
      */
@@ -241,7 +241,7 @@ public abstract class VideoOutput extends VideoIO {
         avFrameSrc = av_frame_alloc();
     }
 
-    /** Create the metadata stream */
+    /** Create the metadata stream. */
     void createMetadataStream() {
         metadataStream = avformat_new_stream(formatContext, metadataCodecContext.codec());
         metadataStream.index(METADATA_STREAM_INDEX);
@@ -249,7 +249,7 @@ public abstract class VideoOutput extends VideoIO {
         metadataStream.time_base(videoStream.time_base());
     }
 
-    /** Release any resources (to be called by any subclasses when stream/file is closed) */
+    /** Release any resources (to be called by any subclasses when stream/file is closed). */
     void cleanup() {
         if (formatContext != null && formatContext.pb() != null) {
             avio_close(formatContext.pb());
@@ -288,7 +288,7 @@ public abstract class VideoOutput extends VideoIO {
     }
 
     /**
-     * Copy a BufferedImage to avFrameDst, transforming to the pixel format required by the codec
+     * Copy a BufferedImage to avFrameDst, transforming to the pixel format required by the codec.
      *
      * @param image The input image
      * @throws IOException If the frame could not be written
@@ -382,7 +382,7 @@ public abstract class VideoOutput extends VideoIO {
     }
 
     /**
-     * Convert a MetadataFrame to an AVPacket
+     * Convert a MetadataFrame to an AVPacket.
      *
      * @param frame the MetadataFrame
      * @return The AVPacket
@@ -410,7 +410,7 @@ public abstract class VideoOutput extends VideoIO {
     }
 
     /**
-     * Encode a video frame
+     * Encode a video frame.
      *
      * @param frame The video frame
      * @throws IOException if an error occurs

--- a/api/src/main/java/org/jmisb/api/video/VideoOutputOptions.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoOutputOptions.java
@@ -1,6 +1,6 @@
 package org.jmisb.api.video;
 
-/** Options to be specified when opening an output file or stream */
+/** Options to be specified when opening an output file or stream. */
 public class VideoOutputOptions {
     private final int width;
     private final int height;
@@ -10,7 +10,7 @@ public class VideoOutputOptions {
     private final boolean klvStream;
 
     /**
-     * Construct with default values
+     * Construct with default values.
      *
      * @param width Video frame width, in pixels
      * @param height Video frame height, in pixels
@@ -20,7 +20,7 @@ public class VideoOutputOptions {
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param width Video frame width, in pixels
      * @param height Video frame height, in pixels
@@ -45,7 +45,7 @@ public class VideoOutputOptions {
     }
 
     /**
-     * Get the image width
+     * Get the image width.
      *
      * @return Width in pixels
      */
@@ -54,7 +54,7 @@ public class VideoOutputOptions {
     }
 
     /**
-     * Get the image height
+     * Get the image height.
      *
      * @return Height in pixels
      */
@@ -63,7 +63,7 @@ public class VideoOutputOptions {
     }
 
     /**
-     * Get the stream bit rate
+     * Get the stream bit rate.
      *
      * @return Bit rate in bits/second
      */
@@ -72,7 +72,7 @@ public class VideoOutputOptions {
     }
 
     /**
-     * Get the stream frame rate
+     * Get the stream frame rate.
      *
      * @return Frame rate in frames/second
      */
@@ -81,7 +81,7 @@ public class VideoOutputOptions {
     }
 
     /**
-     * Get the Group of pictures (GOP) size
+     * Get the Group of pictures (GOP) size.
      *
      * @return GOP size, i.e., the I-frame interval
      */
@@ -90,7 +90,7 @@ public class VideoOutputOptions {
     }
 
     /**
-     * Check if the output has a KLV data stream
+     * Check if the output has a KLV data stream.
      *
      * @return True if the output has a KLV stream
      */

--- a/api/src/main/java/org/jmisb/api/video/VideoStreamInput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoStreamInput.java
@@ -17,20 +17,20 @@ import org.jmisb.core.video.FfmpegUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Manages an incoming video stream */
+/** Manages an incoming video stream. */
 public class VideoStreamInput extends VideoInput implements IVideoStreamInput {
     private static final Logger logger = LoggerFactory.getLogger(VideoStreamInput.class);
     private final VideoStreamInputOptions options;
     private StreamDemuxer demuxer;
     private boolean open = false;
 
-    /** Construct with default options */
+    /** Construct with default options. */
     public VideoStreamInput() {
         this(new VideoStreamInputOptions());
     }
 
     /**
-     * Construct with options
+     * Construct with options.
      *
      * @param options Options for video input
      */
@@ -140,7 +140,7 @@ public class VideoStreamInput extends VideoInput implements IVideoStreamInput {
         // No-op
     }
 
-    /** Stop the demuxer thread */
+    /** Stop the demuxer thread. */
     private void stopStreamDemuxer() {
         demuxer.shutdown();
         try {

--- a/api/src/main/java/org/jmisb/api/video/VideoStreamInputOptions.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoStreamInputOptions.java
@@ -1,21 +1,21 @@
 package org.jmisb.api.video;
 
-/** Options to be specified when opening an input stream */
+/** Options to be specified when opening an input stream. */
 public class VideoStreamInputOptions extends VideoInputOptions {
-    /** Timeout before failing when opening a stream, in milliseconds */
+    /** Timeout before failing when opening a stream, in milliseconds. */
     private long openTimeout;
 
-    /** Maximum analyze duration, in milliseconds */
+    /** Maximum analyze duration, in milliseconds. */
     private long maxAnalyzeDuration;
 
-    /** Constructor specifying default options */
+    /** Constructor specifying default options. */
     public VideoStreamInputOptions() {
         this.openTimeout = 10_000;
         this.maxAnalyzeDuration = 15_000;
     }
 
     /**
-     * Constructor specifying custom options
+     * Constructor specifying custom options.
      *
      * @param decodeAudio True to decode audio (currently unsupported)
      * @param decodeMetadata True to decode metadata
@@ -35,7 +35,7 @@ public class VideoStreamInputOptions extends VideoInputOptions {
     }
 
     /**
-     * Get the timeout before failing when opening a stream
+     * Get the timeout before failing when opening a stream.
      *
      * @return Failure timeout, in milliseconds
      */
@@ -44,7 +44,7 @@ public class VideoStreamInputOptions extends VideoInputOptions {
     }
 
     /**
-     * Get the maximum analysis duration
+     * Get the maximum analysis duration.
      *
      * @return Max analyze duration, in microseconds
      */

--- a/api/src/main/java/org/jmisb/api/video/VideoStreamOutput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoStreamOutput.java
@@ -22,7 +22,7 @@ import org.jmisb.core.video.FfmpegUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Manages an outgoing video stream */
+/** Manages an outgoing video stream. */
 public class VideoStreamOutput extends VideoOutput implements IVideoStreamOutput {
     private static Logger logger = LoggerFactory.getLogger(VideoStreamOutput.class);
     private String url;
@@ -41,7 +41,7 @@ public class VideoStreamOutput extends VideoOutput implements IVideoStreamOutput
     private OutputStatistics outputStatistics = new OutputStatistics();
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param options Options for video output
      */
@@ -166,7 +166,7 @@ public class VideoStreamOutput extends VideoOutput implements IVideoStreamOutput
         return outputStatistics;
     }
 
-    /** Create the video encoder runnable to be run in the background */
+    /** Create the video encoder runnable to be run in the background. */
     private void createVideoEncoder() {
         videoEncoder =
                 () -> {
@@ -209,7 +209,7 @@ public class VideoStreamOutput extends VideoOutput implements IVideoStreamOutput
                 };
     }
 
-    /** Create the packet sender runnable, to be called once every 1/frame_rate seconds */
+    /** Create the packet sender runnable, to be called once every 1/frame_rate seconds. */
     private void createPacketSender() {
         packetSender =
                 () -> {

--- a/api/src/main/java/org/jmisb/api/video/VideoStreamOutputOptions.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoStreamOutputOptions.java
@@ -1,4 +1,4 @@
 package org.jmisb.api.video;
 
-/** Options to be specified when opening an output stream */
+/** Options to be specified when opening an output stream. */
 public class VideoStreamOutputOptions {}

--- a/api/src/main/java/org/jmisb/api/video/VideoSystem.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoSystem.java
@@ -6,7 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Central class used to instantiate all streams
+ * Central class used to instantiate all streams.
  *
  * <p>When possible, it is recommended that <i>try-with-resources</i> blocks be used when creating
  * instances using any of the {@code create*} methods of this class to ensure that the instance's
@@ -41,7 +41,7 @@ public class VideoSystem {
     }
 
     /**
-     * Create a VideoStreamInput
+     * Create a VideoStreamInput.
      *
      * @return The created stream
      */
@@ -51,7 +51,7 @@ public class VideoSystem {
     }
 
     /**
-     * Create a VideoStreamInput
+     * Create a VideoStreamInput.
      *
      * @param options Input stream options
      * @return The created instance
@@ -61,7 +61,7 @@ public class VideoSystem {
     }
 
     /**
-     * Create a VideoFileInput
+     * Create a VideoFileInput.
      *
      * @return The created instance
      */
@@ -71,7 +71,7 @@ public class VideoSystem {
     }
 
     /**
-     * Create a VideoFileInput
+     * Create a VideoFileInput.
      *
      * @param options Input file options
      * @return The created instance
@@ -81,7 +81,7 @@ public class VideoSystem {
     }
 
     /**
-     * Create a VideoFileOutput
+     * Create a VideoFileOutput.
      *
      * @param options Output options
      * @return The created instance
@@ -91,7 +91,7 @@ public class VideoSystem {
     }
 
     /**
-     * Create a VideoStreamOutput
+     * Create a VideoStreamOutput.
      *
      * @param options Output options
      * @return The created instance

--- a/api/src/main/java/org/jmisb/api/video/package-info.java
+++ b/api/src/main/java/org/jmisb/api/video/package-info.java
@@ -1,2 +1,2 @@
-/** Video processing, including muxing/demuxing and encoding/decoding */
+/** Video processing, including muxing/demuxing and encoding/decoding. */
 package org.jmisb.api.video;


### PR DESCRIPTION
## Motivation and Context
Fix style issues in javadoc in api/video.
~~Relates to #193, but doesn't finish it - there are still (at least) 5 methods to document~~
Edit: Resolves #193 with a second commit to add the missing method documentation.

## Description
Just adds `.` in a lot of places.
Adds javadoc for 5 methods.
Removes suppression.

## How Has This Been Tested?
Just build. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

