### PR TITLE
fix: remove deprecated API use in MIMD tests

### DIFF
--- a/miml-maven-plugin/src/main/resources/templates/itemKeyTest.ftl
+++ b/miml-maven-plugin/src/main/resources/templates/itemKeyTest.ftl
@@ -44,7 +44,7 @@ public class ${namespacedName}ItemKeyTest {
     @Test
     public void notEqualsDifferentType() {
         ${namespacedName}ItemKey uut1 = new ${namespacedName}ItemKey(1);
-        assertFalse(uut1.equals(new Integer(1)));
+        assertFalse(uut1.equals(new String()));
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context
This is analogous to the #263 changes, but I didn't notice it until both that was fixed, and MIMD was merged.

## Description
It switches a test from using deprecated `new Integer(...)` to `new String()`. The test is just doing Object class comparison, and it doesn't really matter what the actual thing we're comparing it to is, as long as it is different to the class being tested.
No changes to production code.

## How Has This Been Tested?
Re-ran the tests as part of a full build.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

