### PR TITLE
fix(st0601): avoid implicit narrowing of integer result

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/WaypointList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WaypointList.java
@@ -40,8 +40,8 @@ import org.jmisb.core.klv.PrimitiveConverter;
  */
 public class WaypointList implements IUasDatalinkValue {
     private final List<Waypoint> waypoints = new ArrayList<>();
-    private static int MANUAL_MODE = 0x01;
-    private static int ADHOC_SOURCE = 0x02;
+    private static byte MANUAL_MODE = 0x01;
+    private static byte ADHOC_SOURCE = 0x02;
 
     private final FpEncoder latDecoder = new FpEncoder(-90, 90, 4);
     private final FpEncoder lonDecoder = new FpEncoder(-180, 180, 4);


### PR DESCRIPTION
## Motivation and Context
This resolves two instances of "Implicit cast of source type int to narrower destination type byte." warnings reported by LGTM.

## Description
The source was a static `int` value, changed that to be `byte`.

## How Has This Been Tested?
Unit testing only. The changed code is in WaypointList, which I don't have any real data for.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

