### PR TITLE
core(video): use long for data buffer calcs

### DIFF
--- a/core/src/main/java/org/jmisb/core/video/FrameConverter.java
+++ b/core/src/main/java/org/jmisb/core/video/FrameConverter.java
@@ -52,7 +52,8 @@ public class FrameConverter {
 
         byte[] a = ((DataBufferByte) out).getData();
 
-        ByteBuffer src = frame.data(0).capacity(frame.width() * frame.linesize(0)).asBuffer();
+        ByteBuffer src =
+                frame.data(0).capacity((long) frame.width() * (long) frame.linesize(0)).asBuffer();
         copy(src, frame.linesize(0), ByteBuffer.wrap(a, start, a.length - start), step);
 
         return bufferedImage;

--- a/core/src/test/java/org/jmisb/core/video/FrameConverterTest.java
+++ b/core/src/test/java/org/jmisb/core/video/FrameConverterTest.java
@@ -1,0 +1,72 @@
+package org.jmisb.core.video;
+
+import static java.awt.image.BufferedImage.TYPE_3BYTE_BGR;
+import static org.bytedeco.ffmpeg.global.avutil.AV_PIX_FMT_BGR24;
+import static org.bytedeco.ffmpeg.global.avutil.AV_PIX_FMT_YUV420P;
+import static org.bytedeco.ffmpeg.global.avutil.av_frame_alloc;
+import static org.bytedeco.ffmpeg.global.avutil.av_image_fill_arrays;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
+import org.bytedeco.ffmpeg.avutil.AVFrame;
+import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.PointerPointer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class FrameConverterTest {
+
+    @Test
+    public void basicConstruct() {
+        FrameConverter frameConverter = new FrameConverter();
+        Assert.assertNotNull(frameConverter);
+    }
+
+    @Test
+    public void convertCheck() {
+        BufferedImage sourceImage = new BufferedImage(1024, 960, TYPE_3BYTE_BGR);
+        Graphics2D graphics = sourceImage.createGraphics();
+        graphics.setPaint(Color.CYAN);
+        graphics.fillRect(0, 0, sourceImage.getWidth(), sourceImage.getHeight());
+        DataBuffer dataBuffer = sourceImage.getRaster().getDataBuffer();
+        BytePointer pixelData = new BytePointer(((DataBufferByte) dataBuffer).getData());
+        AVFrame avFrame = av_frame_alloc();
+        avFrame.format(AV_PIX_FMT_BGR24);
+        avFrame.width(sourceImage.getWidth());
+        avFrame.height(sourceImage.getHeight());
+        av_image_fill_arrays(
+                new PointerPointer(avFrame),
+                avFrame.linesize(),
+                pixelData,
+                AV_PIX_FMT_BGR24,
+                sourceImage.getWidth(),
+                sourceImage.getHeight(),
+                1);
+        FrameConverter frameConverter = new FrameConverter();
+        BufferedImage resultImage = frameConverter.convert(avFrame);
+        Assert.assertEquals(sourceImage.getWidth(), resultImage.getWidth());
+        Assert.assertEquals(sourceImage.getHeight(), resultImage.getHeight());
+        for (int y = 0; y < sourceImage.getHeight(); y++) {
+            for (int x = 0; x < sourceImage.getWidth(); x++) {
+                Assert.assertEquals(sourceImage.getRGB(x, y), resultImage.getRGB(x, y));
+            }
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void convertNullFrame() {
+        FrameConverter frameConverter = new FrameConverter();
+        frameConverter.convert(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void convertWrongFrameFormat() {
+        FrameConverter frameConverter = new FrameConverter();
+        AVFrame avFrame = new AVFrame();
+        avFrame.format(AV_PIX_FMT_YUV420P);
+        frameConverter.convert(avFrame);
+    }
+}


### PR DESCRIPTION
## Motivation and Context
LGTM complains that the multiplication in this line:
```
ByteBuffer src = frame.data(0).capacity(frame.width() * frame.linesize(0)).asBuffer();
```
can overflow (because the `linesize` and `width` are `int` so the multiplication result is an `int`, even though `capacity()` takes a `long` argument).

We are unlikely to handle such large results (because BufferedImage will likely probably fail), but its worth protecting our own code.

## Description
Cast to `long` before the multiplication. 

Also adds some tests, although I couldn't get to cause the overflow, so they're just checking the normal path.

## How Has This Been Tested?
Unit testing as part of a full build.
I also ran up the viewer application for a quick check.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

