### PR TITLE
klv: use factories to isolate KlvParser from message implementation

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/IMisbMessageFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/IMisbMessageFactory.java
@@ -1,0 +1,18 @@
+package org.jmisb.api.klv;
+
+import org.jmisb.api.common.KlvParseException;
+
+/** Interface for IMisbMessage factory creation. */
+public interface IMisbMessageFactory {
+    /**
+     * Create a new {@link IMisbMessage} instance from encoded bytes.
+     *
+     * <p>The bytes must contain the 16-byte {@link UniversalLabel} that is used to select the
+     * message handler to use.
+     *
+     * @param bytes the encoded bytes.
+     * @return IMisbMessage implementation.
+     * @throws KlvParseException if the parsing failed.
+     */
+    IMisbMessage create(byte[] bytes) throws KlvParseException;
+}

--- a/api/src/main/java/org/jmisb/api/klv/KlvParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/KlvParser.java
@@ -4,12 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.eg0104.PredatorUavMessage;
-import org.jmisb.api.klv.st0102.localset.SecurityMetadataLocalSet;
-import org.jmisb.api.klv.st0102.universalset.SecurityMetadataUniversalSet;
-import org.jmisb.api.klv.st0601.UasDatalinkMessage;
-import org.jmisb.api.klv.st0808.AncillaryTextLocalSet;
-import org.jmisb.api.klv.st0903.vtrack.VTrackLocalSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +19,8 @@ public class KlvParser {
      * <p>This is the main interface for parsing KLV metadata. It assumes that {@code bytes}
      * contains one or more top-level messages, i.e., byte sequences starting with a Universal Label
      * (UL). If a particular UL is unsupported it will be returned as a {@link RawMisbMessage}.
+     *
+     * <p>The supported UL are determined by the {@link MisbMessageFactory} singleton.
      *
      * @param bytes The byte array
      * @return List of {@link IMisbMessage}s
@@ -43,48 +39,9 @@ public class KlvParser {
             pos += nextMessage.length;
 
             try {
-                // Extract a 16-byte universal label from the beginning of the message
-                UniversalLabel ul =
-                        new UniversalLabel(
-                                Arrays.copyOfRange(nextMessage, 0, UniversalLabel.LENGTH));
-
-                // Parse the message if it is one of the types we support
-                if (ul.equals(KlvConstants.UasDatalinkLocalUl)) {
-                    if (logger.isDebugEnabled()) logger.debug("UAS Datalink message");
-
-                    UasDatalinkMessage message = new UasDatalinkMessage(nextMessage);
-                    messages.add(message);
-                } else if (ul.equals(KlvConstants.SecurityMetadataUniversalSetUl)) {
-                    if (logger.isDebugEnabled())
-                        logger.debug("Security Metadata Universal Set message");
-                    SecurityMetadataUniversalSet message =
-                            new SecurityMetadataUniversalSet(nextMessage);
-                    messages.add(message);
-                } else if (ul.equals(KlvConstants.SecurityMetadataLocalSetUl)) {
-                    if (logger.isDebugEnabled())
-                        logger.debug("Security Metadata Local Set message");
-                    SecurityMetadataLocalSet message =
-                            new SecurityMetadataLocalSet(nextMessage, true);
-                    messages.add(message);
-                } else if (ul.equals(KlvConstants.PredatorMetadataLocalSetUl)) {
-                    if (logger.isDebugEnabled())
-                        logger.debug("Predator UAV Metadata Local Set message");
-                    PredatorUavMessage message = new PredatorUavMessage(nextMessage);
-                    messages.add(message);
-                } else if (ul.equals(KlvConstants.AncillaryTextLocalSetUl)) {
-                    if (logger.isDebugEnabled()) logger.debug("Ancillary Text Local Set message");
-                    AncillaryTextLocalSet message = new AncillaryTextLocalSet(nextMessage);
-                    messages.add(message);
-                } else if (ul.equals(KlvConstants.VTrackLocalSetUl)) {
-                    if (logger.isDebugEnabled()) logger.debug("VTrack Local Set message");
-                    VTrackLocalSet message = new VTrackLocalSet(nextMessage);
-                    messages.add(message);
-                } else {
-                    if (logger.isDebugEnabled())
-                        logger.debug("Unsupported message type; wrapping as a raw message");
-                    RawMisbMessage message = new RawMisbMessage(ul, nextMessage);
-                    messages.add(message);
-                }
+                IMisbMessage message = MisbMessageFactory.getInstance().handleMessage(nextMessage);
+                if (logger.isDebugEnabled()) logger.debug("Parsed as " + message.displayHeader());
+                messages.add(message);
             } catch (IllegalArgumentException ex) {
                 logger.error("Exception thrown by parser", ex);
                 throw new KlvParseException(ex.getMessage());
@@ -104,38 +61,8 @@ public class KlvParser {
     private static byte[] getNextMessage(byte[] bytes) throws KlvParseException {
         // Length of the key field (UL)
         final int keyLength = UniversalLabel.LENGTH;
-        // Length of the length field
-        int lengthLength;
-        // Length of the value field
-        int payloadLength;
-
-        // TODO: can we use BerDecode here?
-
-        // Check for short form vs. long form
-        if ((bytes[keyLength] & 0x80) == 0) {
-            // short form
-            lengthLength = 1;
-            payloadLength = bytes[keyLength] & 0x7f;
-            if (logger.isDebugEnabled()) logger.debug("Short-form length = " + payloadLength);
-        } else {
-            // long form
-            int berLength = bytes[keyLength] & 0x7f;
-            int len = 0;
-            for (int i = 0; i < berLength; ++i) {
-                int b = 0x00ff & bytes[keyLength + i + 1];
-                len = (len << 8) | b;
-            }
-            lengthLength = berLength + 1;
-            payloadLength = len;
-            if (logger.isDebugEnabled())
-                logger.debug(
-                        "Long-form; ber-length = "
-                                + berLength
-                                + "; payload length = "
-                                + payloadLength);
-        }
-
-        final int totalLength = keyLength + lengthLength + payloadLength;
+        BerField lengthField = BerDecoder.decode(bytes, keyLength, false);
+        final int totalLength = keyLength + lengthField.getLength() + lengthField.getValue();
 
         // If the lengths are equal, just return the original array; otherwise copy a subrange.
         if (totalLength > bytes.length) {

--- a/api/src/main/java/org/jmisb/api/klv/MisbMessageFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/MisbMessageFactory.java
@@ -1,0 +1,79 @@
+package org.jmisb.api.klv;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.eg0104.PredatorUavMessageFactory;
+import org.jmisb.api.klv.st0102.localset.SecurityMetadataLocalSetFactory;
+import org.jmisb.api.klv.st0102.universalset.SecurityMetadataUniversalSetFactory;
+import org.jmisb.api.klv.st0601.UasDatalinkMessageFactory;
+import org.jmisb.api.klv.st0808.AncillaryTextLocalSetFactory;
+import org.jmisb.api.klv.st0903.vtrack.VTrackLocalSetFactory;
+
+/**
+ * Factory class for {@link IMisbMessage} instances.
+ *
+ * <p>This singleton provides the ability to get an IMisbMessage class instance corresponding to a
+ * provided {@link UniversalLabel}. Built-in implementations will be registered automatically.
+ * Additional implementations (e.g. for proprietary extensions) can be registered as required.
+ */
+public class MisbMessageFactory {
+    private static final Map<UniversalLabel, IMisbMessageFactory> MESSAGE_HANDLERS =
+            new HashMap<>();
+
+    private MisbMessageFactory() {
+        registerHandler(KlvConstants.UasDatalinkLocalUl, new UasDatalinkMessageFactory());
+        registerHandler(KlvConstants.AncillaryTextLocalSetUl, new AncillaryTextLocalSetFactory());
+        registerHandler(
+                KlvConstants.SecurityMetadataUniversalSetUl,
+                new SecurityMetadataUniversalSetFactory());
+        registerHandler(
+                KlvConstants.SecurityMetadataLocalSetUl, new SecurityMetadataLocalSetFactory());
+        registerHandler(KlvConstants.PredatorMetadataLocalSetUl, new PredatorUavMessageFactory());
+        registerHandler(KlvConstants.VTrackLocalSetUl, new VTrackLocalSetFactory());
+    }
+
+    /**
+     * Get the singleton instance.
+     *
+     * @return the message factory instance.
+     */
+    public static MisbMessageFactory getInstance() {
+        return MisbFactoryHolder.INSTANCE;
+    }
+
+    /**
+     * Register a handler for a given {@link UniversalLabel}.
+     *
+     * @param universalLabel the universal label
+     * @param factory the corresponding factory to use
+     */
+    public final void registerHandler(UniversalLabel universalLabel, IMisbMessageFactory factory) {
+        MESSAGE_HANDLERS.put(universalLabel, factory);
+    }
+
+    /**
+     * Lookup the appropriate message handler for this message, and process it.
+     *
+     * <p>If no matching message handler is available, the data will be returned as a {@link
+     * RawMisbMessage}.
+     *
+     * @param messageData the message data (starting at the universal label)
+     * @return the message instance
+     * @throws KlvParseException if the message handler throws.
+     */
+    public IMisbMessage handleMessage(byte[] messageData) throws KlvParseException {
+        UniversalLabel ul =
+                new UniversalLabel(Arrays.copyOfRange(messageData, 0, UniversalLabel.LENGTH));
+        if (MESSAGE_HANDLERS.containsKey(ul)) {
+            IMisbMessageFactory factory = MESSAGE_HANDLERS.get(ul);
+            return factory.create(messageData);
+        }
+        return new RawMisbMessage(ul, messageData);
+    }
+
+    private static class MisbFactoryHolder {
+        private static final MisbMessageFactory INSTANCE = new MisbMessageFactory();
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/eg0104/PredatorUavMessageFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/eg0104/PredatorUavMessageFactory.java
@@ -1,0 +1,13 @@
+package org.jmisb.api.klv.eg0104;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IMisbMessageFactory;
+
+/** Factory method for PredatorUavMessage. */
+public class PredatorUavMessageFactory implements IMisbMessageFactory {
+
+    @Override
+    public PredatorUavMessage create(byte[] bytes) throws KlvParseException {
+        return new PredatorUavMessage(bytes);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetFactory.java
@@ -1,0 +1,13 @@
+package org.jmisb.api.klv.st0102.localset;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IMisbMessageFactory;
+
+/** Factory method for SecurityMetadataLocalSet. */
+public class SecurityMetadataLocalSetFactory implements IMisbMessageFactory {
+
+    @Override
+    public SecurityMetadataLocalSet create(byte[] bytes) throws KlvParseException {
+        return new SecurityMetadataLocalSet(bytes, true);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0102/universalset/SecurityMetadataUniversalSetFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/universalset/SecurityMetadataUniversalSetFactory.java
@@ -1,0 +1,16 @@
+package org.jmisb.api.klv.st0102.universalset;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IMisbMessageFactory;
+
+/** Factory method for SecurityMetadataUniversalSet. */
+public class SecurityMetadataUniversalSetFactory implements IMisbMessageFactory {
+
+    static {
+    }
+
+    @Override
+    public SecurityMetadataUniversalSet create(byte[] bytes) throws KlvParseException {
+        return new SecurityMetadataUniversalSet(bytes);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkMessageFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkMessageFactory.java
@@ -1,0 +1,12 @@
+package org.jmisb.api.klv.st0601;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IMisbMessageFactory;
+
+/** Factory method for UasDatalinkMessages. */
+public class UasDatalinkMessageFactory implements IMisbMessageFactory {
+    @Override
+    public UasDatalinkMessage create(byte[] bytes) throws KlvParseException {
+        return new UasDatalinkMessage(bytes);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSetFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSetFactory.java
@@ -1,0 +1,16 @@
+package org.jmisb.api.klv.st0808;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IMisbMessageFactory;
+
+/** Factory method for AncillaryTextLocalSet. */
+public class AncillaryTextLocalSetFactory implements IMisbMessageFactory {
+
+    static {
+    }
+
+    @Override
+    public AncillaryTextLocalSet create(byte[] bytes) throws KlvParseException {
+        return new AncillaryTextLocalSet(bytes);
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetFactory.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetFactory.java
@@ -1,0 +1,13 @@
+package org.jmisb.api.klv.st0903.vtrack;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IMisbMessageFactory;
+
+/** Factory method for VTrackLocalSet. */
+public class VTrackLocalSetFactory implements IMisbMessageFactory {
+
+    @Override
+    public VTrackLocalSet create(byte[] bytes) throws KlvParseException {
+        return new VTrackLocalSet(bytes);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/KlvParserTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/KlvParserTest.java
@@ -68,40 +68,155 @@ public class KlvParserTest {
         try {
             List<IMisbMessage> messages = KlvParser.parseBytes(bytes);
             Assert.assertEquals(messages.size(), 1);
-
-            IMisbMessage message = messages.get(0);
-            Assert.assertTrue(message instanceof UasDatalinkMessage);
-
-            UasDatalinkMessage datalinkMessage = (UasDatalinkMessage) message;
-            Assert.assertEquals(datalinkMessage.getTags().size(), 3);
-            Assert.assertEquals(datalinkMessage.getIdentifiers().size(), 3);
-
-            SensorLatitude lat =
-                    (SensorLatitude) datalinkMessage.getField(UasDatalinkTag.SensorLatitude);
-            SensorLongitude lon =
-                    (SensorLongitude) datalinkMessage.getField(UasDatalinkTag.SensorLongitude);
-            SensorTrueAltitude alt =
-                    (SensorTrueAltitude)
-                            datalinkMessage.getField(UasDatalinkTag.SensorTrueAltitude);
-
-            Assert.assertNotNull(lat);
-            Assert.assertNotNull(lon);
-            Assert.assertNotNull(alt);
-
-            Assert.assertEquals(lat.getDegrees(), 42.4036, SensorLatitude.DELTA);
-            Assert.assertEquals(lat.getBytes(), SENSOR_LAT_VALUE);
-            Assert.assertEquals(lon.getDegrees(), -71.1284, SensorLongitude.DELTA);
-            Assert.assertEquals(lon.getBytes(), SENSOR_LON_VALUE);
-            Assert.assertEquals(alt.getMeters(), 1258.3, SensorTrueAltitude.DELTA);
-            Assert.assertEquals(alt.getBytes(), SENSOR_ALT_VALUE);
-
-            SensorLongitude lonFromIKlvKey =
-                    (SensorLongitude)
-                            datalinkMessage.getField((IKlvKey) UasDatalinkTag.SensorLongitude);
-            Assert.assertEquals(lonFromIKlvKey.getDegrees(), lon.getDegrees(), 0.0000001);
+            check0601Parse(messages);
         } catch (KlvParseException e) {
             Assert.fail("Parse exception");
         }
+    }
+
+    @Test
+    public void testUasDatalinkExtraBytes() {
+        byte[] bytes =
+                new byte[] {
+                    (byte) 0x06,
+                    (byte) 0x0e,
+                    (byte) 0x2b,
+                    (byte) 0x34,
+                    (byte) 0x02,
+                    (byte) 0x0b,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x0e,
+                    (byte) 0x01,
+                    (byte) 0x03,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x14,
+                    (byte) 0x0d,
+                    (byte) 0x04,
+                    (byte) 0x3c,
+                    (byte) 0x4e,
+                    (byte) 0xad,
+                    (byte) 0xfa,
+                    (byte) 0x0e,
+                    (byte) 0x04,
+                    (byte) 0xcd,
+                    (byte) 0x6b,
+                    (byte) 0x78,
+                    (byte) 0x4e,
+                    (byte) 0x0f,
+                    (byte) 0x02,
+                    (byte) 0x1b,
+                    (byte) 0xc4,
+                    (byte) 0x01,
+                    (byte) 0x02,
+                    (byte) 0x2d,
+                    (byte) 0xc4,
+                    (byte) 0x06,
+                    (byte) 0x0e,
+                    (byte) 0x2b,
+                    (byte) 0x34,
+                    (byte) 0x02,
+                    (byte) 0x0b,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x0e,
+                    (byte) 0x01,
+                    (byte) 0x03,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00
+                };
+
+        try {
+            List<IMisbMessage> messages = KlvParser.parseBytes(bytes);
+            Assert.assertEquals(messages.size(), 2);
+            check0601Parse(messages);
+        } catch (KlvParseException e) {
+            Assert.fail("Parse exception");
+        }
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testUasDatalinkTooFewBytes() throws KlvParseException {
+        byte[] bytes =
+                new byte[] {
+                    (byte) 0x06,
+                    (byte) 0x0e,
+                    (byte) 0x2b,
+                    (byte) 0x34,
+                    (byte) 0x02,
+                    (byte) 0x0b,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x0e,
+                    (byte) 0x01,
+                    (byte) 0x03,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x14,
+                    (byte) 0x0d,
+                    (byte) 0x04,
+                    (byte) 0x3c,
+                    (byte) 0x4e,
+                    (byte) 0xad,
+                    (byte) 0xfa,
+                    (byte) 0x0e,
+                    (byte) 0x04,
+                    (byte) 0xcd,
+                    (byte) 0x6b,
+                    (byte) 0x78,
+                    (byte) 0x4e,
+                    (byte) 0x0f,
+                    (byte) 0x02,
+                    (byte) 0x1b,
+                    (byte) 0xc4,
+                    (byte) 0x01,
+                    (byte) 0x02,
+                    (byte) 0x2d
+                };
+        KlvParser.parseBytes(bytes);
+    }
+
+    private void check0601Parse(List<IMisbMessage> messages) {
+        IMisbMessage message = messages.get(0);
+        Assert.assertTrue(message instanceof UasDatalinkMessage);
+
+        UasDatalinkMessage datalinkMessage = (UasDatalinkMessage) message;
+        Assert.assertEquals(datalinkMessage.getTags().size(), 3);
+        Assert.assertEquals(datalinkMessage.getIdentifiers().size(), 3);
+
+        SensorLatitude lat =
+                (SensorLatitude) datalinkMessage.getField(UasDatalinkTag.SensorLatitude);
+        SensorLongitude lon =
+                (SensorLongitude) datalinkMessage.getField(UasDatalinkTag.SensorLongitude);
+        SensorTrueAltitude alt =
+                (SensorTrueAltitude) datalinkMessage.getField(UasDatalinkTag.SensorTrueAltitude);
+
+        Assert.assertNotNull(lat);
+        Assert.assertNotNull(lon);
+        Assert.assertNotNull(alt);
+
+        Assert.assertEquals(lat.getDegrees(), 42.4036, SensorLatitude.DELTA);
+        Assert.assertEquals(lat.getBytes(), SENSOR_LAT_VALUE);
+        Assert.assertEquals(lon.getDegrees(), -71.1284, SensorLongitude.DELTA);
+        Assert.assertEquals(lon.getBytes(), SENSOR_LON_VALUE);
+        Assert.assertEquals(alt.getMeters(), 1258.3, SensorTrueAltitude.DELTA);
+        Assert.assertEquals(alt.getBytes(), SENSOR_ALT_VALUE);
+
+        SensorLongitude lonFromIKlvKey =
+                (SensorLongitude)
+                        datalinkMessage.getField((IKlvKey) UasDatalinkTag.SensorLongitude);
+        Assert.assertEquals(lonFromIKlvKey.getDegrees(), lon.getDegrees(), 0.0000001);
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/UniversalLabelTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/UniversalLabelTest.java
@@ -32,6 +32,8 @@ public class UniversalLabelTest {
 
         Assert.assertNotEquals(one, three);
         Assert.assertNotEquals(two, three);
+        Assert.assertFalse(one.equals(null));
+        Assert.assertFalse(one.equals("some string"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -45,6 +47,36 @@ public class UniversalLabelTest {
         byte[] bytes =
                 new byte[] {
                     0x07, 0x0e, 0x2b, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00
+                };
+        new UniversalLabel(bytes);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadLength() {
+        byte[] bytes =
+                new byte[] {
+                    0x06, 0x0f, 0x2b, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00
+                };
+        new UniversalLabel(bytes);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadCode() {
+        byte[] bytes =
+                new byte[] {
+                    0x06, 0x0e, 0x2a, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00
+                };
+        new UniversalLabel(bytes);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBadDesignator() {
+        byte[] bytes =
+                new byte[] {
+                    0x06, 0x0e, 0x2b, 0x3e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00
                 };
         new UniversalLabel(bytes);

--- a/api/src/test/java/org/jmisb/api/klv/eg0104/PredatorUavMessageFactoryTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/eg0104/PredatorUavMessageFactoryTest.java
@@ -1,0 +1,512 @@
+package org.jmisb.api.klv.eg0104;
+
+import static org.testng.Assert.*;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IKlvKey;
+import org.jmisb.api.klv.KlvConstants;
+import org.testng.annotations.Test;
+
+public class PredatorUavMessageFactoryTest {
+
+    public PredatorUavMessageFactoryTest() {}
+
+    @Test
+    public void checkBaseParse() throws KlvParseException {
+        byte[] bytes = {
+            (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x02, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x0e, (byte) 0x01, (byte) 0x01, (byte) 0x02,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x00, (byte) 0x00,
+            (byte) 0x82, (byte) 0x02, (byte) 0xd0, (byte) 0x06, (byte) 0x0e, (byte) 0x2b,
+                    (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x07, (byte) 0x07,
+                    (byte) 0x01, (byte) 0x10, (byte) 0x01, (byte) 0x05,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x04, (byte) 0x41, (byte) 0xfd,
+                    (byte) 0x5c, (byte) 0x29, (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x0a,
+            (byte) 0x07, (byte) 0x01, (byte) 0x02, (byte) 0x01, (byte) 0x03, (byte) 0x16,
+                    (byte) 0x00, (byte) 0x00, (byte) 0x04, (byte) 0x44, (byte) 0x7a, (byte) 0x6a,
+                    (byte) 0xe1, (byte) 0x06, (byte) 0x0e, (byte) 0x2b,
+            (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x07, (byte) 0x04,
+                    (byte) 0x20, (byte) 0x02, (byte) 0x01, (byte) 0x01, (byte) 0x0a, (byte) 0x01,
+                    (byte) 0x00, (byte) 0x04, (byte) 0x42, (byte) 0x35,
+            (byte) 0x99, (byte) 0x9a, (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x05,
+                    (byte) 0x05, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x03, (byte) 0x31, (byte) 0x30, (byte) 0x30,
+                    (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+            (byte) 0x20, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                    (byte) 0x02, (byte) 0x31, (byte) 0x30, (byte) 0x06, (byte) 0x0e, (byte) 0x2b,
+                    (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+            (byte) 0x07, (byte) 0x07, (byte) 0x01, (byte) 0x10, (byte) 0x01, (byte) 0x04,
+                    (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x04, (byte) 0x41, (byte) 0xb0,
+                    (byte) 0x7a, (byte) 0xe1, (byte) 0x06, (byte) 0x0e,
+            (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x07, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x00, (byte) 0x00,
+                    (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x32,
+            (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x07, (byte) 0x07, (byte) 0x01, (byte) 0x10, (byte) 0x01,
+                    (byte) 0x06, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x04, (byte) 0x41, (byte) 0xa0, (byte) 0x14, (byte) 0x7b, (byte) 0x06,
+                    (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x03, (byte) 0x07, (byte) 0x02, (byte) 0x01,
+            (byte) 0x01, (byte) 0x01, (byte) 0x05, (byte) 0x00, (byte) 0x00, (byte) 0x08,
+                    (byte) 0x00, (byte) 0x03, (byte) 0xf3, (byte) 0xb3, (byte) 0x5e, (byte) 0xde,
+                    (byte) 0x0a, (byte) 0x7c, (byte) 0x06, (byte) 0x0e,
+            (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x04, (byte) 0x20, (byte) 0x01, (byte) 0x02, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x00, (byte) 0x00, (byte) 0x07, (byte) 0x45,
+            (byte) 0x4f, (byte) 0x20, (byte) 0x4e, (byte) 0x6f, (byte) 0x73, (byte) 0x65,
+                    (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x07, (byte) 0x02,
+            (byte) 0x01, (byte) 0x02, (byte) 0x01, (byte) 0x01, (byte) 0x00, (byte) 0x00,
+                    (byte) 0x0e, (byte) 0x32, (byte) 0x30, (byte) 0x30, (byte) 0x35, (byte) 0x30,
+                    (byte) 0x33, (byte) 0x33, (byte) 0x31, (byte) 0x30,
+            (byte) 0x38, (byte) 0x30, (byte) 0x34, (byte) 0x35, (byte) 0x32, (byte) 0x06,
+                    (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x07, (byte) 0x02, (byte) 0x01,
+            (byte) 0x02, (byte) 0x07, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x0e,
+                    (byte) 0x32, (byte) 0x30, (byte) 0x30, (byte) 0x35, (byte) 0x30, (byte) 0x33,
+                    (byte) 0x33, (byte) 0x31, (byte) 0x30, (byte) 0x37,
+            (byte) 0x35, (byte) 0x30, (byte) 0x35, (byte) 0x31, (byte) 0x06, (byte) 0x0e,
+                    (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x07, (byte) 0x01, (byte) 0x02, (byte) 0x01,
+            (byte) 0x03, (byte) 0x02, (byte) 0x00, (byte) 0x00, (byte) 0x08, (byte) 0xc0,
+                    (byte) 0x41, (byte) 0x65, (byte) 0x13, (byte) 0x4a, (byte) 0x87, (byte) 0x63,
+                    (byte) 0x29, (byte) 0x06, (byte) 0x0e, (byte) 0x2b,
+            (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x07,
+                    (byte) 0x01, (byte) 0x02, (byte) 0x01, (byte) 0x03, (byte) 0x04, (byte) 0x00,
+                    (byte) 0x00, (byte) 0x08, (byte) 0x40, (byte) 0x61,
+            (byte) 0x54, (byte) 0x5f, (byte) 0x71, (byte) 0x31, (byte) 0x41, (byte) 0x0d,
+                    (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x07, (byte) 0x01,
+            (byte) 0x09, (byte) 0x02, (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                    (byte) 0x04, (byte) 0x45, (byte) 0xe1, (byte) 0xcb, (byte) 0x90, (byte) 0x06,
+                    (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01,
+            (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x07, (byte) 0x01, (byte) 0x02,
+                    (byte) 0x01, (byte) 0x02, (byte) 0x02, (byte) 0x00, (byte) 0x00, (byte) 0x04,
+                    (byte) 0x45, (byte) 0x4a, (byte) 0x18, (byte) 0xa9,
+            (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x03, (byte) 0x07, (byte) 0x01, (byte) 0x02, (byte) 0x01,
+                    (byte) 0x02, (byte) 0x04, (byte) 0x02, (byte) 0x00,
+            (byte) 0x08, (byte) 0xc0, (byte) 0x41, (byte) 0x6b, (byte) 0x46, (byte) 0x46,
+                    (byte) 0x5e, (byte) 0xab, (byte) 0xfe, (byte) 0x06, (byte) 0x0e, (byte) 0x2b,
+                    (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+            (byte) 0x03, (byte) 0x07, (byte) 0x01, (byte) 0x02, (byte) 0x01, (byte) 0x02,
+                    (byte) 0x06, (byte) 0x02, (byte) 0x00, (byte) 0x08, (byte) 0x40, (byte) 0x61,
+                    (byte) 0x52, (byte) 0x2d, (byte) 0x32, (byte) 0x0e,
+            (byte) 0xb7, (byte) 0x4f, (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x07, (byte) 0x01,
+                    (byte) 0x08, (byte) 0x01, (byte) 0x01, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x04, (byte) 0x46, (byte) 0x0e, (byte) 0xd8,
+                    (byte) 0x00, (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x07,
+            (byte) 0x01, (byte) 0x10, (byte) 0x01, (byte) 0x01, (byte) 0x00, (byte) 0x00,
+                    (byte) 0x00, (byte) 0x04, (byte) 0xbf, (byte) 0xb9, (byte) 0x04, (byte) 0x1d,
+                    (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34,
+            (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x07, (byte) 0x01,
+                    (byte) 0x10, (byte) 0x01, (byte) 0x02, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                    (byte) 0x04, (byte) 0x42, (byte) 0x45, (byte) 0xa7,
+            (byte) 0x67, (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x07, (byte) 0x01, (byte) 0x10,
+                    (byte) 0x01, (byte) 0x03, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x04, (byte) 0x43, (byte) 0x49, (byte) 0x54, (byte) 0x7b,
+                    (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x02, (byte) 0x04, (byte) 0x20,
+            (byte) 0x02, (byte) 0x01, (byte) 0x01, (byte) 0x08, (byte) 0x00, (byte) 0x00,
+                    (byte) 0x04, (byte) 0x3f, (byte) 0x40, (byte) 0xb0, (byte) 0x0b, (byte) 0x06,
+                    (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01,
+            (byte) 0x01, (byte) 0x01, (byte) 0x03, (byte) 0x07, (byte) 0x01, (byte) 0x02,
+                    (byte) 0x01, (byte) 0x03, (byte) 0x07, (byte) 0x01, (byte) 0x00, (byte) 0x08,
+                    (byte) 0xc0, (byte) 0x41, (byte) 0x64, (byte) 0xec,
+            (byte) 0x27, (byte) 0xbe, (byte) 0xea, (byte) 0xe8, (byte) 0x06, (byte) 0x0e,
+                    (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x03,
+                    (byte) 0x07, (byte) 0x01, (byte) 0x02, (byte) 0x01,
+            (byte) 0x03, (byte) 0x0b, (byte) 0x01, (byte) 0x00, (byte) 0x08, (byte) 0x40,
+                    (byte) 0x61, (byte) 0x54, (byte) 0x64, (byte) 0xfa, (byte) 0x37, (byte) 0x49,
+                    (byte) 0x24, (byte) 0x06, (byte) 0x0e, (byte) 0x2b,
+            (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x03, (byte) 0x07,
+                    (byte) 0x01, (byte) 0x02, (byte) 0x01, (byte) 0x03, (byte) 0x08, (byte) 0x01,
+                    (byte) 0x00, (byte) 0x08, (byte) 0xc0, (byte) 0x41,
+            (byte) 0x65, (byte) 0x07, (byte) 0x63, (byte) 0x00, (byte) 0x5d, (byte) 0xb2,
+                    (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x03, (byte) 0x07, (byte) 0x01,
+            (byte) 0x02, (byte) 0x01, (byte) 0x03, (byte) 0x0c, (byte) 0x01, (byte) 0x00,
+                    (byte) 0x08, (byte) 0x40, (byte) 0x61, (byte) 0x54, (byte) 0x6c, (byte) 0x1a,
+                    (byte) 0x26, (byte) 0x02, (byte) 0xdb, (byte) 0x06,
+            (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01, (byte) 0x01,
+                    (byte) 0x03, (byte) 0x07, (byte) 0x01, (byte) 0x02, (byte) 0x01, (byte) 0x03,
+                    (byte) 0x09, (byte) 0x01, (byte) 0x00, (byte) 0x08,
+            (byte) 0xc0, (byte) 0x41, (byte) 0x65, (byte) 0x39, (byte) 0x64, (byte) 0xa0,
+                    (byte) 0x9b, (byte) 0x3d, (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x03,
+            (byte) 0x07, (byte) 0x01, (byte) 0x02, (byte) 0x01, (byte) 0x03, (byte) 0x0d,
+                    (byte) 0x01, (byte) 0x00, (byte) 0x08, (byte) 0x40, (byte) 0x61, (byte) 0x54,
+                    (byte) 0x5a, (byte) 0x0d, (byte) 0x9a, (byte) 0xdd,
+            (byte) 0xef, (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x03, (byte) 0x07, (byte) 0x01, (byte) 0x02,
+                    (byte) 0x01, (byte) 0x03, (byte) 0x0a, (byte) 0x01,
+            (byte) 0x00, (byte) 0x08, (byte) 0xc0, (byte) 0x41, (byte) 0x65, (byte) 0x1e,
+                    (byte) 0xe1, (byte) 0x8b, (byte) 0x4e, (byte) 0x23, (byte) 0x06, (byte) 0x0e,
+                    (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01,
+            (byte) 0x01, (byte) 0x03, (byte) 0x07, (byte) 0x01, (byte) 0x02, (byte) 0x01,
+                    (byte) 0x03, (byte) 0x0e, (byte) 0x01, (byte) 0x00, (byte) 0x08, (byte) 0x40,
+                    (byte) 0x61, (byte) 0x54, (byte) 0x53, (byte) 0x1d,
+            (byte) 0xdb, (byte) 0xcd, (byte) 0x29
+        };
+        PredatorUavMessageFactory factory = new PredatorUavMessageFactory();
+        PredatorUavMessage predatorUavMessage = factory.create(bytes);
+        assertNotNull(predatorUavMessage);
+        assertEquals(predatorUavMessage.displayHeader(), "Predator EG0104.5");
+        assertEquals(predatorUavMessage.getIdentifiers().size(), 31);
+        assertEquals(
+                predatorUavMessage.getUniversalLabel(), KlvConstants.PredatorMetadataLocalSetUl);
+
+        // Frame Center Latitude
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.FrameCenterLatitude));
+        IPredatorMetadataValue v =
+                predatorUavMessage.getField(PredatorMetadataKey.FrameCenterLatitude);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue frameCenterLat = (LatLonValue) v;
+        assertEquals(frameCenterLat.getDisplayName(), "Frame Center Latitude");
+        assertEquals(frameCenterLat.getDisplayableValue(), "-34.7897\u00B0");
+        assertEquals(frameCenterLat.getDegrees(), -34.7897, 0.0001);
+        assertEquals(
+                predatorUavMessage
+                        .getField((IKlvKey) PredatorMetadataKey.FrameCenterLatitude)
+                        .getDisplayableValue(),
+                "-34.7897\u00B0");
+
+        // Frame Center Longitude
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.FrameCenterLongitude));
+        v = predatorUavMessage.getField(PredatorMetadataKey.FrameCenterLongitude);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue frameCenterLon = (LatLonValue) v;
+        assertEquals(frameCenterLon.getDisplayName(), "Frame Center Longitude");
+        assertEquals(frameCenterLon.getDisplayableValue(), "138.6367\u00B0");
+        assertEquals(frameCenterLon.getDegrees(), 138.6367, 0.0001);
+
+        // Frame Center Elevation
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.FrameCenterElevation));
+        v = predatorUavMessage.getField(PredatorMetadataKey.FrameCenterElevation);
+        assertTrue(v instanceof AltitudeValue);
+        AltitudeValue frameCenterElevation = (AltitudeValue) v;
+        assertEquals(frameCenterElevation.getDisplayName(), "Frame Center Elevation");
+        assertEquals(frameCenterElevation.getDisplayableValue(), "1001.7 m");
+        assertEquals(frameCenterElevation.getElevation(), 1001.6700, 0.0001);
+
+        // Image Coordinate System
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.ImageCoordinateSystem));
+        v = predatorUavMessage.getField(PredatorMetadataKey.ImageCoordinateSystem);
+        assertTrue(v instanceof TextValue);
+        TextValue imageCoordinateSystem = (TextValue) v;
+        assertEquals(imageCoordinateSystem.getDisplayName(), "Image Coordinate System");
+        assertEquals(imageCoordinateSystem.getDisplayableValue(), "2");
+
+        // Target Width
+        assertTrue(predatorUavMessage.getIdentifiers().contains(PredatorMetadataKey.TargetWidth));
+        v = predatorUavMessage.getField(PredatorMetadataKey.TargetWidth);
+        assertTrue(v instanceof TargetWidth);
+        TargetWidth targetWidth = (TargetWidth) v;
+        assertEquals(targetWidth.getDisplayName(), "Target Width");
+        assertEquals(targetWidth.getDisplayableValue(), "7225.4 m");
+        assertEquals(targetWidth.getDistance(), 7225.445, 0.001);
+
+        // Start Date Time - UTC
+        assertTrue(
+                predatorUavMessage.getIdentifiers().contains(PredatorMetadataKey.StartDateTimeUtc));
+        v = predatorUavMessage.getField(PredatorMetadataKey.StartDateTimeUtc);
+        assertTrue(v instanceof DateTimeUTC);
+        DateTimeUTC startDateTime = (DateTimeUTC) v;
+        assertEquals(startDateTime.getDisplayName(), "Start Date Time (UTC)");
+        assertEquals(startDateTime.getDisplayableValue(), "20050331080452");
+
+        // Event Start Date Time - UTC
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.EventStartDateTimeUtc));
+        v = predatorUavMessage.getField(PredatorMetadataKey.EventStartDateTimeUtc);
+        assertTrue(v instanceof DateTimeUTC);
+        DateTimeUTC eventStartDateTime = (DateTimeUTC) v;
+        assertEquals(eventStartDateTime.getDisplayName(), "Event Start Date Time (UTC)");
+        assertEquals(eventStartDateTime.getDisplayableValue(), "20050331075051");
+
+        // User Defined Time Stamp
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.UserDefinedTimeStamp));
+        v = predatorUavMessage.getField(PredatorMetadataKey.UserDefinedTimeStamp);
+        assertTrue(v instanceof UserDefinedTimeStamp);
+        UserDefinedTimeStamp timestamp = (UserDefinedTimeStamp) v;
+        assertEquals(timestamp.getDisplayName(), "User Defined Time Stamp");
+        assertEquals(timestamp.getDisplayableValue(), "1112376646437500");
+
+        // Corner Latitude Point 1
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.CornerLatitudePoint1));
+        v = predatorUavMessage.getField(PredatorMetadataKey.CornerLatitudePoint1);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue cornerLatitudePoint1 = (LatLonValue) v;
+        assertEquals(cornerLatitudePoint1.getDisplayName(), "Corner Latitude Point 1");
+        assertEquals(cornerLatitudePoint1.getDisplayableValue(), "-34.7885\u00B0");
+        assertEquals(cornerLatitudePoint1.getDegrees(), -34.7885, 0.0001);
+
+        // Corner Latitude Point 2
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.CornerLatitudePoint2));
+        v = predatorUavMessage.getField(PredatorMetadataKey.CornerLatitudePoint2);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue cornerLatitudePoint2 = (LatLonValue) v;
+        assertEquals(cornerLatitudePoint2.getDisplayName(), "Corner Latitude Point 2");
+        assertEquals(cornerLatitudePoint2.getDisplayableValue(), "-34.7893\u00B0");
+        assertEquals(cornerLatitudePoint2.getDegrees(), -34.7893, 0.0001);
+
+        // Corner Latitude Point 3
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.CornerLatitudePoint3));
+        v = predatorUavMessage.getField(PredatorMetadataKey.CornerLatitudePoint3);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue cornerLatitudePoint3 = (LatLonValue) v;
+        assertEquals(cornerLatitudePoint3.getDisplayName(), "Corner Latitude Point 3");
+        assertEquals(cornerLatitudePoint3.getDisplayableValue(), "-34.7908\u00B0");
+        assertEquals(cornerLatitudePoint3.getDegrees(), -34.7908, 0.0001);
+
+        // Corner Latitude Point 4
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.CornerLatitudePoint4));
+        v = predatorUavMessage.getField(PredatorMetadataKey.CornerLatitudePoint4);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue cornerLatitudePoint4 = (LatLonValue) v;
+        assertEquals(cornerLatitudePoint4.getDisplayName(), "Corner Latitude Point 4");
+        assertEquals(cornerLatitudePoint4.getDisplayableValue(), "-34.7900\u00B0");
+        assertEquals(cornerLatitudePoint4.getDegrees(), -34.7900, 0.0001);
+
+        // Corner Longitude Point 1
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.CornerLongitudePoint1));
+        v = predatorUavMessage.getField(PredatorMetadataKey.CornerLongitudePoint1);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue cornerLongitudePoint1 = (LatLonValue) v;
+        assertEquals(cornerLongitudePoint1.getDisplayName(), "Corner Longitude Point 1");
+        assertEquals(cornerLongitudePoint1.getDisplayableValue(), "138.6373\u00B0");
+        assertEquals(cornerLongitudePoint1.getDegrees(), 138.6373, 0.0001);
+
+        // Corner Longitude Point 2
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.CornerLongitudePoint2));
+        v = predatorUavMessage.getField(PredatorMetadataKey.CornerLongitudePoint2);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue cornerLongitudePoint2 = (LatLonValue) v;
+        assertEquals(cornerLongitudePoint2.getDisplayName(), "Corner Longitude Point 2");
+        assertEquals(cornerLongitudePoint2.getDisplayableValue(), "138.6382\u00B0");
+        assertEquals(cornerLongitudePoint2.getDegrees(), 138.6382, 0.0001);
+
+        // Corner Longitude Point 3
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.CornerLongitudePoint3));
+        v = predatorUavMessage.getField(PredatorMetadataKey.CornerLongitudePoint3);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue cornerLongitudePoint3 = (LatLonValue) v;
+        assertEquals(cornerLongitudePoint3.getDisplayName(), "Corner Longitude Point 3");
+        assertEquals(cornerLongitudePoint3.getDisplayableValue(), "138.6360\u00B0");
+        assertEquals(cornerLongitudePoint3.getDegrees(), 138.6360, 0.0001);
+
+        // Corner Longitude Point 4
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.CornerLongitudePoint4));
+        v = predatorUavMessage.getField(PredatorMetadataKey.CornerLongitudePoint4);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue cornerLongitudePoint4 = (LatLonValue) v;
+        assertEquals(cornerLongitudePoint4.getDisplayName(), "Corner Longitude Point 4");
+        assertEquals(cornerLongitudePoint4.getDisplayableValue(), "138.6351\u00B0");
+        assertEquals(cornerLongitudePoint4.getDegrees(), 138.6351, 0.0001);
+
+        // Slant Range
+        assertTrue(predatorUavMessage.getIdentifiers().contains(PredatorMetadataKey.SlantRange));
+        v = predatorUavMessage.getField(PredatorMetadataKey.SlantRange);
+        assertTrue(v instanceof SlantRange);
+        SlantRange slantRange = (SlantRange) v;
+        assertEquals(slantRange.getDisplayName(), "Slant Range");
+        assertEquals(slantRange.getDisplayableValue(), "9142.0 m");
+        assertEquals(slantRange.getRange(), 9142.000, 0.001);
+
+        // Sensor Roll Angle
+        assertTrue(
+                predatorUavMessage.getIdentifiers().contains(PredatorMetadataKey.SensorRollAngle));
+        v = predatorUavMessage.getField(PredatorMetadataKey.SensorRollAngle);
+        assertTrue(v instanceof AngleValue);
+        AngleValue sensorRollAngle = (AngleValue) v;
+        assertEquals(sensorRollAngle.getDisplayName(), "Sensor Roll Angle");
+        assertEquals(sensorRollAngle.getDisplayableValue(), "-1.4454\u00B0");
+        assertEquals(sensorRollAngle.getDegrees(), -1.4454, 0.0001);
+
+        // Angle to North
+        assertTrue(predatorUavMessage.getIdentifiers().contains(PredatorMetadataKey.AngleToNorth));
+        v = predatorUavMessage.getField(PredatorMetadataKey.AngleToNorth);
+        assertTrue(v instanceof AngleValue);
+        AngleValue angleToNorth = (AngleValue) v;
+        assertEquals(angleToNorth.getDisplayName(), "Angle to North");
+        assertEquals(angleToNorth.getDisplayableValue(), "49.4135\u00B0");
+        assertEquals(angleToNorth.getDegrees(), 49.4135, 0.0001);
+
+        // Obliquity Angle
+        assertTrue(
+                predatorUavMessage.getIdentifiers().contains(PredatorMetadataKey.ObliquityAngle));
+        v = predatorUavMessage.getField(PredatorMetadataKey.ObliquityAngle);
+        assertTrue(v instanceof AngleValue);
+        AngleValue obliquityAngle = (AngleValue) v;
+        assertEquals(obliquityAngle.getDisplayName(), "Obliquity Angle");
+        assertEquals(obliquityAngle.getDisplayableValue(), "201.3300\u00B0");
+        assertEquals(obliquityAngle.getDegrees(), 201.3300, 0.0001);
+
+        // Platform Roll Angle
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.PlatformRollAngle));
+        v = predatorUavMessage.getField(PredatorMetadataKey.PlatformRollAngle);
+        assertTrue(v instanceof AngleValue);
+        AngleValue platformRollAngle = (AngleValue) v;
+        assertEquals(platformRollAngle.getDisplayName(), "Platform Roll Angle");
+        assertEquals(platformRollAngle.getDisplayableValue(), "22.0600\u00B0");
+        assertEquals(platformRollAngle.getDegrees(), 22.0600, 0.0001);
+
+        // Platform Pitch Angle
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.PlatformPitchAngle));
+        v = predatorUavMessage.getField(PredatorMetadataKey.PlatformPitchAngle);
+        assertTrue(v instanceof AngleValue);
+        AngleValue platformPitchAngle = (AngleValue) v;
+        assertEquals(platformPitchAngle.getDisplayName(), "Platform Pitch Angle");
+        assertEquals(platformPitchAngle.getDisplayableValue(), "31.6700\u00B0");
+        assertEquals(platformPitchAngle.getDegrees(), 31.6700, 0.0001);
+
+        // Platform Heading Angle
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.PlatformHeadingAngle));
+        v = predatorUavMessage.getField(PredatorMetadataKey.PlatformHeadingAngle);
+        assertTrue(v instanceof AngleValue);
+        AngleValue platformHeadingAngle = (AngleValue) v;
+        assertEquals(platformHeadingAngle.getDisplayName(), "Platform Heading Angle");
+        assertEquals(platformHeadingAngle.getDisplayableValue(), "20.0100\u00B0");
+        assertEquals(platformHeadingAngle.getDegrees(), 20.0100, 0.0001);
+
+        // Field of View (Horizontal)
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.FieldOfViewHorizontal));
+        v = predatorUavMessage.getField(PredatorMetadataKey.FieldOfViewHorizontal);
+        assertTrue(v instanceof AngleValue);
+        AngleValue fieldOfViewHorizontal = (AngleValue) v;
+        assertEquals(fieldOfViewHorizontal.getDisplayName(), "Field of View - Horizontal");
+        assertEquals(fieldOfViewHorizontal.getDisplayableValue(), "0.7527\u00B0");
+        assertEquals(fieldOfViewHorizontal.getDegrees(), 0.7527, 0.0001);
+
+        // Field of View (Vertical)
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.FieldOfViewVertical));
+        v = predatorUavMessage.getField(PredatorMetadataKey.FieldOfViewVertical);
+        assertTrue(v instanceof AngleValue);
+        AngleValue fieldOfViewVertical = (AngleValue) v;
+        assertEquals(fieldOfViewVertical.getDisplayName(), "Field of View - Vertical");
+        assertEquals(fieldOfViewVertical.getDisplayableValue(), "45.4000\u00B0");
+        assertEquals(fieldOfViewVertical.getDegrees(), 45.4000, 0.0001);
+
+        // Device Altitude
+        assertTrue(
+                predatorUavMessage.getIdentifiers().contains(PredatorMetadataKey.DeviceAltitude));
+        v = predatorUavMessage.getField(PredatorMetadataKey.DeviceAltitude);
+        assertTrue(v instanceof AltitudeValue);
+        AltitudeValue deviceAlt = (AltitudeValue) v;
+        assertEquals(deviceAlt.getDisplayName(), "Device Altitude");
+        assertEquals(deviceAlt.getDisplayableValue(), "3233.5 m");
+        assertEquals(deviceAlt.getElevation(), 3233.5413, 0.0001);
+
+        // Device Latitude
+        assertTrue(
+                predatorUavMessage.getIdentifiers().contains(PredatorMetadataKey.DeviceLatitude));
+        v = predatorUavMessage.getField(PredatorMetadataKey.DeviceLatitude);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue deviceLat = (LatLonValue) v;
+        assertEquals(deviceLat.getDisplayName(), "Device Latitude");
+        assertEquals(deviceLat.getDisplayableValue(), "-34.8381\u00B0");
+        assertEquals(deviceLat.getDegrees(), -34.8381, 0.0001);
+
+        // Device Longitude
+        assertTrue(
+                predatorUavMessage.getIdentifiers().contains(PredatorMetadataKey.DeviceLongitude));
+        v = predatorUavMessage.getField(PredatorMetadataKey.DeviceLongitude);
+        assertTrue(v instanceof LatLonValue);
+        LatLonValue deviceLon = (LatLonValue) v;
+        assertEquals(deviceLon.getDisplayName(), "Device Longitude");
+        assertEquals(deviceLon.getDisplayableValue(), "138.5680\u00B0");
+        assertEquals(deviceLon.getDegrees(), 138.5680, 0.0001);
+
+        // Image Source Device
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.ImageSourceDevice));
+        v = predatorUavMessage.getField(PredatorMetadataKey.ImageSourceDevice);
+        assertTrue(v instanceof ImageSourceDevice);
+        ImageSourceDevice imageSourceDevice = (ImageSourceDevice) v;
+        assertEquals(imageSourceDevice.getDisplayName(), "Image Source Device");
+        assertEquals(imageSourceDevice.getDisplayableValue(), "EO Nose");
+
+        // Episode Number
+        assertTrue(predatorUavMessage.getIdentifiers().contains(PredatorMetadataKey.EpisodeNumber));
+        v = predatorUavMessage.getField(PredatorMetadataKey.EpisodeNumber);
+        assertTrue(v instanceof TextValue);
+        TextValue episodeNumber = (TextValue) v;
+        assertEquals(episodeNumber.getDisplayName(), "Episode Number");
+        assertEquals(episodeNumber.getDisplayableValue(), "100");
+
+        // Device Designation
+        assertTrue(
+                predatorUavMessage
+                        .getIdentifiers()
+                        .contains(PredatorMetadataKey.DeviceDesignation));
+        v = predatorUavMessage.getField(PredatorMetadataKey.DeviceDesignation);
+        assertTrue(v instanceof TextValue);
+        TextValue deviceDesignation = (TextValue) v;
+        assertEquals(deviceDesignation.getDisplayName(), "Device Designation");
+        assertEquals(deviceDesignation.getDisplayableValue(), "10");
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetFactoryTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetFactoryTest.java
@@ -1,0 +1,54 @@
+package org.jmisb.api.klv.st0102.localset;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.st0102.*;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SecurityMetadataLocalSetFactoryTest extends LoggerChecks {
+    private SecurityMetadataLocalSet localSet;
+    private static final byte[] ItemDesignatorIdValue =
+            new byte[] {
+                (byte) 0x00,
+                (byte) 0x01,
+                (byte) 0x02,
+                (byte) 0x03,
+                (byte) 0x04,
+                (byte) 0x05,
+                (byte) 0x06,
+                (byte) 0x07,
+                (byte) 0x08,
+                (byte) 0x09,
+                (byte) 0x0A,
+                (byte) 0x0B,
+                (byte) 0x0C,
+                (byte) 0x0D,
+                (byte) 0x0E,
+                (byte) 0x0F
+            };
+
+    public SecurityMetadataLocalSetFactoryTest() {
+        super(SecurityMetadataLocalSet.class);
+    }
+
+    @Test
+    public void testParse() throws KlvParseException {
+        byte[] bytes =
+                new byte[] {
+                    0x06, 0x0e, 0x2b, 0x34, 0x02, 0x03, 0x01, 0x01, 0x0e, 0x01, 0x03, 0x03, 0x02,
+                    0x00, 0x00, 0x00, 0x12, 0x15, 0x10, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+                    0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+                };
+        SecurityMetadataLocalSetFactory factory = new SecurityMetadataLocalSetFactory();
+        SecurityMetadataLocalSet securityMetadataLocalSet = factory.create(bytes);
+        Assert.assertEquals(securityMetadataLocalSet.displayHeader(), "ST 0102 (local)");
+        Assert.assertNotNull(
+                securityMetadataLocalSet.getField(SecurityMetadataKey.ItemDesignatorId));
+        ISecurityMetadataValue val =
+                securityMetadataLocalSet.getField(SecurityMetadataKey.ItemDesignatorId);
+        Assert.assertTrue(val instanceof ItemDesignatorId);
+        ItemDesignatorId id = (ItemDesignatorId) val;
+        Assert.assertEquals(id.getItemDesignatorId(), ItemDesignatorIdValue);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0102/universalset/SecurityMetadataUniversalSetFactoryTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/universalset/SecurityMetadataUniversalSetFactoryTest.java
@@ -1,0 +1,83 @@
+package org.jmisb.api.klv.st0102.universalset;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.KlvConstants;
+import org.jmisb.api.klv.st0102.*;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SecurityMetadataUniversalSetFactoryTest {
+    @Test
+    public void parseBytes() throws KlvParseException {
+        byte[] bytes =
+                new byte[] {
+                    (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x02, (byte) 0x01,
+                            (byte) 0x01, (byte) 0x01,
+                    (byte) 0x02, (byte) 0x08, (byte) 0x02, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                            (byte) 0x00, (byte) 0x00,
+                    (byte) 0x6b, (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01,
+                            (byte) 0x01, (byte) 0x01,
+                    (byte) 0x03, (byte) 0x02, (byte) 0x08, (byte) 0x02, (byte) 0x01, (byte) 0x00,
+                            (byte) 0x00, (byte) 0x00,
+                    (byte) 0x00, (byte) 0x0e, (byte) 0x55, (byte) 0x4e, (byte) 0x43, (byte) 0x4c,
+                            (byte) 0x41, (byte) 0x53,
+                    (byte) 0x53, (byte) 0x49, (byte) 0x46, (byte) 0x49, (byte) 0x45, (byte) 0x44,
+                            (byte) 0x2f, (byte) 0x2f,
+                    (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01, (byte) 0x01,
+                            (byte) 0x01, (byte) 0x03,
+                    (byte) 0x07, (byte) 0x01, (byte) 0x20, (byte) 0x01, (byte) 0x02, (byte) 0x07,
+                            (byte) 0x00, (byte) 0x00,
+                    (byte) 0x13, (byte) 0x49, (byte) 0x53, (byte) 0x4f, (byte) 0x2d, (byte) 0x33,
+                            (byte) 0x31, (byte) 0x36,
+                    (byte) 0x36, (byte) 0x20, (byte) 0x54, (byte) 0x77, (byte) 0x6f, (byte) 0x20,
+                            (byte) 0x4c, (byte) 0x65,
+                    (byte) 0x74, (byte) 0x74, (byte) 0x65, (byte) 0x72, (byte) 0x06, (byte) 0x0e,
+                            (byte) 0x2b, (byte) 0x34,
+                    (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x03, (byte) 0x07, (byte) 0x01,
+                            (byte) 0x20, (byte) 0x01,
+                    (byte) 0x02, (byte) 0x08, (byte) 0x00, (byte) 0x00, (byte) 0x04, (byte) 0x2f,
+                            (byte) 0x2f, (byte) 0x55,
+                    (byte) 0x53, (byte) 0x06, (byte) 0x0e, (byte) 0x2b, (byte) 0x34, (byte) 0x01,
+                            (byte) 0x01, (byte) 0x01,
+                    (byte) 0x01, (byte) 0x0e, (byte) 0x01, (byte) 0x02, (byte) 0x05, (byte) 0x04,
+                            (byte) 0x00, (byte) 0x00,
+                    (byte) 0x00, (byte) 0x02, (byte) 0x00, (byte) 0x0C
+                };
+        SecurityMetadataUniversalSetFactory factory = new SecurityMetadataUniversalSetFactory();
+        SecurityMetadataUniversalSet universalSet = factory.create(bytes);
+        Assert.assertEquals(universalSet.displayHeader(), "ST 0102 (universal)");
+        Assert.assertEquals(
+                universalSet.getUniversalLabel(), KlvConstants.SecurityMetadataUniversalSetUl);
+        Assert.assertEquals(universalSet.getKeys().size(), 4);
+        Assert.assertTrue(
+                universalSet.getKeys().contains(SecurityMetadataKey.SecurityClassification));
+        Assert.assertEquals(
+                universalSet.getField(SecurityMetadataKey.SecurityClassification).getDisplayName(),
+                "Classification");
+        Assert.assertEquals(
+                universalSet
+                        .getField(SecurityMetadataKey.SecurityClassification)
+                        .getDisplayableValue(),
+                "UNCLASSIFIED//");
+        Assert.assertTrue(universalSet.getKeys().contains(SecurityMetadataKey.CcCodingMethod));
+        Assert.assertEquals(
+                universalSet.getField(SecurityMetadataKey.CcCodingMethod).getDisplayName(),
+                "Country Coding Method");
+        Assert.assertEquals(
+                universalSet.getField(SecurityMetadataKey.CcCodingMethod).getDisplayableValue(),
+                "ISO-3166 Two Letter");
+        Assert.assertTrue(universalSet.getKeys().contains(SecurityMetadataKey.ClassifyingCountry));
+        Assert.assertEquals(
+                universalSet.getField(SecurityMetadataKey.ClassifyingCountry).getDisplayName(),
+                "Classifying Country");
+        Assert.assertEquals(
+                universalSet.getField(SecurityMetadataKey.ClassifyingCountry).getDisplayableValue(),
+                "//US");
+        Assert.assertTrue(universalSet.getKeys().contains(SecurityMetadataKey.Version));
+        Assert.assertEquals(
+                universalSet.getField(SecurityMetadataKey.Version).getDisplayName(),
+                "ST0102 Version");
+        Assert.assertEquals(
+                universalSet.getField(SecurityMetadataKey.Version).getDisplayableValue(), "12");
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSetFactoryTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSetFactoryTest.java
@@ -1,0 +1,307 @@
+package org.jmisb.api.klv.st0808;
+
+import static org.testng.Assert.*;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.KlvConstants;
+import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.st0603.ST0603TimeStamp;
+import org.testng.annotations.Test;
+
+/** Tests for the ST0808 Ancillary Text Local Set Factory. */
+public class AncillaryTextLocalSetFactoryTest extends LoggerChecks {
+    AncillaryTextLocalSetFactoryTest() {
+        super(AncillaryTextLocalSet.class);
+    }
+
+    @Test
+    public void parseTags() throws KlvParseException {
+        final byte[] bytes =
+                new byte[] {
+                    0x06,
+                    0x0e,
+                    0x2b,
+                    0x34,
+                    0x02,
+                    0x03,
+                    0x01,
+                    0x01,
+                    0x0e,
+                    0x01,
+                    0x03,
+                    0x05,
+                    0x02,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x39,
+                    0x01,
+                    0x08,
+                    0x41,
+                    0x75,
+                    0x74,
+                    0x68,
+                    0x6f,
+                    0x72,
+                    0x20,
+                    0x31,
+                    0x02,
+                    0x08,
+                    0x00,
+                    0x03,
+                    (byte) 0xf3,
+                    (byte) 0xb3,
+                    0x5f,
+                    0x58,
+                    0x59,
+                    0x6c,
+                    0x03,
+                    0x09,
+                    0x4d,
+                    0x65,
+                    0x73,
+                    0x73,
+                    0x61,
+                    0x67,
+                    0x65,
+                    0x20,
+                    0x31,
+                    0x04,
+                    0x0e,
+                    0x54,
+                    0x65,
+                    0x73,
+                    0x74,
+                    0x20,
+                    0x43,
+                    0x68,
+                    0x61,
+                    0x74,
+                    0x20,
+                    0x52,
+                    0x6f,
+                    0x6f,
+                    0x6d,
+                    0x05,
+                    0x08,
+                    0x00,
+                    0x03,
+                    (byte) 0xf3,
+                    (byte) 0xb3,
+                    0x5f,
+                    0x58,
+                    0x59,
+                    0x6c
+                };
+        AncillaryTextLocalSetFactory factory = new AncillaryTextLocalSetFactory();
+        AncillaryTextLocalSet localSet = factory.create(bytes);
+        assertNotNull(localSet);
+        assertEquals(localSet.displayHeader(), "ST0808 Ancillary Text");
+        assertEquals(localSet.getUniversalLabel(), KlvConstants.AncillaryTextLocalSetUl);
+        assertEquals(localSet.getIdentifiers().size(), 5);
+        checkOriginatorExample(localSet);
+        checkPrecisionTimeStampExample(localSet);
+        checkMessageBodyExample(localSet);
+        checkSourceExample(localSet);
+        checkMessageCreationTimeExample(localSet);
+        assertEquals(
+                localSet.frameMessage(false),
+                new byte[] {
+                    0x06,
+                    0x0e,
+                    0x2b,
+                    0x34,
+                    0x02,
+                    0x03,
+                    0x01,
+                    0x01,
+                    0x0e,
+                    0x01,
+                    0x03,
+                    0x05,
+                    0x02,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x39,
+                    0x01,
+                    0x08,
+                    0x41,
+                    0x75,
+                    0x74,
+                    0x68,
+                    0x6f,
+                    0x72,
+                    0x20,
+                    0x31,
+                    0x02,
+                    0x08,
+                    0x00,
+                    0x03,
+                    (byte) 0xf3,
+                    (byte) 0xb3,
+                    0x5f,
+                    0x58,
+                    0x59,
+                    0x6c,
+                    0x03,
+                    0x09,
+                    0x4d,
+                    0x65,
+                    0x73,
+                    0x73,
+                    0x61,
+                    0x67,
+                    0x65,
+                    0x20,
+                    0x31,
+                    0x04,
+                    0x0e,
+                    0x54,
+                    0x65,
+                    0x73,
+                    0x74,
+                    0x20,
+                    0x43,
+                    0x68,
+                    0x61,
+                    0x74,
+                    0x20,
+                    0x52,
+                    0x6f,
+                    0x6f,
+                    0x6d,
+                    0x05,
+                    0x08,
+                    0x00,
+                    0x03,
+                    (byte) 0xf3,
+                    (byte) 0xb3,
+                    0x5f,
+                    0x58,
+                    0x59,
+                    0x6c
+                });
+        assertEquals(
+                localSet.frameMessage(true),
+                new byte[] {
+                    0x01,
+                    0x08,
+                    0x41,
+                    0x75,
+                    0x74,
+                    0x68,
+                    0x6f,
+                    0x72,
+                    0x20,
+                    0x31,
+                    0x02,
+                    0x08,
+                    0x00,
+                    0x03,
+                    (byte) 0xf3,
+                    (byte) 0xb3,
+                    0x5f,
+                    0x58,
+                    0x59,
+                    0x6c,
+                    0x03,
+                    0x09,
+                    0x4d,
+                    0x65,
+                    0x73,
+                    0x73,
+                    0x61,
+                    0x67,
+                    0x65,
+                    0x20,
+                    0x31,
+                    0x04,
+                    0x0e,
+                    0x54,
+                    0x65,
+                    0x73,
+                    0x74,
+                    0x20,
+                    0x43,
+                    0x68,
+                    0x61,
+                    0x74,
+                    0x20,
+                    0x52,
+                    0x6f,
+                    0x6f,
+                    0x6d,
+                    0x05,
+                    0x08,
+                    0x00,
+                    0x03,
+                    (byte) 0xf3,
+                    (byte) 0xb3,
+                    0x5f,
+                    0x58,
+                    0x59,
+                    0x6c
+                });
+    }
+
+    private void checkOriginatorExample(AncillaryTextLocalSet localSet) {
+        final String stringVal = "Author 1";
+        assertTrue(localSet.getIdentifiers().contains(AncillaryTextMetadataKey.Originator));
+        IAncillaryTextMetadataValue v = localSet.getField(AncillaryTextMetadataKey.Originator);
+        assertEquals(v.getDisplayName(), "Originator");
+        assertEquals(v.getDisplayableValue(), stringVal);
+        assertTrue(v instanceof NaturalText);
+        NaturalText text = (NaturalText) localSet.getField(AncillaryTextMetadataKey.Originator);
+        assertEquals(text.getValue(), stringVal);
+    }
+
+    private void checkPrecisionTimeStampExample(AncillaryTextLocalSet localSet) {
+        assertTrue(localSet.getIdentifiers().contains(AncillaryTextMetadataKey.PrecisionTimeStamp));
+        IAncillaryTextMetadataValue v =
+                localSet.getField(AncillaryTextMetadataKey.PrecisionTimeStamp);
+        assertEquals(v.getDisplayName(), "Precision Time Stamp");
+        assertEquals(v.getDisplayableValue(), "1112376654453100");
+        assertTrue(v instanceof ST0603TimeStamp);
+        ST0603TimeStamp timestamp =
+                (ST0603TimeStamp) localSet.getField(AncillaryTextMetadataKey.PrecisionTimeStamp);
+        assertEquals(timestamp.getDisplayableValueDateTime(), "2005-04-01T17:30:54.4531");
+        assertEquals(timestamp.getMicroseconds(), 1112376654453100L);
+    }
+
+    private void checkMessageBodyExample(AncillaryTextLocalSet localSet) {
+        final String stringVal = "Message 1";
+        assertTrue(localSet.getIdentifiers().contains(AncillaryTextMetadataKey.MessageBody));
+        IAncillaryTextMetadataValue v = localSet.getField(AncillaryTextMetadataKey.MessageBody);
+        assertEquals(v.getDisplayName(), "Message Body");
+        assertEquals(v.getDisplayableValue(), stringVal);
+        assertTrue(v instanceof NaturalText);
+        NaturalText text = (NaturalText) localSet.getField(AncillaryTextMetadataKey.MessageBody);
+        assertEquals(text.getValue(), stringVal);
+    }
+
+    private void checkSourceExample(AncillaryTextLocalSet localSet) {
+        final String stringVal = "Test Chat Room";
+        assertTrue(localSet.getIdentifiers().contains(AncillaryTextMetadataKey.Source));
+        IAncillaryTextMetadataValue v = localSet.getField(AncillaryTextMetadataKey.Source);
+        assertEquals(v.getDisplayName(), "Source");
+        assertEquals(v.getDisplayableValue(), stringVal);
+        assertTrue(v instanceof NaturalText);
+        NaturalText text = (NaturalText) localSet.getField(AncillaryTextMetadataKey.Source);
+        assertEquals(text.getValue(), stringVal);
+    }
+
+    private void checkMessageCreationTimeExample(AncillaryTextLocalSet localSet) {
+        assertTrue(
+                localSet.getIdentifiers().contains(AncillaryTextMetadataKey.MessageCreationTime));
+        IAncillaryTextMetadataValue v =
+                localSet.getField(AncillaryTextMetadataKey.MessageCreationTime);
+        assertEquals(v.getDisplayName(), "Message Creation Time");
+        assertEquals(v.getDisplayableValue(), "2005-04-01T17:30:54.4531");
+        assertTrue(v instanceof ST0603TimeStamp);
+        ST0603TimeStamp timestamp =
+                (ST0603TimeStamp) localSet.getField(AncillaryTextMetadataKey.MessageCreationTime);
+        assertEquals(timestamp.getDisplayableValueDateTime(), "2005-04-01T17:30:54.4531");
+        assertEquals(timestamp.getMicroseconds(), 1112376654453100L);
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetFactoryTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetFactoryTest.java
@@ -1,0 +1,150 @@
+package org.jmisb.api.klv.st0903.vtrack;
+
+import static org.testng.Assert.*;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IKlvKey;
+import org.jmisb.api.klv.IKlvValue;
+import org.jmisb.api.klv.LoggerChecks;
+import org.jmisb.api.klv.st0903.ST0903Version;
+import org.jmisb.api.klv.st0903.VmtiVerticalFieldOfView;
+import org.jmisb.api.klv.st0903.shared.IVTrackItemMetadataValue;
+import org.jmisb.api.klv.st0903.shared.IVTrackMetadataValue;
+import org.jmisb.api.klv.st0903.shared.VmtiTextString;
+import org.testng.annotations.Test;
+
+/** Tests for the ST0903 VTrack Local Set. */
+public class VTrackLocalSetFactoryTest extends LoggerChecks {
+    VTrackLocalSetFactoryTest() {
+        super(VTrackLocalSet.class);
+    }
+
+    @Test
+    public void parseLegacyEncoding() throws KlvParseException {
+        final byte[] bytes =
+                new byte[] {0x65, 0x06, 0x05, 0x03, 0x17, 0x02, 0x0e, 0x39, 0x0b, 0x01, 0x03};
+        VTrackLocalSetFactory factory = new VTrackLocalSetFactory();
+        VTrackLocalSet localSet = factory.create(bytes);
+        assertNotNull(localSet);
+        assertEquals(localSet.getIdentifiers().size(), 2);
+        assertTrue(localSet.getIdentifiers().contains(VTrackMetadataKey.VersionNumber));
+        IVTrackMetadataValue v = localSet.getField(VTrackMetadataKey.VersionNumber);
+        assertEquals(v.getDisplayName(), "Version Number");
+        assertEquals(v.getDisplayableValue(), "ST0903.3");
+        assertEquals(v.getBytes(), new byte[] {0x03});
+        assertTrue(v instanceof ST0903Version);
+        ST0903Version version = (ST0903Version) localSet.getField(VTrackMetadataKey.VersionNumber);
+        assertEquals(version.getVersion(), 3);
+        assertTrue(localSet.getIdentifiers().contains(VTrackMetadataKey.VTrackItemSeries));
+        IVTrackMetadataValue s = localSet.getField(VTrackMetadataKey.VTrackItemSeries);
+        assertEquals(s.getDisplayName(), "Track Points");
+        assertEquals(s.getDisplayableValue(), "[1 Points]");
+        assertTrue(s instanceof VTrackItemSeries);
+        VTrackItemSeries trackSeries = (VTrackItemSeries) s;
+        assertEquals(trackSeries.getTrackItems().size(), 1);
+        VTrackItem trackItem = trackSeries.getTrackItems().get(0);
+        assertEquals(trackItem.getTargetIdentifier(), 3);
+        assertEquals(trackItem.getDisplayName(), "VTrackItem");
+        assertEquals(trackItem.getIdentifiers().size(), 1);
+        assertTrue(trackItem.getIdentifiers().contains(VTrackItemMetadataKey.SensorVerticalFov));
+        IVTrackItemMetadataValue itemValue =
+                trackItem.getField(VTrackItemMetadataKey.SensorVerticalFov);
+        assertTrue(itemValue instanceof VmtiVerticalFieldOfView);
+        IKlvValue itemValueFromKey =
+                trackItem.getField((IKlvKey) VTrackItemMetadataKey.SensorVerticalFov);
+        assertTrue(itemValueFromKey instanceof VmtiVerticalFieldOfView);
+        assertEquals(itemValueFromKey.getDisplayableValue(), itemValue.getDisplayableValue());
+        VmtiVerticalFieldOfView verticalFoV = (VmtiVerticalFieldOfView) itemValue;
+        assertEquals(verticalFoV.getDisplayName(), "Vertical Field of View");
+        assertEquals(verticalFoV.getDisplayableValue(), "10.0\u00B0");
+        assertEquals(verticalFoV.getFieldOfView(), 10.00, 0.003);
+        assertEquals(
+                localSet.frameMessage(false),
+                new byte[] {
+                    (byte) 0x06, // UL
+                    (byte) 0x0E,
+                    (byte) 0x2B,
+                    (byte) 0x34,
+                    (byte) 0x02,
+                    (byte) 0x03,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x0E,
+                    (byte) 0x01,
+                    (byte) 0x03,
+                    (byte) 0x03,
+                    (byte) 0x1e,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    0x12, // LS length
+                    0x0b, // Version - bumped to current
+                    0x01,
+                    0x05,
+                    0x0d, // Num track items
+                    0x01,
+                    0x01,
+                    0x65, // VTrackSeries
+                    0x06, // series length
+                    0x05, // item length
+                    0x03, // target id
+                    0x17, // vertical fov - note IMAP encoding
+                    0x02,
+                    0x05,
+                    0x00,
+                    0x01, // Checksum
+                    0x02,
+                    (byte) 0x91,
+                    (byte) 0xe2
+                });
+    }
+
+    @Test
+    public void parseTagsWithChecksum() throws KlvParseException {
+        final byte[] bytes =
+                new byte[] {
+                    0x0a, 0x0E, 0x44, 0x53, 0x54, 0x4F, 0x5F, 0x41, 0x44, 0x53, 0x53, 0x5F, 0x56,
+                    0x4D, 0x54, 0x49, 0x0b, 0x01, 0x04, 0x01, 0x02, 0x55, 0x3b
+                };
+        VTrackLocalSetFactory factory = new VTrackLocalSetFactory();
+        VTrackLocalSet localSet = factory.create(bytes);
+        assertNotNull(localSet);
+        assertEquals(localSet.getIdentifiers().size(), 2);
+        checkVersionNumberExample(localSet);
+        checkSystemNameExample(localSet);
+    }
+
+    private void checkSystemNameExample(VTrackLocalSet localSet) {
+        final String stringVal = "DSTO_ADSS_VMTI";
+        assertTrue(localSet.getIdentifiers().contains(VTrackMetadataKey.SystemName));
+        IVTrackMetadataValue v = localSet.getField(VTrackMetadataKey.SystemName);
+        assertEquals(v.getDisplayName(), "System Name/Description");
+        assertEquals(v.getDisplayName(), VmtiTextString.SYSTEM_NAME);
+        assertEquals(v.getDisplayableValue(), stringVal);
+        assertTrue(v instanceof VmtiTextString);
+        VmtiTextString text = (VmtiTextString) localSet.getField(VTrackMetadataKey.SystemName);
+        assertEquals(text.getValue(), stringVal);
+    }
+
+    private void checkVersionNumberExample(VTrackLocalSet localSet) {
+        final String stringVal = "ST0903.4";
+        assertTrue(localSet.getIdentifiers().contains(VTrackMetadataKey.VersionNumber));
+        IVTrackMetadataValue v = localSet.getField(VTrackMetadataKey.VersionNumber);
+        assertEquals(v.getDisplayName(), "Version Number");
+        assertEquals(v.getDisplayableValue(), stringVal);
+        assertEquals(v.getBytes(), new byte[] {0x04});
+        assertTrue(v instanceof ST0903Version);
+        ST0903Version version = (ST0903Version) localSet.getField(VTrackMetadataKey.VersionNumber);
+        assertEquals(version.getVersion(), 4);
+        ST0903Version versionFromIKlvKey =
+                (ST0903Version) localSet.getField((IKlvKey) VTrackMetadataKey.VersionNumber);
+        assertEquals(versionFromIKlvKey.getVersion(), 4);
+        assertEquals(
+                localSet.getUniversalLabel().getBytes(),
+                new byte[] {
+                    0x06, 0x0e, 0x2b, 0x34, 0x02, 0x03, 0x01, 0x01, 0x0e, 0x01, 0x03, 0x03, 0x1e,
+                    0x00, 0x00, 0x00
+                });
+        assertEquals(localSet.displayHeader(), "ST0903 VTrack");
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,4 +27,9 @@ This example is a work-in-progress. See [its README](movingfeatures/README.md) f
 ## gstsink
 
 It provides a GStreamer Sink for KLV metadata.
-This example is a work-in-progress See [its README](gstsink/README.md) for more information.
+This example is a work-in-progress. See [its README](gstsink/README.md) for more information.
+
+## parserplugin
+
+It shows how to parse an unsupported KLV blob (perhaps a local set or universal set) without changing jMISB.
+This example considered complete. See [its README](parserplugin/README.md) for more information.

--- a/examples/parserplugin/README.md
+++ b/examples/parserplugin/README.md
@@ -1,0 +1,75 @@
+# Parser Plugin example for jMISB
+
+This is demonstration / example code for <https://github.com/WestRidgeSystems/jmisb>
+
+It shows how to add a parser to jMISB without modifying the source code. This might be useful
+where you need to support a custom (not MISB standardised) local set or universal set.
+
+In this example (based on a production system), there is a message that is not parsed correctly by
+jMISB, and is to returned as a `RawMisbMessage`.
+
+The structure looks like:
+
+``` txt
+0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x07, 0x02, 0x01, 0x01, 0x01, 0x05, 0x00, 0x00,
+0x08, 0x00, 0x05, 0x09, 0x95, 0xc4, 0xff, 0xba, 0x00
+```
+
+For the sake of this example, this is the "Time Message" structure.
+
+The first 16 bytes are a Universal Label. Typically you'd have documentation defining your message,
+but in this case, it happens to match the Precision Time Stamp field registered in SMPTE RP210.
+The next byte (`0x08`) is the length - it is BER-OID encoded, but for this example is effectively
+a constant. The remaining 8 bytes are the timestamp value.
+
+There is more on this in TRM1006, which just happens to use the same structure for one of its examples.
+
+Writing a parser for this is relatively easy. One approach would be to skip over the Universal
+Label and length, and then parse the timestamp. Because a timestamp is such a common thing in motion
+imagery, we can just use the code in ST0603 for the timestamp itself. A more complex example might use
+the `LdsParser` utility code to parse a local set, or the `UdsParser` to parse a universal set. More
+advanced parsing is of course possible. If you are looking for a simple local set example, try ST0808.
+
+So we can parse the message, and return our own `IMisbMessage` implementation instead of getting a
+`RawMisbMessage`. That implementation is `TimeMessage` in the example code. The supporting code is
+more complex than strictly needed, but is intended provide a model for more complex structures.
+
+To link in our parser, we use a simple factory (`TimeMessageFactory` in the example). That gets
+registered with code that looks like:
+
+``` java
+        TimeMessageFactory timeMessageFactory = new TimeMessageFactory();
+        MisbMessageFactory.getInstance()
+                .registerHandler(TimeMessageConstants.TIME_STAMP_UL, timeMessageFactory);
+```
+
+The constant `TIME_STAMP_UL` is just the `UniversalLabel` that matches what we want to handle.
+
+When its all wired up, the output of the metadata dump will look like:
+
+``` txt
+Time Message Example
+        Precision Time Stamp: 2014-12-07T00:55:43.424
+```
+
+Note that this plugin is not restricted to command line parsing. It will work wherever its loaded.
+
+## Building
+
+To build the example, use maven.
+
+``` sh
+mvn clean install
+```
+
+## Using
+
+There are several ways to invoke it. One way is:
+
+``` sh
+java -jar target/parserplugin-1.10.0-SNAPSHOT-jar-with-dependencies.jar {filename}
+```
+
+## Helping us
+
+Please provide pull requests.

--- a/examples/parserplugin/nbactions.xml
+++ b/examples/parserplugin/nbactions.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<actions>
+        <action>
+            <actionName>run</actionName>
+            <packagings>
+                <packaging>jar</packaging>
+            </packagings>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
+            </goals>
+            <properties>
+                <exec.args>-classpath %classpath ${packageClassName} /home/bradh/jmisb/examples/parserplugin/t.mpg</exec.args>
+                <exec.executable>java</exec.executable>
+            </properties>
+        </action>
+        <action>
+            <actionName>debug</actionName>
+            <packagings>
+                <packaging>jar</packaging>
+            </packagings>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
+            </goals>
+            <properties>
+                <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName} /home/bradh/jmisb/examples/parserplugin/t.mpg</exec.args>
+                <exec.executable>java</exec.executable>
+                <jpda.listen>true</jpda.listen>
+            </properties>
+        </action>
+        <action>
+            <actionName>profile</actionName>
+            <packagings>
+                <packaging>jar</packaging>
+            </packagings>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
+            </goals>
+            <properties>
+                <exec.args>-classpath %classpath ${packageClassName} /home/bradh/jmisb/examples/parserplugin/t.mpg</exec.args>
+                <exec.executable>java</exec.executable>
+            </properties>
+        </action>
+    </actions>

--- a/examples/parserplugin/pom.xml
+++ b/examples/parserplugin/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jmisb</groupId>
+        <artifactId>examples</artifactId>
+        <version>1.10.0-SNAPSHOT</version>
+    </parent>
+    <groupId>org.jmisb.examples</groupId>
+    <artifactId>parserplugin</artifactId>
+    <name>Parser Plugin example</name>
+    <description>Example code to add an extra plugin to the parser</description>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.jmisb</groupId>
+            <artifactId>jmisb-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <!-- java source code formatter -->
+                <groupId>com.theoryinpractise</groupId>
+                <artifactId>googleformatter-maven-plugin</artifactId>
+                <version>${googleformatter.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>reformat-sources</id>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.plugin.version}</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>org.jmisb.examples.parserplugin.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase> 
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/Main.java
+++ b/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/Main.java
@@ -1,0 +1,20 @@
+package org.jmisb.examples.parserplugin;
+
+import java.io.IOException;
+import org.jmisb.api.klv.MisbMessageFactory;
+import org.jmisb.examples.parserplugin.timemessage.TimeMessageConstants;
+import org.jmisb.examples.parserplugin.timemessage.TimeMessageFactory;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        if (args.length < 1) {
+            System.out.println("Need to specify the file name on the command line");
+            System.exit(1);
+        }
+        TimeMessageFactory timeMessageFactory = new TimeMessageFactory();
+        MisbMessageFactory.getInstance()
+                .registerHandler(TimeMessageConstants.TIME_STAMP_UL, timeMessageFactory);
+        MetadataPlayer player = new MetadataPlayer();
+        player.play(args[0]);
+    }
+}

--- a/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/MetadataPlayer.java
+++ b/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/MetadataPlayer.java
@@ -1,0 +1,85 @@
+package org.jmisb.examples.parserplugin;
+
+import java.io.IOException;
+import org.jmisb.api.klv.IKlvKey;
+import org.jmisb.api.klv.IKlvValue;
+import org.jmisb.api.klv.IMisbMessage;
+import org.jmisb.api.klv.INestedKlvValue;
+import org.jmisb.api.video.IFileEventListener;
+import org.jmisb.api.video.IMetadataListener;
+import org.jmisb.api.video.IVideoFileInput;
+import org.jmisb.api.video.MetadataFrame;
+import org.jmisb.api.video.VideoFileInput;
+import org.jmisb.api.video.VideoFileInputOptions;
+import org.jmisb.core.klv.ArrayUtils;
+
+public class MetadataPlayer implements IMetadataListener, IFileEventListener {
+
+    private IVideoFileInput fileInput;
+
+    public MetadataPlayer() {}
+
+    public void play(String filename) throws IOException {
+        // These options configure for metadata decode only
+        VideoFileInputOptions videoFileInputOptions =
+                new VideoFileInputOptions(false, true, false, false);
+        fileInput = new VideoFileInput(videoFileInputOptions);
+        fileInput.addMetadataListener(this);
+        fileInput.addFileEventListener(this);
+        fileInput.open(filename);
+    }
+
+    @Override
+    // This is from IMetadataListener
+    public void onMetadataReceived(MetadataFrame metadataFrame) {
+        outputTopLevelMessageHeader(metadataFrame.getMisbMessage());
+        outputNestedKlvValue(metadataFrame.getMisbMessage(), 1);
+    }
+
+    private void outputTopLevelMessageHeader(IMisbMessage misbMessage) {
+        String displayHeader = misbMessage.displayHeader();
+        if (displayHeader.equalsIgnoreCase("Unknown")) {
+            System.out.println(
+                    displayHeader
+                            + " ["
+                            + ArrayUtils.toHexString(misbMessage.getUniversalLabel().getBytes())
+                                    .trim()
+                            + "]");
+            outputUnknownMessageContent(misbMessage.frameMessage(true));
+        } else {
+            System.out.println(displayHeader);
+        }
+    }
+
+    private void outputUnknownMessageContent(byte[] frameMessage) {
+        System.out.println(ArrayUtils.toHexString(frameMessage, 16, true));
+    }
+
+    @Override
+    // This is from IFileEventListener
+    public void onEndOfFile() {
+        try {
+            fileInput.close();
+        } catch (IOException ex) {
+            System.out.println("Failed to close file: " + ex.getMessage());
+        }
+    }
+
+    private void outputNestedKlvValue(INestedKlvValue nestedKlvValue, int indentationLevel) {
+        for (IKlvKey identifier : nestedKlvValue.getIdentifiers()) {
+            IKlvValue value = nestedKlvValue.getField(identifier);
+            outputValueWithIndentation(value, indentationLevel);
+            // if this has nested content, output that at the next indentation level
+            if (value instanceof INestedKlvValue) {
+                outputNestedKlvValue((INestedKlvValue) value, indentationLevel + 1);
+            }
+        }
+    }
+
+    private void outputValueWithIndentation(IKlvValue value, int indentationLevel) {
+        for (int i = 0; i < indentationLevel; ++i) {
+            System.out.print("\t");
+        }
+        System.out.println(value.getDisplayName() + ": " + value.getDisplayableValue());
+    }
+}

--- a/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/ITimeMessageValue.java
+++ b/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/ITimeMessageValue.java
@@ -1,0 +1,13 @@
+package org.jmisb.examples.parserplugin.timemessage;
+
+import org.jmisb.api.klv.IKlvValue;
+
+/** Interface for a value in a Time Message. */
+public interface ITimeMessageValue extends IKlvValue {
+    /**
+     * Get the encoded bytes associated with a value.
+     *
+     * @return The encoded byte array
+     */
+    byte[] getBytes();
+}

--- a/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/PrecisionTimeStamp.java
+++ b/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/PrecisionTimeStamp.java
@@ -1,0 +1,57 @@
+package org.jmisb.examples.parserplugin.timemessage;
+
+import java.time.LocalDateTime;
+import org.jmisb.api.klv.st0603.ST0603TimeStamp;
+
+/**
+ * Precision Time Stamp Microseconds.
+ *
+ * <p>This is the only field in our Time Message example, but most messages would be more complex.
+ */
+public class PrecisionTimeStamp extends ST0603TimeStamp implements ITimeMessageValue {
+    /**
+     * Create from value.
+     *
+     * @param microseconds Microseconds since the epoch
+     */
+    public PrecisionTimeStamp(long microseconds) {
+        super(microseconds);
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * @param bytes Encoded byte array, length of 8 bytes.
+     */
+    public PrecisionTimeStamp(byte[] bytes) {
+        super(bytes);
+        if (bytes.length < 8) {
+            throw new IllegalArgumentException(
+                    this.getDisplayName() + " encoding is an 8-byte unsigned int");
+        }
+    }
+
+    /**
+     * Create from {@code LocalDateTime}.
+     *
+     * @param dateTime The date and time
+     */
+    public PrecisionTimeStamp(LocalDateTime dateTime) {
+        super(dateTime);
+    }
+
+    @Override
+    public final String getDisplayName() {
+        return "Precision Time Stamp";
+    }
+
+    @Override
+    public byte[] getBytes() {
+        return getBytesFull();
+    }
+
+    @Override
+    public final String getDisplayableValue() {
+        return this.getDisplayableValueDateTime();
+    }
+}

--- a/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/TimeMessage.java
+++ b/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/TimeMessage.java
@@ -1,0 +1,81 @@
+package org.jmisb.examples.parserplugin.timemessage;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ArrayBuilder;
+import org.jmisb.api.klv.IKlvKey;
+import org.jmisb.api.klv.IMisbMessage;
+import org.jmisb.api.klv.UniversalLabel;
+
+/**
+ * Example Time Message.
+ *
+ * <p>This example handles a simple message, comprising a Universal Label, a length, and a single
+ * field that is an 8 byte timestamp.
+ */
+public class TimeMessage implements IMisbMessage {
+
+    /** Map containing all elements in the message. */
+    private final Map<TimeMessageKey, ITimeMessageValue> map = new TreeMap<>();
+
+    /**
+     * Create the time message from the given key/value pairs.
+     *
+     * @param values Tag/value pairs to be included in the time message.
+     */
+    public TimeMessage(Map<TimeMessageKey, ITimeMessageValue> values) {
+        map.putAll(values);
+    }
+
+    /**
+     * Create the time message from encoded bytes.
+     *
+     * @param bytes the encoded byte array, including the universal label.
+     * @throws KlvParseException if parsing fails
+     */
+    public TimeMessage(byte[] bytes) throws KlvParseException {
+        if (bytes.length != UniversalLabel.LENGTH + 1 + 8) {
+            throw new KlvParseException("Incorrect number of bytes for an example Time Message");
+        }
+        byte[] timestampBytes = Arrays.copyOfRange(bytes, UniversalLabel.LENGTH + 1, bytes.length);
+        PrecisionTimeStamp timeStamp = new PrecisionTimeStamp(timestampBytes);
+        map.put(TimeMessageKey.PrecisionTimeStamp, timeStamp);
+    }
+
+    @Override
+    public UniversalLabel getUniversalLabel() {
+        return TimeMessageConstants.TIME_STAMP_UL;
+    }
+
+    @Override
+    public byte[] frameMessage(boolean isNested) {
+        ArrayBuilder builder = new ArrayBuilder();
+        for (TimeMessageKey tag : map.keySet()) {
+            byte[] valueBytes = getField(tag).getBytes();
+            builder.append(valueBytes);
+        }
+        if (!isNested) {
+            builder.prependLength();
+            builder.prepend(TimeMessageConstants.TIME_STAMP_UL);
+        }
+        return builder.toBytes();
+    }
+
+    @Override
+    public String displayHeader() {
+        return "Time Message Example";
+    }
+
+    @Override
+    public ITimeMessageValue getField(IKlvKey tag) {
+        return map.get((TimeMessageKey) tag);
+    }
+
+    @Override
+    public Set<? extends IKlvKey> getIdentifiers() {
+        return map.keySet();
+    }
+}

--- a/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/TimeMessageConstants.java
+++ b/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/TimeMessageConstants.java
@@ -1,0 +1,19 @@
+package org.jmisb.examples.parserplugin.timemessage;
+
+import org.jmisb.api.klv.UniversalLabel;
+
+/** Constants used in the Time Message example. */
+public class TimeMessageConstants {
+    /**
+     * The Universal Label used in the time message.
+     *
+     * <p>In this case, its the KLV Universal Label (UL) for Precision Time Stamp from SMPTE RP210.
+     * Your code may or may not be formally published.
+     */
+    public static final UniversalLabel TIME_STAMP_UL =
+            new UniversalLabel(
+                    new byte[] {
+                        0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x07, 0x02, 0x01, 0x01,
+                        0x01, 0x05, 0x00, 0x00
+                    });
+}

--- a/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/TimeMessageFactory.java
+++ b/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/TimeMessageFactory.java
@@ -1,0 +1,19 @@
+package org.jmisb.examples.parserplugin.timemessage;
+
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IMisbMessage;
+import org.jmisb.api.klv.IMisbMessageFactory;
+
+/**
+ * Factory for TimeMessage example.
+ *
+ * <p>The concept is that the main KLV parser looks up a factory instance based on the Universal
+ * Label in the message.
+ */
+public class TimeMessageFactory implements IMisbMessageFactory {
+
+    @Override
+    public IMisbMessage create(byte[] bytes) throws KlvParseException {
+        return new TimeMessage(bytes);
+    }
+}

--- a/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/TimeMessageKey.java
+++ b/examples/parserplugin/src/main/java/org/jmisb/examples/parserplugin/timemessage/TimeMessageKey.java
@@ -1,0 +1,24 @@
+package org.jmisb.examples.parserplugin.timemessage;
+
+import org.jmisb.api.klv.IKlvKey;
+
+/**
+ * Metadata keys for Time Message example.
+ *
+ * <p>A real message would likely have more than one key.
+ */
+public enum TimeMessageKey implements IKlvKey {
+    /** The precision time stamp key. */
+    PrecisionTimeStamp(1);
+
+    private final int key;
+
+    private TimeMessageKey(int tag) {
+        this.key = tag;
+    }
+
+    @Override
+    public int getIdentifier() {
+        return key;
+    }
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -15,5 +15,6 @@
         <module>systemout</module>
         <module>movingfeatures</module>
         <module>gstsink</module>
+        <module>parserplugin</module>
     </modules>
 </project>


### PR DESCRIPTION
## Motivation and Context
As discussed in #241, it would be useful to be able to plug in additional handlers. The API extension for that also provides an opportunity to clean up a chain of `if(...)` calls.

## Description
Adds a factory interface, and factories for each of the affected top level message implementations.

Also adds an example showing how to use it externally.

## How Has This Been Tested?
Unit tests.
Ran viewer on some test data to make sure basic parsing is still OK.
Ran example on test data that has the non-standard structure.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

