### PR TITLE
fix(klv): remove test that is always false

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/BerDecoder.java
+++ b/api/src/main/java/org/jmisb/api/klv/BerDecoder.java
@@ -71,8 +71,8 @@ public class BerDecoder {
             value = tag;
         }
 
-        if (length < 1 || value < 0) {
-            throw new IllegalArgumentException("BER: error decoding length");
+        if (value < 0) {
+            throw new IllegalArgumentException("BER: error decoding value");
         }
 
         return new BerField(length, value);


### PR DESCRIPTION
## Motivation and Context
LGTM complains that the BER length can never be `< 1`. I've checked the code, and agree. I normally like to have this kind of sanity check, but in this case its probably worth removing considering the amount of BER decoding we do.

## Description
Just removes that part of the check.

## How Has This Been Tested?
Full build.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

