### PR TITLE
fix: use BOM instead of aggregate for SBOM

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -159,7 +159,7 @@
                     <execution>
                         <phase>verify</phase>
                         <goals>
-                            <goal>makeAggregateBom</goal>
+                            <goal>makeBom</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -240,5 +240,3 @@
         </profile>
     </profiles>
 </project>
-
-

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -87,7 +87,7 @@
                     <execution>
                         <phase>verify</phase>
                         <goals>
-                            <goal>makeAggregateBom</goal>
+                            <goal>makeBom</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -135,5 +135,3 @@
         </profile>
     </profiles>
 </project>
-
-

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -108,12 +108,12 @@
                     <execution>
                         <phase>verify</phase>
                         <goals>
-                            <goal>makeAggregateBom</goal>
+                            <goal>makeBom</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
-                    <projectType>library</projectType>
+                    <projectType>application</projectType>
                     <schemaVersion>${cyclonedx.schema.version}</schemaVersion>
                     <includeBomSerialNumber>true</includeBomSerialNumber>
                     <includeCompileScope>true</includeCompileScope>
@@ -156,4 +156,3 @@
         </profile>
     </profiles>
 </project>
-


### PR DESCRIPTION
## Motivation and Context
#254 added Software Bill of Materials (SBOM) support. Unfortunately, that appears to have slowed down the build for our key modules (e.g. core and api), which is #255. 

## Description
The fix is to generate a plain `bom` instead of `aggregateBom`. The only change is in the POMs.

## How Has This Been Tested?
I manually inspected the resulting XML and JSON files. The results are pretty much what I expected, although I'm very new at SBOM.

Timing is objectively better. The aggregate results are in #255, and show the core, api and viewer modules taking around 70 seconds longer (each) than they did before the Cyclone DX maven modules were added in #254. 

Building with CycloneDX modules disabled (`mvn clean install -Dcyclonedx.skip=true`) now looks like:
```
[INFO] Reactor Summary for jMISB 1.11.0-SNAPSHOT:
[INFO] 
[INFO] jMISB .............................................. SUCCESS [  0.785 s]
[INFO] jmisb-core ......................................... SUCCESS [  8.988 s]
[INFO] jmisb-api .......................................... SUCCESS [ 32.218 s]
[INFO] jmisb-viewer ....................................... SUCCESS [  5.084 s]
[INFO] Examples ........................................... SUCCESS [  0.008 s]
[INFO] KLV generator example .............................. SUCCESS [ 23.567 s]
[INFO] System.out example ................................. SUCCESS [ 23.521 s]
[INFO] Moving Features example ............................ SUCCESS [ 24.013 s]
[INFO] GStreamer sink example ............................. SUCCESS [ 22.853 s]
[INFO] Parser Plugin example .............................. SUCCESS [ 22.809 s]
```

A rebuild with those modules enabled (`mvn clean install`):
```
[INFO] jMISB .............................................. SUCCESS [  0.829 s]
[INFO] jmisb-core ......................................... SUCCESS [ 18.430 s]
[INFO] jmisb-api .......................................... SUCCESS [ 41.158 s]
[INFO] jmisb-viewer ....................................... SUCCESS [ 14.216 s]
[INFO] Examples ........................................... SUCCESS [  0.008 s]
[INFO] KLV generator example .............................. SUCCESS [ 24.702 s]
[INFO] System.out example ................................. SUCCESS [ 25.127 s]
[INFO] Moving Features example ............................ SUCCESS [ 24.167 s]
[INFO] GStreamer sink example ............................. SUCCESS [ 24.942 s]
[INFO] Parser Plugin example .............................. SUCCESS [ 23.152 s]
```

So its about 9 seconds slower per module, rather than 70 seconds slower. Not ideal, but improved, and I think I'm OK with that overhead. A future option would be a  profile to only generate them when doing releases, but don't think that is needed for now.

I also tried a top-level aggregate BOM build, but that happens before the modules get built, so the results don't look right for jMISB. Also, that conflated the different modules (e.g. viewer and core) together, which doesn't seem as useful in any case.

## Screenshots (if appropriate):

N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

