### PR TITLE
st0808: fix minor javadoc issue

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSet.java
@@ -51,7 +51,7 @@ public class AncillaryTextLocalSet implements IMisbMessage {
         return null;
     }
 
-    /** Map containing all non-repeating elements in the message. */
+    /** Map containing all elements in the message. */
     private final SortedMap<AncillaryTextMetadataKey, IAncillaryTextMetadataValue> map =
             new TreeMap<>();
 


### PR DESCRIPTION
## Motivation and Context
Fixes a minor cut-n-paste issue in the ST0808 javadocs.

## Description
No code changes, just the docs.

## How Has This Been Tested?
N/A.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

