### PR TITLE
ci: add JDK11

### DIFF
--- a/.github/workflows/jdk11.yml
+++ b/.github/workflows/jdk11.yml
@@ -1,0 +1,16 @@
+name: JDK11 Build (Ubuntu 20.04 default)
+
+on:
+    push:
+      branches: [ develop ]
+    pull_request:
+      branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Build and check dependencies
+        run: mvn -B install --file pom.xml
+


### PR DESCRIPTION
## Motivation and Context
During some previous work, the QA tests failed for things unrelated. I think that could be JDK11 related.
This change adds JDK11 to the CI to make sure its all OK.

Resolves #207  

## Description
Adds a github workflow using the default JDK on Ubuntu 20.04 (which is mean to be JDK11)
No code changes.

## How Has This Been Tested?
Testing as part of this draft PR.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

