### PR TITLE
chore: remove deprecated API use from 0601/0903 tests

### DIFF
--- a/api/src/test/java/org/jmisb/api/klv/st0601/PayloadIdentifierKeyTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/PayloadIdentifierKeyTest.java
@@ -39,7 +39,7 @@ public class PayloadIdentifierKeyTest {
         PayloadIdentifierKey payloadIdentifierKey = new PayloadIdentifierKey(2);
         assertFalse(payloadIdentifierKey.equals(null));
         assertFalse(payloadIdentifierKey.equals(new PayloadIdentifierKey(3)));
-        assertFalse(payloadIdentifierKey.equals(new Integer(2)));
+        assertFalse(payloadIdentifierKey.equals(2));
         assertTrue(payloadIdentifierKey.equals(payloadIdentifierKey));
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/AlgorithmIdentifierKeyTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/AlgorithmIdentifierKeyTest.java
@@ -39,7 +39,7 @@ public class AlgorithmIdentifierKeyTest {
         AlgorithmIdentifierKey algorithmIdentifierKey = new AlgorithmIdentifierKey(2);
         assertFalse(algorithmIdentifierKey.equals(null));
         assertFalse(algorithmIdentifierKey.equals(new AlgorithmIdentifierKey(3)));
-        assertFalse(algorithmIdentifierKey.equals(new Integer(2)));
+        assertFalse(algorithmIdentifierKey.equals(2));
         assertTrue(algorithmIdentifierKey.equals(algorithmIdentifierKey));
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/OntologyIdentifierKeyTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/OntologyIdentifierKeyTest.java
@@ -39,7 +39,7 @@ public class OntologyIdentifierKeyTest {
         OntologyIdentifierKey ontologyIdentifierKey = new OntologyIdentifierKey(2);
         assertFalse(ontologyIdentifierKey.equals(null));
         assertFalse(ontologyIdentifierKey.equals(new OntologyIdentifierKey(3)));
-        assertFalse(ontologyIdentifierKey.equals(new Integer(2)));
+        assertFalse(ontologyIdentifierKey.equals(2));
         assertTrue(ontologyIdentifierKey.equals(ontologyIdentifierKey));
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetIdentifierKeyTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtarget/TargetIdentifierKeyTest.java
@@ -32,7 +32,7 @@ public class TargetIdentifierKeyTest {
         TargetIdentifierKey targetIdentifierKey = new TargetIdentifierKey(2);
         assertFalse(targetIdentifierKey.equals(null));
         assertFalse(targetIdentifierKey.equals(new TargetIdentifierKey(3)));
-        assertFalse(targetIdentifierKey.equals(new Integer(2)));
+        assertFalse(targetIdentifierKey.equals(2));
         assertTrue(targetIdentifierKey.equals(targetIdentifierKey));
     }
 }


### PR DESCRIPTION
## Motivation and Context
There is a warning about deprecated API use in one of the ST 0903 tests. Its caused by a pointless `new Integer(2)` that was deprecated in Java 9 (see https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Integer.html#%3Cinit%3E(int)), and isn't required.

## Description
Updates code in four tests to avoid this call. No change to production code.

## How Has This Been Tested?
Re-ran all the unit tests as part of a build.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

