### PR TITLE
fix(map): avoid using Integer as a counter

### DIFF
--- a/viewer/src/main/java/org/jmisb/viewer/map/SensorFootprintPainter.java
+++ b/viewer/src/main/java/org/jmisb/viewer/map/SensorFootprintPainter.java
@@ -48,10 +48,10 @@ public class SensorFootprintPainter implements Painter<JXMapViewer> {
         if (localCorners.size() != 4) {
             return;
         }
-        Integer count = 1;
+        int count = 1;
         for (GeoPosition gp : localCorners) {
             Point2D pt = map.getTileFactory().geoToPixel(gp, map.getZoom());
-            g.drawString(count.toString(), (int) pt.getX(), (int) pt.getY());
+            g.drawString(Integer.toString(count), (int) pt.getX(), (int) pt.getY());
             count += 1;
             if (first) {
                 firstX = (int) pt.getX();


### PR DESCRIPTION
## Motivation and Context
I used an `Integer` as the "footprint" corner counter in the viewer map. LGTM complains that its unnecessary.

## Description
Switched to `int`, and generated the String representation of that using `Integer.toString(int)`. 

## How Has This Been Tested?
Full rebuild, and tested that corners still render correctly in the viewer.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

