### PR TITLE
example(gst): add missing GST buffer unmap()

### DIFF
--- a/examples/gstsink/src/main/java/org/jmisb/examples/gstsink/Main.java
+++ b/examples/gstsink/src/main/java/org/jmisb/examples/gstsink/Main.java
@@ -2,6 +2,7 @@ package org.jmisb.examples.gstsink;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import org.freedesktop.gstreamer.Buffer;
 import org.freedesktop.gstreamer.Bus;
 import org.freedesktop.gstreamer.FlowReturn;
 import org.freedesktop.gstreamer.Gst;
@@ -29,7 +30,8 @@ public class Main {
                 (AppSink.NEW_SAMPLE)
                         (AppSink elem) -> {
                             Sample sample = elem.pullSample();
-                            ByteBuffer byteBuffer = sample.getBuffer().map(false);
+                            Buffer buffer = sample.getBuffer();
+                            ByteBuffer byteBuffer = buffer.map(false);
                             byte[] bytes = new byte[byteBuffer.capacity()];
                             byteBuffer.get(bytes);
                             try {
@@ -41,6 +43,7 @@ public class Main {
                             } catch (KlvParseException e) {
                                 System.err.println(e);
                             }
+                            buffer.unmap();
                             sample.dispose();
                             return FlowReturn.OK;
                         });


### PR DESCRIPTION
## Motivation and Context
There was some follow-up discussion on https://github.com/WestRidgeSystems/jmisb/pull/240 where neilcsmith-net pointed out an implementation error in the gstreamer example.

## Description
Reworks the code to implement the required `unmap()` call.

## How Has This Been Tested?
No testing, although the fix is concurred by the original reporter, and he's the java gstreamer lead, so I'm feeling OK with it.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [N/A] My change requires a change to the documentation.
- [N/A] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

