### PR TITLE
add pom formatting

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,14 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jmisb</groupId>
         <artifactId>jmisb</artifactId>
         <version>1.11.0-SNAPSHOT</version>
     </parent>
-
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>jmisb-api</artifactId>
     <packaging>jar</packaging>
 
@@ -24,13 +22,13 @@
             <artifactId>ffmpeg-platform</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.org.lidalia</groupId>
@@ -62,14 +60,14 @@
                 <executions>
                     <execution>
                         <id>reformat-sources</id>
-                        <configuration>
-                            <style>AOSP</style>
-                            <fixImports>true</fixImports>
-                        </configuration>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -89,6 +87,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${failsafe.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>testng-integration.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -97,16 +100,14 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <suiteXmlFiles>
-                        <suiteXmlFile>testng-integration.xml</suiteXmlFile>
-                    </suiteXmlFiles>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs.maven.version}</version>
+                <configuration>
+                    <excludeFilterFile>SpotBugsFilter.xml</excludeFilterFile>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>com.github.spotbugs</groupId>
@@ -114,9 +115,6 @@
                         <version>${spotbugs.version}</version>
                     </dependency>
                 </dependencies>
-                <configuration>
-                    <excludeFilterFile>SpotBugsFilter.xml</excludeFilterFile>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -139,10 +137,10 @@
                 <executions>
                     <execution>
                         <id>validate</id>
-                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>
+                        <phase>validate</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -155,14 +153,6 @@
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
                 <version>${cyclonedx.version}</version>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>makeBom</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <projectType>library</projectType>
                     <schemaVersion>${cyclonedx.schema.version}</schemaVersion>
@@ -176,6 +166,14 @@
                     <outputFormat>all</outputFormat>
                     <outputName>${project.artifactId}-${project.version}-cyclonedx</outputName>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jmisb.maven</groupId>
@@ -217,10 +215,10 @@
                         <executions>
                             <execution>
                                 <id>make-assembly</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>single</goal>
                                 </goals>
+                                <phase>package</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,23 +1,16 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jmisb</groupId>
         <artifactId>jmisb</artifactId>
         <version>1.11.0-SNAPSHOT</version>
     </parent>
-
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>jmisb-core</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -25,6 +18,11 @@
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>ffmpeg-platform</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -38,14 +36,14 @@
                 <executions>
                     <execution>
                         <id>reformat-sources</id>
-                        <configuration>
-                            <style>AOSP</style>
-                            <fixImports>true</fixImports>
-                        </configuration>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -83,14 +81,6 @@
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
                 <version>${cyclonedx.version}</version>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>makeBom</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <projectType>library</projectType>
                     <schemaVersion>${cyclonedx.schema.version}</schemaVersion>
@@ -104,6 +94,14 @@
                     <outputFormat>all</outputFormat>
                     <outputName>${project.artifactId}-${project.version}-cyclonedx</outputName>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/examples/generator/pom.xml
+++ b/examples/generator/pom.xml
@@ -8,9 +8,9 @@
     </parent>
     <groupId>org.jmisb.examples</groupId>
     <artifactId>generator</artifactId>
+    <packaging>jar</packaging>
     <name>KLV generator example</name>
     <description>Example code that generates KLV in a test file.</description>
-    <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>org.jmisb</groupId>
@@ -38,14 +38,14 @@
                 <executions>
                     <execution>
                         <id>reformat-sources</id>
-                        <configuration>
-                            <style>AOSP</style>
-                            <fixImports>true</fixImports>
-                        </configuration>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -67,10 +67,10 @@
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>package</phase> 
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <phase>package</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/examples/gstsink/pom.xml
+++ b/examples/gstsink/pom.xml
@@ -8,9 +8,9 @@
     </parent>
     <groupId>org.jmisb.examples</groupId>
     <artifactId>gstsink</artifactId>
+    <packaging>jar</packaging>
     <name>GStreamer sink example</name>
     <description>Example code that adapts jMISB to be a GStreamer Sink.</description>
-    <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>org.jmisb</groupId>
@@ -39,14 +39,14 @@
                 <executions>
                     <execution>
                         <id>reformat-sources</id>
-                        <configuration>
-                            <style>AOSP</style>
-                            <fixImports>true</fixImports>
-                        </configuration>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -68,10 +68,10 @@
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>package</phase> 
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <phase>package</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/examples/mimdgenerator/pom.xml
+++ b/examples/mimdgenerator/pom.xml
@@ -8,9 +8,9 @@
     </parent>
     <groupId>org.jmisb.examples</groupId>
     <artifactId>mimdgenerator</artifactId>
+    <packaging>jar</packaging>
     <name>MIMD generator example</name>
     <description>Example code that generates MIMD KLV in a test file.</description>
-    <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>org.jmisb</groupId>
@@ -33,14 +33,14 @@
                 <executions>
                     <execution>
                         <id>reformat-sources</id>
-                        <configuration>
-                            <style>AOSP</style>
-                            <fixImports>true</fixImports>
-                        </configuration>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -62,10 +62,10 @@
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>package</phase> 
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <phase>package</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/examples/movingfeatures/pom.xml
+++ b/examples/movingfeatures/pom.xml
@@ -8,9 +8,9 @@
     </parent>
     <groupId>org.jmisb.examples</groupId>
     <artifactId>movingfeatures</artifactId>
+    <packaging>jar</packaging>
     <name>Moving Features example</name>
     <description>Example code that generates OGC Moving Features from ST0903 VMTI.</description>
-    <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>org.jmisb</groupId>
@@ -23,10 +23,10 @@
             <version>1.7.30</version>
         </dependency>
         <dependency>
-	    <groupId>com.fasterxml.jackson.core</groupId>
-	    <artifactId>jackson-databind</artifactId>
-	    <version>2.11.2</version>
-	</dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.11.2</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -38,14 +38,14 @@
                 <executions>
                     <execution>
                         <id>reformat-sources</id>
-                        <configuration>
-                            <style>AOSP</style>
-                            <fixImports>true</fixImports>
-                        </configuration>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -67,10 +67,10 @@
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>package</phase> 
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <phase>package</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/examples/parserplugin/pom.xml
+++ b/examples/parserplugin/pom.xml
@@ -8,9 +8,9 @@
     </parent>
     <groupId>org.jmisb.examples</groupId>
     <artifactId>parserplugin</artifactId>
+    <packaging>jar</packaging>
     <name>Parser Plugin example</name>
     <description>Example code to add an extra plugin to the parser</description>
-    <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>org.jmisb</groupId>
@@ -33,14 +33,14 @@
                 <executions>
                     <execution>
                         <id>reformat-sources</id>
-                        <configuration>
-                            <style>AOSP</style>
-                            <fixImports>true</fixImports>
-                        </configuration>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -62,10 +62,10 @@
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>package</phase> 
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <phase>package</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,9 +7,9 @@
         <version>1.11.0-SNAPSHOT</version>
     </parent>
     <artifactId>examples</artifactId>
+    <packaging>pom</packaging>
     <name>Examples</name>
     <description>Parent project for jMISB code examples</description>
-    <packaging>pom</packaging>
     <modules>
         <module>generator</module>
         <module>systemout</module>

--- a/examples/systemout/pom.xml
+++ b/examples/systemout/pom.xml
@@ -8,9 +8,9 @@
     </parent>
     <groupId>org.jmisb.examples</groupId>
     <artifactId>systemout</artifactId>
+    <packaging>jar</packaging>
     <name>System.out example</name>
     <description>Example code that dumps decoded KLV to standard output.</description>
-    <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>org.jmisb</groupId>
@@ -33,14 +33,14 @@
                 <executions>
                     <execution>
                         <id>reformat-sources</id>
-                        <configuration>
-                            <style>AOSP</style>
-                            <fixImports>true</fixImports>
-                        </configuration>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -62,10 +62,10 @@
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>package</phase> 
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <phase>package</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/miml-maven-plugin/pom.xml
+++ b/miml-maven-plugin/pom.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>jmisb</artifactId>
         <groupId>org.jmisb</groupId>
+        <artifactId>jmisb</artifactId>
         <version>1.11.0-SNAPSHOT</version>
     </parent>
 
@@ -15,17 +14,16 @@
 
     <name>MIML Maven Plugin</name>
 
-
     <prerequisites>
         <maven>${maven.version}</maven>
     </prerequisites>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <antlr4.version>4.9.1</antlr4.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.version>3.3.9</maven.version>
-        <antlr4.version>4.9.1</antlr4.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
@@ -72,16 +70,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <version>${maven.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.6.0</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
@@ -93,13 +91,14 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>7.0.0</version>
-            <scope>test</scope>
             <type>jar</type>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
-        <pluginManagement>            <!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+        <pluginManagement>
+            <!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
@@ -187,14 +186,14 @@
                 <executions>
                     <execution>
                         <id>reformat-sources</id>
-                        <configuration>
-                            <style>AOSP</style>
-                            <fixImports>true</fixImports>
-                        </configuration>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -202,14 +201,6 @@
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
                 <version>${cyclonedx.version}</version>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>makeBom</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <projectType>library</projectType>
                     <schemaVersion>${cyclonedx.schema.version}</schemaVersion>
@@ -223,14 +214,22 @@
                     <outputFormat>all</outputFormat>
                     <outputName>${project.artifactId}-${project.version}-cyclonedx</outputName>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs.maven.version}</version>
-                       <configuration>
-          <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
-          </configuration>
+                <configuration>
+                    <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>com.github.spotbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.jmisb</groupId>
@@ -13,11 +11,9 @@
     <description>jMISB is an open source Java library implementing various MISB standards.</description>
     <url>https://github.com/WestRidgeSystems/jmisb</url>
 
-    <scm>
-        <url>https://github.com/WestRidgeSystems/jmisb</url>
-        <connection>scm:git:git://github.com/WestRidgeSystems/jmisb.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/WestRidgeSystems/jmisb.git</developerConnection>
-    </scm>
+    <organization>
+        <name>West Ridge Systems</name>
+    </organization>
 
     <licenses>
         <license>
@@ -26,10 +22,6 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-
-    <organization>
-        <name>West Ridge Systems</name>
-    </organization>
 
     <developers>
         <developer>
@@ -40,31 +32,46 @@
         </developer>
     </developers>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <surefire.version>2.22.0</surefire.version>
-        <failsafe.version>2.22.0</failsafe.version>
-        <jacoco.version>0.8.6</jacoco.version>
-        <coveralls.version>4.3.0</coveralls.version>
-        <owasp.version>6.1.2</owasp.version>
-        <spotbugs.maven.version>4.0.0</spotbugs.maven.version>
-        <spotbugs.version>4.0.2</spotbugs.version>
-        <googleformatter.maven.plugin.version>1.7.3</googleformatter.maven.plugin.version>
-        <maven.assembly.plugin.version>3.1.0</maven.assembly.plugin.version>
-        <cyclonedx.version>2.3.0</cyclonedx.version>
-        <cyclonedx.schema.version>1.2</cyclonedx.schema.version>
-    </properties>
+    <modules>
+        <module>api</module>
+        <module>core</module>
+        <module>miml-maven-plugin</module>
+        <module>viewer</module>
+        <module>examples</module>
+    </modules>
+
+    <scm>
+        <connection>scm:git:git://github.com/WestRidgeSystems/jmisb.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/WestRidgeSystems/jmisb.git</developerConnection>
+        <url>https://github.com/WestRidgeSystems/jmisb</url>
+    </scm>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
+
+    <properties>
+        <coveralls.version>4.3.0</coveralls.version>
+        <cyclonedx.schema.version>1.2</cyclonedx.schema.version>
+        <cyclonedx.version>2.3.0</cyclonedx.version>
+        <failsafe.version>2.22.0</failsafe.version>
+        <googleformatter.maven.plugin.version>1.7.3</googleformatter.maven.plugin.version>
+        <jacoco.version>0.8.6</jacoco.version>
+        <maven.assembly.plugin.version>3.1.0</maven.assembly.plugin.version>
+        <owasp.version>6.1.2</owasp.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sortpom.version>2.15.0</sortpom.version>
+        <spotbugs.maven.version>4.0.0</spotbugs.maven.version>
+        <spotbugs.version>4.0.2</spotbugs.version>
+        <surefire.version>2.22.0</surefire.version>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -90,14 +97,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <modules>
-        <module>api</module>
-        <module>core</module>
-        <module>miml-maven-plugin</module>
-        <module>viewer</module>
-        <module>examples</module>
-    </modules>
 
     <build>
         <plugins>
@@ -193,10 +192,10 @@
                     </execution>
                     <execution>
                         <id>report</id>
-                        <phase>prepare-package</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
+                        <phase>prepare-package</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -204,6 +203,28 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>${coveralls.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>com.github.ekryd.sortpom</groupId>
+                <artifactId>sortpom-maven-plugin</artifactId>
+                <version>${sortpom.version}</version>
+                <configuration>
+                    <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
+                    <lineSeparator>\n</lineSeparator>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <nrOfIndentSpace>4</nrOfIndentSpace>
+                    <sortProperties>true</sortProperties>
+                    <keepBlankLines>true</keepBlankLines>
+                    <sortDependencies>scope</sortDependencies>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>sort</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -226,10 +247,10 @@
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
-                                <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <phase>verify</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -1,13 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jmisb</groupId>
         <artifactId>jmisb</artifactId>
         <version>1.11.0-SNAPSHOT</version>
     </parent>
-
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>jmisb-viewer</artifactId>
     <packaging>jar</packaging>
 
@@ -51,14 +50,14 @@
                 <executions>
                     <execution>
                         <id>reformat-sources</id>
-                        <configuration>
-                            <style>AOSP</style>
-                            <fixImports>true</fixImports>
-                        </configuration>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -73,7 +72,7 @@
                         <argument>-Xms512m</argument>
                         <argument>-Xmx2048m</argument>
                         <argument>-classpath</argument>
-                        <classpath/>
+                        <classpath></classpath>
                         <argument>org.jmisb.viewer.MisbViewer</argument>
                     </arguments>
                 </configuration>
@@ -82,6 +81,9 @@
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs.maven.version}</version>
+                <configuration>
+                    <excludeFilterFile>SpotBugsFilter.xml</excludeFilterFile>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>com.github.spotbugs</groupId>
@@ -89,9 +91,6 @@
                         <version>${spotbugs.version}</version>
                     </dependency>
                 </dependencies>
-                <configuration>
-                    <excludeFilterFile>SpotBugsFilter.xml</excludeFilterFile>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -104,14 +103,6 @@
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
                 <version>${cyclonedx.version}</version>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>makeBom</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <projectType>application</projectType>
                     <schemaVersion>${cyclonedx.schema.version}</schemaVersion>
@@ -125,6 +116,14 @@
                     <outputFormat>all</outputFormat>
                     <outputName>${project.artifactId}-${project.version}-cyclonedx</outputName>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Motivation and Context
Much like the automatic code formatting plugin, this change adds automatic formatting for the Maven poms. I became aware of this based on use in GeoServer.

The formatting / sort order is fairly flexible. Its also possible to define your own. I went with the Maven recommended profile, and switched on 4 spaces (default is 2, but we mostly use 4 in the existing pom files and that matches the Java convention).
See https://github.com/Ekryd/sortpom/wiki/Parameters and https://github.com/Ekryd/sortpom/wiki/PredefinedSortOrderProfiles
for more options. Happy to discuss further or for you to make changes.

## Description
Adds a plugin, reformats the existing pom.xml files.

## How Has This Been Tested?
Did a full rebuild, looked at the revised code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

