### PR TITLE
video: add timeout for thread join

### DIFF
--- a/api/src/main/java/org/jmisb/api/video/VideoFileInput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoFileInput.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 /** Read video/metadata from a file. */
 public class VideoFileInput extends VideoInput implements IVideoFileInput {
     private static final Logger logger = LoggerFactory.getLogger(VideoFileInput.class);
+    private static final int SHUTDOWN_TIMEOUT_MILLIS = 2000;
     private final VideoFileInputOptions options;
     private FileDemuxer demuxer;
     private final Set<IFileEventListener> fileEventListeners = new HashSet<>();
@@ -293,7 +294,7 @@ public class VideoFileInput extends VideoInput implements IVideoFileInput {
     private void stopFileDemuxer() {
         demuxer.shutdown();
         try {
-            demuxer.join();
+            demuxer.join(SHUTDOWN_TIMEOUT_MILLIS);
         } catch (InterruptedException e) {
             logger.warn("Interrupted while joining demuxer thread", e);
         }


### PR DESCRIPTION
## Motivation and Context
While working on a command line example, I couldn't seem to make the playing thread terminate. This changes the timeout for the `thread.join()` to be 2000 (milliseconds). Otherwise it just seems to wait indefinitely.

## Description
Adds timeout

## How Has This Been Tested?
Command line test code, plus viewer application. Doesn't really lend itself to unit testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

