### PR TITLE
miml-plugin: fix resource leak in file writing

### DIFF
--- a/miml-maven-plugin/src/main/java/org/jmisb/maven/CodeGeneratorListener.java
+++ b/miml-maven-plugin/src/main/java/org/jmisb/maven/CodeGeneratorListener.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -373,9 +374,10 @@ public class CodeGeneratorListener implements MIML_v3Listener {
     private void processTemplate(String templateFile, File outputFile, ClassModelEntry entry)
             throws FileNotFoundException, IOException, TemplateException {
         Template temp = templateConfiguration.getTemplate(templateFile);
-        Writer out =
-                new OutputStreamWriter(new FileOutputStream(outputFile), StandardCharsets.UTF_8);
-        temp.process(entry, out);
+        try (OutputStream outputStream = new FileOutputStream(outputFile);
+                Writer out = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+            temp.process(entry, out);
+        }
     }
 
     private void setupTemplateEngine() {


### PR DESCRIPTION
## Motivation and Context
Fixes a resource leak (closing FileOutputStream) in the MIML generator plugin. This is a flaw reported by LGTM.

## Description
Changed to try-with-resources, which is clearly what I should have done in the first place.

## How Has This Been Tested?
Just did a full build.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

