### PR TITLE
st1909: add support for north arrow from full corners

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st1909/ST0601Converter.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1909/ST0601Converter.java
@@ -313,6 +313,9 @@ public class ST0601Converter {
                         .getDegrees();
         double angleLeftSide = Math.atan2(lat1 - lat4, lon1 - lon4) * 180.0 / Math.PI;
         angleLeftSide -= 90.0;
+        if (angleLeftSide < 0) {
+            angleLeftSide += 360.0;
+        }
         double lat2 =
                 ((CornerOffset) (message.getField(UasDatalinkTag.OffsetCornerLatitudePoint2)))
                         .getDegrees();

--- a/api/src/test/java/org/jmisb/api/klv/st1909/ST0601ConverterTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1909/ST0601ConverterTest.java
@@ -865,6 +865,150 @@ public class ST0601ConverterTest {
     }
 
     @Test
+    public void checkNorthGroupAngle360Outwards() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint1,
+                new CornerOffset(0.01, CornerOffset.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint2,
+                new CornerOffset(0.01, CornerOffset.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint3,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint4,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint1,
+                new CornerOffset(-0.011, CornerOffset.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint2,
+                new CornerOffset(0.011, CornerOffset.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint3,
+                new CornerOffset(0.01, CornerOffset.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint4,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "360.0");
+    }
+
+    @Test
+    public void checkNorthGroupAngle360Inwards() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint1,
+                new CornerOffset(0.01, CornerOffset.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint2,
+                new CornerOffset(0.01, CornerOffset.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint3,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint4,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint1,
+                new CornerOffset(-0.011, CornerOffset.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint2,
+                new CornerOffset(0.011, CornerOffset.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint3,
+                new CornerOffset(0.015, CornerOffset.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint4,
+                new CornerOffset(-0.015, CornerOffset.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "360.0");
+    }
+
+    @Test
+    public void checkNorthGroupAngle180() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint1,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint2,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint3,
+                new CornerOffset(0.01, CornerOffset.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint4,
+                new CornerOffset(0.01, CornerOffset.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint1,
+                new CornerOffset(0.01, CornerOffset.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint2,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint3,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint4,
+                new CornerOffset(0.01, CornerOffset.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "180.0");
+    }
+
+    @Test
+    public void checkNorthGroupAngle180Outwards() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint1,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint2,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint3,
+                new CornerOffset(0.01, CornerOffset.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.OffsetCornerLatitudePoint4,
+                new CornerOffset(0.01, CornerOffset.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint1,
+                new CornerOffset(0.01, CornerOffset.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint2,
+                new CornerOffset(-0.01, CornerOffset.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint3,
+                new CornerOffset(-0.011, CornerOffset.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.OffsetCornerLongitudePoint4,
+                new CornerOffset(0.011, CornerOffset.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "180.0");
+    }
+
+    @Test
     public void checkNorthGroupAngle0FullCorner() {
         SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
         map.put(
@@ -898,6 +1042,258 @@ public class ST0601ConverterTest {
         assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
         assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
         assertEquals(metadata.getValue(MetadataKey.NorthAngle), "0.0");
+    }
+
+    @Test
+    public void checkNorthGroupAngle0FullCornerSlant() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.CornerLatPt1,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.CornerLatPt2,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.CornerLatPt3,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.CornerLatPt4,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.CornerLonPt1,
+                new FullCornerLongitude(-0.01, FullCornerLongitude.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.CornerLonPt2,
+                new FullCornerLongitude(0.01, FullCornerLongitude.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.CornerLonPt3,
+                new FullCornerLongitude(0.02, FullCornerLongitude.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.CornerLonPt4,
+                new FullCornerLongitude(-0.01, FullCornerLongitude.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle).substring(0, 5), "13.28");
+    }
+
+    @Test
+    public void checkNorthGroupAngle0FullCornerOutwards() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.CornerLatPt1,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.CornerLatPt2,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.CornerLatPt3,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.CornerLatPt4,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.CornerLonPt1,
+                new FullCornerLongitude(-0.011, FullCornerLongitude.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.CornerLonPt2,
+                new FullCornerLongitude(0.011, FullCornerLongitude.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.CornerLonPt3,
+                new FullCornerLongitude(0.01, FullCornerLongitude.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.CornerLonPt4,
+                new FullCornerLongitude(-0.01, FullCornerLongitude.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "360.0");
+    }
+
+    @Test
+    public void checkNorthGroupAngle0FullCornerInwards() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.CornerLatPt1,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.CornerLatPt2,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.CornerLatPt3,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.CornerLatPt4,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.CornerLonPt1,
+                new FullCornerLongitude(-0.011, FullCornerLongitude.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.CornerLonPt2,
+                new FullCornerLongitude(0.011, FullCornerLongitude.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.CornerLonPt3,
+                new FullCornerLongitude(0.015, FullCornerLongitude.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.CornerLonPt4,
+                new FullCornerLongitude(-0.015, FullCornerLongitude.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "360.0");
+    }
+
+    @Test
+    public void checkNorthGroupAngle180FullCorner() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.CornerLatPt1,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.CornerLatPt2,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.CornerLatPt3,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.CornerLatPt4,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.CornerLonPt1,
+                new FullCornerLongitude(0.01, FullCornerLongitude.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.CornerLonPt2,
+                new FullCornerLongitude(-0.01, FullCornerLongitude.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.CornerLonPt3,
+                new FullCornerLongitude(-0.01, FullCornerLongitude.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.CornerLonPt4,
+                new FullCornerLongitude(0.01, FullCornerLongitude.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "180.0");
+    }
+
+    @Test
+    public void checkNorthGroupAngle180FullCornerOutwards() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.CornerLatPt1,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.CornerLatPt2,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.CornerLatPt3,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.CornerLatPt4,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.CornerLonPt1,
+                new FullCornerLongitude(0.01, FullCornerLongitude.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.CornerLonPt2,
+                new FullCornerLongitude(-0.01, FullCornerLongitude.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.CornerLonPt3,
+                new FullCornerLongitude(-0.011, FullCornerLongitude.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.CornerLonPt4,
+                new FullCornerLongitude(0.011, FullCornerLongitude.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "180.0");
+    }
+
+    @Test
+    public void checkNorthGroupAngle180FullCornerInwards() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.CornerLatPt1,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.CornerLatPt2,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.CornerLatPt3,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.CornerLatPt4,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.CornerLonPt1,
+                new FullCornerLongitude(0.014, FullCornerLongitude.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.CornerLonPt2,
+                new FullCornerLongitude(-0.014, FullCornerLongitude.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.CornerLonPt3,
+                new FullCornerLongitude(-0.010, FullCornerLongitude.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.CornerLonPt4,
+                new FullCornerLongitude(0.010, FullCornerLongitude.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "180.0");
+    }
+
+    @Test
+    public void checkNorthGroupAngle180FullCornerRightOut() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.CornerLatPt1,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.CornerLatPt2,
+                new FullCornerLatitude(-0.013, FullCornerLatitude.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.CornerLatPt3,
+                new FullCornerLatitude(0.017, FullCornerLatitude.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.CornerLatPt4,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.CornerLonPt1,
+                new FullCornerLongitude(0.010, FullCornerLongitude.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.CornerLonPt2,
+                new FullCornerLongitude(-0.015, FullCornerLongitude.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.CornerLonPt3,
+                new FullCornerLongitude(-0.010, FullCornerLongitude.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.CornerLonPt4,
+                new FullCornerLongitude(0.010, FullCornerLongitude.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle).substring(0, 6), "175.26");
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st1909/ST0601ConverterTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1909/ST0601ConverterTest.java
@@ -26,6 +26,8 @@ import org.jmisb.api.klv.st0601.FrameCenterElevation;
 import org.jmisb.api.klv.st0601.FrameCenterHae;
 import org.jmisb.api.klv.st0601.FrameCenterLatitude;
 import org.jmisb.api.klv.st0601.FrameCenterLongitude;
+import org.jmisb.api.klv.st0601.FullCornerLatitude;
+import org.jmisb.api.klv.st0601.FullCornerLongitude;
 import org.jmisb.api.klv.st0601.GenericFlagData01;
 import org.jmisb.api.klv.st0601.HorizontalFov;
 import org.jmisb.api.klv.st0601.IUasDatalinkValue;
@@ -853,6 +855,42 @@ public class ST0601ConverterTest {
         map.put(
                 UasDatalinkTag.OffsetCornerLongitudePoint4,
                 new CornerOffset(-0.01, CornerOffset.CORNER_LON_4));
+        UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
+        MetadataItems metadata = new MetadataItems();
+        ST0601Converter.convertST0601(st0601message, metadata);
+        assertEquals(metadata.getItemKeys().size(), 2);
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.LaserSensorName));
+        assertTrue(metadata.getItemKeys().contains(MetadataKey.NorthAngle));
+        assertEquals(metadata.getValue(MetadataKey.NorthAngle), "0.0");
+    }
+
+    @Test
+    public void checkNorthGroupAngle0FullCorner() {
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> map = new TreeMap<>();
+        map.put(
+                UasDatalinkTag.CornerLatPt1,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_1));
+        map.put(
+                UasDatalinkTag.CornerLatPt2,
+                new FullCornerLatitude(0.01, FullCornerLatitude.CORNER_LAT_2));
+        map.put(
+                UasDatalinkTag.CornerLatPt3,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_3));
+        map.put(
+                UasDatalinkTag.CornerLatPt4,
+                new FullCornerLatitude(-0.01, FullCornerLatitude.CORNER_LAT_4));
+        map.put(
+                UasDatalinkTag.CornerLonPt1,
+                new FullCornerLongitude(-0.01, FullCornerLongitude.CORNER_LON_1));
+        map.put(
+                UasDatalinkTag.CornerLonPt2,
+                new FullCornerLongitude(0.01, FullCornerLongitude.CORNER_LON_2));
+        map.put(
+                UasDatalinkTag.CornerLonPt3,
+                new FullCornerLongitude(0.01, FullCornerLongitude.CORNER_LON_3));
+        map.put(
+                UasDatalinkTag.CornerLonPt4,
+                new FullCornerLongitude(-0.01, FullCornerLongitude.CORNER_LON_4));
         UasDatalinkMessage st0601message = new UasDatalinkMessage(map);
         MetadataItems metadata = new MetadataItems();
         ST0601Converter.convertST0601(st0601message, metadata);


### PR DESCRIPTION
## Motivation and Context
ST1909 includes a north arrow group, with how to determine north being implementation dependent. We previously supported working it out from the angles of the left and right sides (based on offset corner coordinate items). However not all files include those, and MISB would actually prefer Full Corner Coordinates (ST 0601 Items 82-89) over offsets (Items 26-33).

This PR adds support for full coordinates, while continuing to support offsets.

Resolves #217 

## Description
Adds an additional code path for full coordinates.
There is a small change to the offset path as well, based on a glitch I noted (where it "flips" 180, then back) on the full coordinates. 

## How Has This Been Tested?
Mostly viewer - a lot of staring at the arrow.
Includes one unit test.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/174642/91383451-834b8580-e86f-11ea-8241-aa8c9af26c60.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

