### PR TITLE
fix(st0601): avoid unnecessary boxing in PositioningMethodSource impl

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/PositioningMethodSource.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PositioningMethodSource.java
@@ -103,10 +103,10 @@ public class PositioningMethodSource implements IUasDatalinkValue {
                 numberOfNavsatTypes++;
             }
         }
-        Boolean hasMultiNavsat = numberOfNavsatTypes > 1;
-        Boolean hasGPS = ((this.source & GPS) == GPS);
-        Boolean hasOtherNavsat = numberOfNavsatTypes > 0;
-        Boolean hasINS = ((this.source & INS) == INS);
+        boolean hasMultiNavsat = numberOfNavsatTypes > 1;
+        boolean hasGPS = ((this.source & GPS) == GPS);
+        boolean hasOtherNavsat = numberOfNavsatTypes > 0;
+        boolean hasINS = ((this.source & INS) == INS);
         StringBuilder sb = new StringBuilder();
         if (hasMultiNavsat) {
             sb.append("Mixed");


### PR DESCRIPTION
## Motivation and Context
LGTM produces a warning that the use of `Boolean` in the ST 0601 PositioningMethodSource implementation is not required.

## Description
Simple replacement with use of `boolean`.

## How Has This Been Tested?
Unit testing only. I don't have real data that uses this tag.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

