### PR TITLE
st0102: add fuzzing for local set

### DIFF
--- a/api/fuzzing.md
+++ b/api/fuzzing.md
@@ -25,4 +25,4 @@ where the `id_000000` part corresponds to the failure.
 
 Other fuzz targets:
 
-- None yet.
+- `-Dclass=org.jmisb.api.klv.st0102.localset.LocalSetFactoryFuzzTest -Dmethod=checkCreateValue`

--- a/api/src/main/java/org/jmisb/api/klv/st0102/DeclassificationDate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/DeclassificationDate.java
@@ -4,6 +4,7 @@ import static java.time.format.DateTimeFormatter.BASIC_ISO_DATE;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 
 /**
  * Declassification Date (ST 0102 tag 10).
@@ -37,7 +38,11 @@ public class DeclassificationDate implements ISecurityMetadataValue {
 
         // TODO: can we avoid the string allocation?
         String dateString = new String(bytes, StandardCharsets.US_ASCII);
-        date = LocalDate.parse(dateString, BASIC_ISO_DATE);
+        try {
+            date = LocalDate.parse(dateString, BASIC_ISO_DATE);
+        } catch (DateTimeParseException ex) {
+            throw new IllegalArgumentException(ex.getMessage());
+        }
     }
 
     /**

--- a/api/src/test/java/org/jmisb/api/klv/st0102/DeclassificationDateTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/DeclassificationDateTest.java
@@ -36,4 +36,12 @@ public class DeclassificationDateTest {
     public void testBadArrayLength() {
         new DeclassificationDate(new byte[] {0x01, 0x02, 0x03});
     }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void fuzz1() {
+        new DeclassificationDate(
+                new byte[] {
+                    (byte) 0xc0, (byte) 0xfe, 0x15, 0x52, (byte) 0xbc, 0x66, (byte) 0xb0, 0x06
+                });
+    }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0102/localset/LocalSetFactoryFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/localset/LocalSetFactoryFuzzTest.java
@@ -1,0 +1,24 @@
+package org.jmisb.api.klv.st0102.localset;
+
+import static org.testng.Assert.assertNotNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.klv.st0102.ISecurityMetadataValue;
+import org.jmisb.api.klv.st0102.SecurityMetadataKey;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class LocalSetFactoryFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(SecurityMetadataKey tag, byte[] bytes) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            ISecurityMetadataValue v = LocalSetFactory.createValue(tag, bytes);
+            assertNotNull(v);
+        } catch (IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context
A recent change added fuzzing for ST0601. This change uses the same infrastructure to allow fuzzing of ST 0102 security local set.

Resolves #225 

## Description
Adds a fuzz target for the `createValue()` factory. Updates fuzzing.md to document that.

Fixes one fuzz problem found.

## How Has This Been Tested?
Ran the fuzzer.
Added a unit test matching the fuzzing problem found in DeclassificationDate.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

