### PR TITLE
st1303: add more natural format encoding support

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st1303/MDAPDecoder.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1303/MDAPDecoder.java
@@ -366,6 +366,62 @@ public class MDAPDecoder {
     }
 
     /**
+     * Decode a one-dimensional signed integer array from a byte array.
+     *
+     * @param bytes the byte array to decode from
+     * @param offset the offset to start the decoding from
+     * @return (signed) 1D integer array containing the data decoded from the byte array.
+     * @throws KlvParseException if the parsing fails.
+     */
+    public long[] decodeInt1D(byte[] bytes, final int offset) throws KlvParseException {
+        int i = offset;
+        BerField ndim = BerDecoder.decode(bytes, i, true);
+        if (ndim.getValue() != 1) {
+            throw new KlvParseException("Wrong dimensions for this call");
+        }
+        i += ndim.getLength();
+        BerField dim1 = BerDecoder.decode(bytes, i, true);
+        i += dim1.getLength();
+        BerField ebytes = BerDecoder.decode(bytes, i, true);
+        i += ebytes.getLength();
+        BerField apa = BerDecoder.decode(bytes, i, true);
+        i += apa.getLength();
+        switch (ArrayProcessingAlgorithm.getValue(apa.getValue())) {
+            case NaturalFormat:
+                return decodeInt1D_NaturalFormat(bytes, i, dim1.getValue(), ebytes.getValue());
+            case ST1201:
+                throw new KlvParseException(
+                        "Invalid APA algorithm for signed integer 1D decode: ST1201");
+            case BooleanArray:
+                throw new KlvParseException(
+                        "Invalid APA algorithm for signed integer 1D decode: BooleanArray");
+            case UnsignedInteger:
+                throw new KlvParseException(
+                        "Invalid APA algorithm for signed integer 1D decode: UnsignedInteger");
+            case RunLengthEncoding:
+                throw new KlvParseException(
+                        "Unsupported APA algorithm for signed integer 1D decode: RunLengthEncoding");
+            default:
+                throw new KlvParseException(
+                        String.format(
+                                "Unknown APA algorithm for  signed integer 1D decode: %d",
+                                apa.getValue()));
+        }
+    }
+
+    private long[] decodeInt1D_NaturalFormat(
+            byte[] bytes, final int offset, final int numElements, final int eBytes)
+            throws KlvParseException {
+        int index = offset;
+        long[] result = new long[numElements];
+        for (int i = 0; i < numElements; ++i) {
+            result[i] = PrimitiveConverter.variableBytesToInt64(bytes, index, eBytes);
+            index += eBytes;
+        }
+        return result;
+    }
+
+    /**
      * Decode a two-dimensional signed integer array from a byte array.
      *
      * @param bytes the byte array to decode from
@@ -394,20 +450,20 @@ public class MDAPDecoder {
                         bytes, i, dim1.getValue(), dim2.getValue(), ebytes.getValue());
             case ST1201:
                 throw new KlvParseException(
-                        "Invalid APA algorithm for signed integer 1D decode: ST1201");
+                        "Invalid APA algorithm for signed integer 2D decode: ST1201");
             case BooleanArray:
                 throw new KlvParseException(
-                        "Invalid APA algorithm for signed integer 1D decode: BooleanArray");
+                        "Invalid APA algorithm for signed integer 2D decode: BooleanArray");
             case UnsignedInteger:
                 throw new KlvParseException(
-                        "Invalid APA algorithm for signed integer 1D decode: UnsignedInteger");
+                        "Invalid APA algorithm for signed integer 2D decode: UnsignedInteger");
             case RunLengthEncoding:
                 throw new KlvParseException(
-                        "Unsupported APA algorithm for signed integer 1D decode: RunLengthEncoding");
+                        "Unsupported APA algorithm for signed integer 2D decode: RunLengthEncoding");
             default:
                 throw new KlvParseException(
                         String.format(
-                                "Unknown APA algorithm for  signed integer 1D decode: %d",
+                                "Unknown APA algorithm for signed integer 2D decode: %d",
                                 apa.getValue()));
         }
     }

--- a/api/src/main/java/org/jmisb/api/klv/st1303/NaturalFormatEncoder.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1303/NaturalFormatEncoder.java
@@ -49,6 +49,35 @@ public class NaturalFormatEncoder {
     }
 
     /**
+     * Encode a one dimensional (signed) integer array to a Multi-Dimensional Array Pack using
+     * Natural Format Encoding.
+     *
+     * @param data the array of ({@code long}) values.
+     * @return the encoded byte array including the MISB ST1303 header and array data.
+     * @throws KlvParseException if the encoding fails, such as for invalid array dimensions.
+     */
+    public byte[] encode(long[] data) throws KlvParseException {
+        if (data.length < 1) {
+            throw new KlvParseException("MDAP encoding requires each dimension to be at least 1");
+        }
+        ArrayBuilder builder =
+                new ArrayBuilder()
+                        // Number of dimensions
+                        .appendAsOID(1)
+                        // dim_1
+                        .appendAsOID(data.length)
+                        // E_bytes value
+                        .appendAsOID(Long.BYTES)
+                        // array processing algorithm (APA)
+                        // note: no array processing algorithm support (APAS)
+                        .appendAsOID(ArrayProcessingAlgorithm.NaturalFormat.getCode());
+        for (int c = 0; c < data.length; ++c) {
+            builder.append(PrimitiveConverter.int64ToBytes(data[c]));
+        }
+        return builder.toBytes();
+    }
+
+    /**
      * Encode a two dimensional (signed) integer array to a Multi-Dimensional Array Pack using
      * Natural Format Encoding.
      *
@@ -85,7 +114,7 @@ public class NaturalFormatEncoder {
      * Encode a one dimensional unsigned integer array to a Multi-Dimensional Array Pack using
      * Natural Format Encoding.
      *
-     * @param data the array of arrays of ({@code long}) values.
+     * @param data the arrays of ({@code long}) values.
      * @return the encoded byte array including the MISB ST1303 header and array data.
      * @throws KlvParseException if the encoding fails, such as for invalid array dimensions.
      */
@@ -116,6 +145,87 @@ public class NaturalFormatEncoder {
                 builder.appendByte((byte) 0x00);
             }
             builder.append(encodedValue);
+        }
+        return builder.toBytes();
+    }
+
+    /**
+     * Encode a two dimensional unsigned integer array to a Multi-Dimensional Array Pack using
+     * Natural Format Encoding.
+     *
+     * @param data the array of arrays of ({@code long}) values.
+     * @return the encoded byte array including the MISB ST1303 header and array data.
+     * @throws KlvParseException if the encoding fails, such as for invalid array dimensions.
+     */
+    public byte[] encodeUnsigned(long[][] data) throws KlvParseException {
+        if ((data.length < 1) || (data[0].length < 1)) {
+            throw new KlvParseException("MDAP encoding requires each dimension to be at least 1");
+        }
+        int minRequiredLength = 0;
+        for (int r = 0; r < data.length; ++r) {
+            for (int c = 0; c < data[r].length; ++c) {
+                byte[] bytes = PrimitiveConverter.uintToVariableBytes(data[r][c]);
+                minRequiredLength = Math.max(minRequiredLength, bytes.length);
+            }
+        }
+        ArrayBuilder builder =
+                new ArrayBuilder()
+                        // Number of dimensions
+                        .appendAsOID(2)
+                        // dim_1
+                        .appendAsOID(data.length)
+                        // dim_2
+                        .appendAsOID(data[0].length)
+                        // E_bytes value
+                        .appendAsOID(minRequiredLength)
+                        // array processing algorithm (APA)
+                        // note: no array processing algorithm support (APAS)
+                        .appendAsOID(ArrayProcessingAlgorithm.NaturalFormat.getCode());
+        for (int r = 0; r < data.length; ++r) {
+            for (int c = 0; c < data[r].length; ++c) {
+                byte[] encodedValue = PrimitiveConverter.uintToVariableBytes(data[r][c]);
+                int numPaddingBytes = minRequiredLength - encodedValue.length;
+                for (int i = 0; i < numPaddingBytes; i++) {
+                    builder.appendByte((byte) 0x00);
+                }
+                builder.append(encodedValue);
+            }
+        }
+        return builder.toBytes();
+    }
+
+    /**
+     * Encode a two dimensional Boolean array to a Multi-Dimensional Array Pack using Natural Format
+     * Encoding.
+     *
+     * <p>This serialises each value into a byte array.
+     *
+     * @param data the array of arrays of ({@code boolean}) values.
+     * @return the encoded byte array including the MISB ST1303 header and array data.
+     * @throws KlvParseException if the encoding fails, such as for invalid array dimensions.
+     */
+    public byte[] encode(boolean[][] data) throws KlvParseException {
+        if ((data.length < 1) || (data[0].length < 1)) {
+            throw new KlvParseException("MDAP encoding requires each dimension to be at least 1");
+        }
+        ArrayBuilder builder =
+                new ArrayBuilder()
+                        // Number of dimensions
+                        .appendAsOID(2)
+                        // dim_1
+                        .appendAsOID(data.length)
+                        // dim_2
+                        .appendAsOID(data[0].length)
+                        // E_bytes value - single byte
+                        .appendAsOID(1)
+                        // array processing algorithm (APA)
+                        // note no array processing algorithm support (APAS) values
+                        .appendAsOID(ArrayProcessingAlgorithm.NaturalFormat.getCode());
+        // Array Of Elements
+        for (int r = 0; r < data.length; ++r) {
+            for (int c = 0; c < data[r].length; ++c) {
+                builder.appendByte(data[r][c] == true ? (byte) 0x01 : (byte) 0x00);
+            }
         }
         return builder.toBytes();
     }

--- a/api/src/test/java/org/jmisb/api/klv/st1303/MDAPDecoderTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1303/MDAPDecoderTest.java
@@ -993,6 +993,72 @@ public class MDAPDecoderTest {
     }
 
     @Test
+    public void testInt1DimNaturalEncoding() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        long[] decoded =
+                decoder.decodeInt1D(
+                        new byte[] {
+                            (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x02
+                        },
+                        0);
+        assertEquals(decoded, new long[] {0x2});
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testInt1Dim_BadAPA_Unused() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeInt1D(
+                new byte[] {(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x00, (byte) 0x02}, 0);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testInt1Dim_BadAPA_ST1201() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeInt1D(
+                new byte[] {(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x02, (byte) 0x02}, 0);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testInt1Dim_BadAPA_BooleanArray() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeInt1D(
+                new byte[] {(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x03, (byte) 0x02}, 0);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testInt1Dim_BadAPA_UnsignedInteger() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeInt1D(
+                new byte[] {(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x04, (byte) 0x02}, 0);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testInt1Dim_BadAPA_RunLengthEncoding() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeInt1D(
+                new byte[] {(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x05, (byte) 0x02}, 0);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testInt1Dim_BadDimension() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeInt1D(
+                new byte[] {
+                    (byte) 0x02,
+                    (byte) 0x05,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x81,
+                    (byte) 0x02,
+                    (byte) 0x00,
+                    (byte) 0x28,
+                    (byte) 0x19
+                },
+                0);
+    }
+
+    @Test
     public void testInt2DimNaturalEncoding() throws KlvParseException {
         MDAPDecoder decoder = new MDAPDecoder();
         long[][] decoded =

--- a/api/src/test/java/org/jmisb/api/klv/st1303/NaturalFormatEncoderTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1303/NaturalFormatEncoderTest.java
@@ -18,6 +18,71 @@ public class NaturalFormatEncoderTest {
     }
 
     @Test(expectedExceptions = KlvParseException.class)
+    public void check1DIntBadLength() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        encoder.encode(new long[0]);
+    }
+
+    @Test
+    public void check1DimSignedEncoding() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        long[] input = new long[] {130, -170, 65535, 143, -256};
+        byte[] encoded = encoder.encode(input);
+        assertEquals(
+                encoded,
+                new byte[] {
+                    (byte) 0x01,
+                    (byte) 0x05,
+                    (byte) 0x08,
+                    (byte) 0x01,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x82,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0x56,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x8f,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0xff,
+                    (byte) 0x00
+                });
+        MDAPDecoder checkDecoder = new MDAPDecoder();
+        long[] decoded = checkDecoder.decodeInt1D(encoded, 0);
+        assertEquals(decoded, input);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
     public void check2DIntBadColumns() throws KlvParseException {
         NaturalFormatEncoder encoder = new NaturalFormatEncoder();
         assertNotNull(encoder);
@@ -46,7 +111,7 @@ public class NaturalFormatEncoderTest {
     }
 
     @Test
-    public void check1DimEncoding() throws KlvParseException {
+    public void check1DimUnsignedEncoding() throws KlvParseException {
         NaturalFormatEncoder encoder = new NaturalFormatEncoder();
         long[] input = new long[] {130, 170, 155, 143, 190};
         byte[] encoded = encoder.encodeUnsigned(input);
@@ -69,7 +134,7 @@ public class NaturalFormatEncoderTest {
     }
 
     @Test
-    public void check1DimEncodingTwpByte() throws KlvParseException {
+    public void check1DimUnsignedEncodingTwoByte() throws KlvParseException {
         NaturalFormatEncoder encoder = new NaturalFormatEncoder();
         long[] input = new long[] {130, 170, 258, 143, 190};
         byte[] encoded = encoder.encodeUnsigned(input);
@@ -94,5 +159,86 @@ public class NaturalFormatEncoderTest {
         MDAPDecoder checkDecoder = new MDAPDecoder();
         long[] decoded = checkDecoder.decodeUInt1D(encoded, 0);
         assertEquals(decoded, input);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void check2DUnsignedBadColumns() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        encoder.encodeUnsigned(new long[1][0]);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void check2DUnsignedBadRows() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        encoder.encodeUnsigned(new long[0][1]);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void check2DUnsignedBadRowsAndColumns() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        encoder.encodeUnsigned(new long[0][0]);
+    }
+
+    @Test
+    public void check2DUnsigned() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        byte[] encoded = encoder.encodeUnsigned(new long[][] {{130, 170, 258}, {143, 190, 5}});
+        assertEquals(
+                encoded,
+                new byte[] {
+                    (byte) 0x02,
+                    (byte) 0x02,
+                    (byte) 0x03,
+                    (byte) 0x02,
+                    (byte) 0x01,
+                    (byte) 0x00,
+                    (byte) 0x82,
+                    (byte) 0x00,
+                    (byte) 0xaa,
+                    (byte) 0x01,
+                    (byte) 0x02,
+                    (byte) 0x00,
+                    (byte) 0x8F,
+                    (byte) 0x00,
+                    (byte) 0xBE,
+                    (byte) 0x00,
+                    (byte) 0x05
+                });
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void check2DBooleanBadColumns() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        encoder.encode(new boolean[1][0]);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void check2DBooleanBadRows() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        encoder.encode(new boolean[0][1]);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void check2DBooleanBadRowsAndColumns() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        encoder.encode(new boolean[0][0]);
+    }
+
+    @Test
+    public void check2DBoolean() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        byte[] encoded =
+                encoder.encode(new boolean[][] {{true, false, true}, {false, false, true}});
+        assertEquals(
+                encoded,
+                new byte[] {0x02, 0x02, 0x03, 0x01, 0x1, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01});
     }
 }


### PR DESCRIPTION
## Motivation and Context
We have most of what we need from ST 1303 (array encoding) for MIMD and ST 1206, but coverage isn't too good on other aspects, especially on 1D signed integer, and some other natural format encoding. I'm working down the list in preparation for future MIMD and some of the lesser-used formats which potentially need this.

Relates to #198, but doesn't complete it.
 
## Description
Adds encoding for:
 - 1D signed integer in natural format
 - 2D unsigned integer in natural format
 - 2D boolean in natural format

Adds decoding for:
 - 1D signed integer in natural format

Fixes some minor issues and test naming in existing code.

## How Has This Been Tested?
Re-ran unit tests as part of full build.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

