### PR TITLE
chore: remove TODO comment

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0102/CcmDate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/CcmDate.java
@@ -42,7 +42,6 @@ public class CcmDate implements ISecurityMetadataValue {
                     "Classifying Country Coding Method Version Date must have the format YYYY-MM-DD");
         }
 
-        // TODO: can we avoid the string allocation?
         String dateString = new String(bytes, StandardCharsets.US_ASCII);
         try {
             date = LocalDate.parse(dateString, ISO_LOCAL_DATE);

--- a/api/src/main/java/org/jmisb/api/klv/st0102/DeclassificationDate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/DeclassificationDate.java
@@ -36,7 +36,6 @@ public class DeclassificationDate implements ISecurityMetadataValue {
                     "Declassification Date must have the format YYYYMMDD");
         }
 
-        // TODO: can we avoid the string allocation?
         String dateString = new String(bytes, StandardCharsets.US_ASCII);
         try {
             date = LocalDate.parse(dateString, BASIC_ISO_DATE);

--- a/api/src/main/java/org/jmisb/api/klv/st0102/OcmDate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/OcmDate.java
@@ -39,7 +39,6 @@ public class OcmDate implements ISecurityMetadataValue {
                     "Object Country Coding Method Version Date must have the format YYYY-MM-DD");
         }
 
-        // TODO: can we avoid the string allocation?
         String dateString = new String(bytes, StandardCharsets.US_ASCII);
         try {
             date = LocalDate.parse(dateString, ISO_LOCAL_DATE);


### PR DESCRIPTION
## Motivation and Context

We have comments that are TODO items about avoiding a string allocation.

I had a look at alternatives to String for `LocalDate.parse()`, and while it can potentially take
any CharSequence, those require char[] and we're working from UTF-8 byte[].

In addition, the implementation of `LocalDate.parse()` ends up calling into a method that calls
`toString()` on the input text, so its not going to save us anything.

## Description

Just remove the comment. There are no code changes.

## How Has This Been Tested?
Ran unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

