### PR TITLE
st0903: Add fuzzing targets for ST0903 VMTI and VTrack LS

### DIFF
--- a/api/fuzzing.md
+++ b/api/fuzzing.md
@@ -15,7 +15,7 @@ You can ^C or wait for the results.
 Output goes to `target/fuzz-results/org.jmisb.api.klv.st0601.UasDatalinkFactoryFuzzTest/checkCreateValue/`, and
 the `failure` directory of that has the failure cases.
 
-If there are any failure cases, you can reproduce it using:
+If there are any failure cases, you can reproduce a failure using:
 
 ``` sh
 mvn jqf:repro -Dclass=org.jmisb.api.klv.st0601.UasDatalinkFactoryFuzzTest -Dmethod=checkCreateValue -Dinput=target/fuzz-results/org.jmisb.api.klv.st0601.UasDatalinkFactoryFuzzTest/checkCreateValue/failures/id_000000 -DprintArgs
@@ -26,3 +26,14 @@ where the `id_000000` part corresponds to the failure.
 Other fuzz targets:
 
 - `-Dclass=org.jmisb.api.klv.st0102.localset.LocalSetFactoryFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.VmtiLocalSetFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.algorithm.AlgorithmLocalSetFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.ontology.OntologyLocalSetFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.vchip.VChipLocalSetFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.vfeature.VFeatureLocalSetFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.vmask.VMaskLocalSetFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.vobject.VObjectLocalSetFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.vtarget.VTargetPackFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.vtrack.VTrackLocalSetFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.vtrack.VTrackItemFuzzTest -Dmethod=checkCreateValue`
+- `-Dclass=org.jmisb.api.klv.st0903.vtracker.VTrackerLocalSetFuzzTest -Dmethod=checkCreateValue`

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/TrackId.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtracker/TrackId.java
@@ -1,6 +1,7 @@
 package org.jmisb.api.klv.st0903.vtracker;
 
 import java.util.UUID;
+import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 import org.jmisb.api.klv.st0903.shared.IVTrackMetadataValue;
 import org.jmisb.core.klv.UuidUtils;
@@ -27,9 +28,14 @@ public class TrackId implements IVmtiMetadataValue, IVTrackMetadataValue {
      * Create from encoded bytes.
      *
      * @param bytes Encoded byte array
+     * @throws KlvParseException if the TrackId could not be parsed.
      */
-    public TrackId(byte[] bytes) {
-        id = UuidUtils.arrayToUuid(bytes, 0);
+    public TrackId(byte[] bytes) throws KlvParseException {
+        try {
+            id = UuidUtils.arrayToUuid(bytes, 0);
+        } catch (IllegalArgumentException ex) {
+            throw new KlvParseException(ex.getMessage());
+        }
     }
 
     @Override

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetFuzzTest.java
@@ -1,0 +1,29 @@
+package org.jmisb.api.klv.st0903;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class VmtiLocalSetFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(VmtiMetadataKey tag, byte[] bytes, EncodingMode encodingMode) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVmtiMetadataValue v = VmtiLocalSet.createValue(tag, bytes, encodingMode);
+            if ((tag == VmtiMetadataKey.Undefined) || (tag == VmtiMetadataKey.Checksum)) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLocalSetFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLocalSetFuzzTest.java
@@ -1,0 +1,29 @@
+package org.jmisb.api.klv.st0903.algorithm;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class AlgorithmLocalSetFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(AlgorithmMetadataKey tag, byte[] bytes) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVmtiMetadataValue v = AlgorithmLS.createValue(tag, bytes);
+            if (tag == AlgorithmMetadataKey.Undefined) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/ontology/OntologyLocalSetFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/ontology/OntologyLocalSetFuzzTest.java
@@ -1,0 +1,29 @@
+package org.jmisb.api.klv.st0903.ontology;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class OntologyLocalSetFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(OntologyMetadataKey tag, byte[] bytes) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVmtiMetadataValue v = OntologyLS.createValue(tag, bytes);
+            if (tag == OntologyMetadataKey.Undefined) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vchip/VChipLocalSetFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vchip/VChipLocalSetFuzzTest.java
@@ -1,0 +1,29 @@
+package org.jmisb.api.klv.st0903.vchip;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class VChipLocalSetFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(VChipMetadataKey tag, byte[] bytes) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVmtiMetadataValue v = VChipLS.createValue(tag, bytes);
+            if (tag == VChipMetadataKey.Undefined) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vfeature/VFeatureLocalSetFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vfeature/VFeatureLocalSetFuzzTest.java
@@ -1,0 +1,29 @@
+package org.jmisb.api.klv.st0903.vfeature;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class VFeatureLocalSetFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(VFeatureMetadataKey tag, byte[] bytes) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVmtiMetadataValue v = VFeatureLS.createValue(tag, bytes);
+            if (tag == VFeatureMetadataKey.Undefined) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vmask/VMaskLocalSetFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vmask/VMaskLocalSetFuzzTest.java
@@ -1,0 +1,29 @@
+package org.jmisb.api.klv.st0903.vmask;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class VMaskLocalSetFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(VMaskMetadataKey tag, byte[] bytes) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVmtiMetadataValue v = VMaskLS.createValue(tag, bytes);
+            if (tag == VMaskMetadataKey.Undefined) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vobject/VObjectLocalSetFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vobject/VObjectLocalSetFuzzTest.java
@@ -1,0 +1,29 @@
+package org.jmisb.api.klv.st0903.vobject;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class VObjectLocalSetFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(VObjectMetadataKey tag, byte[] bytes) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVmtiMetadataValue v = VObjectLS.createValue(tag, bytes);
+            if (tag == VObjectMetadataKey.Undefined) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTargetPackFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTargetPackFuzzTest.java
@@ -1,0 +1,30 @@
+package org.jmisb.api.klv.st0903.vtarget;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class VTargetPackFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(VTargetMetadataKey tag, byte[] bytes, EncodingMode encodingMode) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVmtiMetadataValue v = VTargetPack.createValue(tag, bytes, encodingMode);
+            if (tag == VTargetMetadataKey.Undefined) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTargetPackTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/VTargetPackTest.java
@@ -102,4 +102,10 @@ public class VTargetPackTest extends LoggerChecks {
         assertNotNull(localSet);
         assertEquals(localSet.getTags().size(), 1);
     }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void fuzz1() throws KlvParseException {
+        final byte[] bytes = new byte[] {0x01, 0x00};
+        VTargetPack.createValue(VTargetMetadataKey.VTracker, bytes, EncodingMode.IMAPB);
+    }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackItemFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackItemFuzzTest.java
@@ -1,0 +1,31 @@
+package org.jmisb.api.klv.st0903.vtrack;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+import org.jmisb.api.klv.st0903.shared.IVTrackItemMetadataValue;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class VTrackItemFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(
+            VTrackItemMetadataKey tag, byte[] bytes, EncodingMode encodingMode) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVTrackItemMetadataValue v = VTrackItem.createValue(tag, bytes, encodingMode);
+            if (tag == VTrackItemMetadataKey.Undefined) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetFuzzTest.java
@@ -1,0 +1,30 @@
+package org.jmisb.api.klv.st0903.vtrack;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+import org.jmisb.api.klv.st0903.shared.IVTrackMetadataValue;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class VTrackLocalSetFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(VTrackMetadataKey tag, byte[] bytes, EncodingMode encodingMode) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVTrackMetadataValue v = VTrackLocalSet.createValue(tag, bytes, encodingMode);
+            if ((tag == VTrackMetadataKey.Undefined) || (tag == VTrackMetadataKey.Checksum)) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/TrackIdTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/TrackIdTest.java
@@ -49,4 +49,13 @@ public class TrackIdTest {
         Assert.assertEquals(id.getDisplayableValue(), "F81D-4FAE-7DEC-11D0-A765-00A0-C91E-6BF6");
         Assert.assertEquals(id.getUUID(), UUID.fromString("F81D4FAE-7DEC-11D0-A765-00A0C91E6BF6"));
     }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testTooShort() throws KlvParseException {
+        new TrackId(
+                new byte[] {
+                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+                    0x0e
+                });
+    }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLSTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLSTest.java
@@ -69,4 +69,12 @@ public class VTrackerLSTest extends LoggerChecks {
         VTrackerLS localSet = new VTrackerLS(bytes, EncodingMode.IMAPB);
         checkLocalSetWithAlgorithmId(localSet);
     }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void fuzz1() throws KlvParseException {
+        VTrackerLS.createValue(
+                VTrackerMetadataKey.trackId,
+                new byte[] {0x5b, 0x78, (byte) 0x93, 0x45, 0x05, (byte) 0xcc, 0x1d},
+                EncodingMode.IMAPB);
+    }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLocalSetFuzzTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtracker/VTrackerLocalSetFuzzTest.java
@@ -1,0 +1,30 @@
+package org.jmisb.api.klv.st0903.vtracker;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
+import org.jmisb.core.klv.ArrayUtils;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class VTrackerLocalSetFuzzTest {
+    @Fuzz /* The args to this method will be generated automatically by JQF */
+    public void checkCreateValue(VTrackerMetadataKey tag, byte[] bytes, EncodingMode encodingMode) {
+        try {
+            System.out.println("checkCreateValue: " + ArrayUtils.toHexString(bytes, 16, true));
+            IVmtiMetadataValue v = VTrackerLS.createValue(tag, bytes, encodingMode);
+            if (tag == VTrackerMetadataKey.Undefined) {
+                assertNull(v);
+            } else {
+                assertNotNull(v);
+            }
+        } catch (KlvParseException | IllegalArgumentException e) {
+            // OK when we're fuzzing.
+        }
+    }
+}

--- a/core/src/main/java/org/jmisb/core/klv/UuidUtils.java
+++ b/core/src/main/java/org/jmisb/core/klv/UuidUtils.java
@@ -57,6 +57,9 @@ public class UuidUtils {
      * @return UUID
      */
     public static UUID arrayToUuid(byte[] bytes, int index) {
+        if (index + 16 > bytes.length) {
+            throw new IllegalArgumentException("Too few bytes available to read UUID");
+        }
         ByteBuffer bb = ByteBuffer.wrap(bytes, index, 16);
         return new UUID(bb.getLong(), bb.getLong());
     }


### PR DESCRIPTION
## Motivation and Context
This continues the recent work on adding fuzzing targets to include ST0903.

Resolves #226 

## Description
Adds fuzzing targets and documentation for the main entry points into ST0903.
Fixes one fuzzing issue in core, where malformed input in UUID parsing could cause an out-of-bounds array index.

## How Has This Been Tested?
Ran the fuzzer for at least 5 minutes on each new target. Added unit tests for problems.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

