### PR TITLE
st0102: work around incorrect ObjectCountryCodes encoding

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0102/ObjectCountryCodeString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/ObjectCountryCodeString.java
@@ -1,9 +1,13 @@
 package org.jmisb.api.klv.st0102;
 
 import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Represents an Object Country Code value in ST 0102. */
 public class ObjectCountryCodeString implements ISecurityMetadataValue {
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectCountryCodeString.class);
+
     private String stringValue;
 
     /**
@@ -21,7 +25,15 @@ public class ObjectCountryCodeString implements ISecurityMetadataValue {
      * @param bytes Encoded byte array
      */
     public ObjectCountryCodeString(byte[] bytes) {
-        this.stringValue = new String(bytes, StandardCharsets.UTF_16);
+        if (bytes.length < 4) {
+            // This probably isn't going to be a valid UTF-16 country code
+            LOG.warn(
+                    "{} has too few bytes for required UTF-16 encoding. Trying UTF-8 workaround.",
+                    getDisplayName());
+            this.stringValue = new String(bytes, StandardCharsets.UTF_8);
+        } else {
+            this.stringValue = new String(bytes, StandardCharsets.UTF_16);
+        }
     }
 
     /**

--- a/api/src/test/java/org/jmisb/api/klv/st0102/ObjectCountryCodeStringTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/ObjectCountryCodeStringTest.java
@@ -1,12 +1,19 @@
 package org.jmisb.api.klv.st0102;
 
+import org.jmisb.api.klv.LoggerChecks;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class ObjectCountryCodeStringTest {
+public class ObjectCountryCodeStringTest extends LoggerChecks {
+    public ObjectCountryCodeStringTest() {
+        super(ObjectCountryCodeString.class);
+    }
+
     @Test
     public void testConstructFromValue() {
+        verifyNoLoggerMessages();
         ObjectCountryCodeString objectCountryCode = new ObjectCountryCodeString("US;CA");
+        verifyNoLoggerMessages();
         Assert.assertEquals(objectCountryCode.getBytes().length, 10);
         Assert.assertEquals(objectCountryCode.getDisplayableValue(), "US;CA");
         Assert.assertEquals(objectCountryCode.getDisplayName(), "Object Country Codes");
@@ -28,6 +35,7 @@ public class ObjectCountryCodeStringTest {
 
     @Test
     public void testConstructFromEncoded() {
+        verifyNoLoggerMessages();
         ObjectCountryCodeString objectCountryCode =
                 new ObjectCountryCodeString(
                         new byte[] {
@@ -42,6 +50,7 @@ public class ObjectCountryCodeStringTest {
                             (byte) 0x00,
                             (byte) 0x41
                         });
+        verifyNoLoggerMessages();
         Assert.assertEquals(objectCountryCode.getValue(), "US;CA");
         Assert.assertEquals(objectCountryCode.getDisplayableValue(), "US;CA");
         Assert.assertEquals(objectCountryCode.getDisplayName(), "Object Country Codes");
@@ -58,6 +67,23 @@ public class ObjectCountryCodeStringTest {
                     (byte) 0x43,
                     (byte) 0x00,
                     (byte) 0x41
+                });
+    }
+
+    @Test
+    public void testConstructFromEncodedUTF8() {
+        verifyNoLoggerMessages();
+        ObjectCountryCodeString objectCountryCode =
+                new ObjectCountryCodeString(new byte[] {(byte) 0x55, (byte) 0x53, (byte) 0x41});
+        verifySingleLoggerMessage(
+                "Object Country Codes has too few bytes for required UTF-16 encoding. Trying UTF-8 workaround.");
+        Assert.assertEquals(objectCountryCode.getValue(), "USA");
+        Assert.assertEquals(objectCountryCode.getDisplayableValue(), "USA");
+        Assert.assertEquals(objectCountryCode.getDisplayName(), "Object Country Codes");
+        Assert.assertEquals(
+                objectCountryCode.getBytes(),
+                new byte[] {
+                    (byte) 0x00, (byte) 0x55, (byte) 0x00, (byte) 0x53, (byte) 0x00, (byte) 0x41
                 });
     }
 }


### PR DESCRIPTION
## Motivation and Context
ST0102 has a mix of string encodings. The Object Country Code is meant to be UTF-16 Big Endian. However some producers just put ASCII (equivalent to UTF-8 for this purpose) in there. This PR provides a workaround based on the usual case being a single country, and the minimum length of a country code being 2 characters (4 bytes in UTF-16). So if the byte length is < 4, we're probably dealing with ASCII.

Resolves #233.

## Description
Adds a check to the ST0102 ObjectCountryCodes implementation to check length and output a warning, then decode as UTF-8.
Adds a corresponding unit test to check the result, including the logger warning.
Checks that the output (`getBytes()`) is still UTF-16.

## How Has This Been Tested?
Unit test.
Ran viewer on some known-good files (MISB), and some known-bad files (the klv_metadata_test_async.ts and klv_metadata_test_sync.ts examples), and a couple of files with no Object Country Code. Outputs as expected.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

