### PR TITLE
fix: update VTrack test case

### DIFF
--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetTest.java
@@ -240,11 +240,11 @@ public class VTrackLocalSetTest extends LoggerChecks {
         VTrackLocalSet localSet = buildLocalSetValues();
         byte[] expectedBytes =
                 new byte[] {
-                    0x03, 0x0E, 0x44, 0x53, 0x54, 0x4F, 0x5F, 0x41, 0x44, 0x53, 0x53, 0x5F, 0x56,
-                    0x4D, 0x54, 0x49, 0x04, 0x01, 0x04,
+                    0x0a, 0x0E, 0x44, 0x53, 0x54, 0x4F, 0x5F, 0x41, 0x44, 0x53, 0x53, 0x5F, 0x56,
+                    0x4D, 0x54, 0x49, 0x0b, 0x01, 0x04, 0x0d, 0x01, 0x00
                 };
-        // TODO: fix
-        // assertEquals(localSet.frameMessage(true), expectedBytes);
+        byte[] framedMessage = localSet.frameMessage(true);
+        assertEquals(framedMessage, expectedBytes);
         assertTrue(localSet instanceof IMisbMessage);
         assertEquals(localSet.displayHeader(), "ST0903 VTrack");
         assertEquals(localSet.getUniversalLabel(), KlvConstants.VTrackLocalSetUl);


### PR DESCRIPTION
## Motivation and Context
For reasons I can't recall, I left a TODO item in one of the VTrack tests.  This PR fixes that.

## Description
Replaces some commented-out code and removes the TODO. Only affects test code.

## How Has This Been Tested?
Updated the test, re-ran all the unit tests.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

