### PR TITLE
fix: correct javadoc for horizon pixel pack tag

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -270,7 +270,7 @@ public enum UasDatalinkTag implements IKlvKey {
     SensorEastVelocity(80),
     /**
      * Tag 81; Location of earth-sky horizon in the Imagery; Value is an {@link
-     * ImageHorizonPixelPack}
+     * ImageHorizonPixelPack}.
      */
     ImageHorizonPixelPack(81),
     /** Tag 82; Frame latitude for upper left corner; Value is a {@link FullCornerLatitude}. */


### PR DESCRIPTION
## Motivation and Context
Trivial fix for a warning I inadvertently introduced in #164.

## Description
Just updates the javadoc to end in a full stop.

## How Has This Been Tested?
Regenerated the javadoc as part of a build.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [N/A] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

