### PR TITLE
fix(st1204): avoid unneeded boxing of core id version

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st1204/CoreIdentifier.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1204/CoreIdentifier.java
@@ -371,7 +371,7 @@ public class CoreIdentifier {
     }
 
     private void parseVersionAndUsage(String versionAndUsage) {
-        Integer versionAndUsageValue = Integer.parseInt(versionAndUsage, 16);
+        int versionAndUsageValue = Integer.parseInt(versionAndUsage, 16);
         setVersion(versionAndUsageValue >> 8);
         int usage = versionAndUsageValue & 0xFF;
         parseUsage(usage);


### PR DESCRIPTION
## Motivation and Context
Another LGTM warning about boxing primitive types. This one affects the CoreId parsing.

## Description
Simple replacement of `Integer` with `int`.

## How Has This Been Tested?
Unit testing only.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

