### PR TITLE
fix(miml-maven): update MIML maven plugin dependencies

### DIFF
--- a/miml-maven-plugin/pom.xml
+++ b/miml-maven-plugin/pom.xml
@@ -22,6 +22,7 @@
         <antlr4.version>4.9.1</antlr4.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.core.version>3.8.1</maven.core.version>
         <maven.version>3.3.9</maven.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -38,15 +39,21 @@
             <version>${antlr4.version}</version>
         </dependency>
         <dependency>
+            <!-- Override for CVE 2021-29425 -->
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${maven.version}</version>
+            <version>${maven.core.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${maven.version}</version>
+            <version>${maven.core.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -74,18 +81,6 @@
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.6.0</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <version>${maven.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugin-testing</groupId>
-            <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>3.3.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <googleformatter.maven.plugin.version>1.7.3</googleformatter.maven.plugin.version>
         <jacoco.version>0.8.6</jacoco.version>
         <maven.assembly.plugin.version>3.1.0</maven.assembly.plugin.version>
-        <owasp.version>6.1.2</owasp.version>
+        <owasp.version>6.1.6</owasp.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sortpom.version>2.15.0</sortpom.version>
         <spotbugs.maven.version>4.0.0</spotbugs.maven.version>


### PR DESCRIPTION
## Motivation and Context
During #281 / #282 investigation, I noted that the dependency check plugin managed to get reverted from 6.1.5 to 6.1.2 during the maven formatting merge. 
On updating that, I found some new dependency issues in the MIML maven plugin. This updates the dependency check plugin to an even newer 6.1.6, and updates the dependencies for the MIML maven plugin module.

## Description
Updates versions in relevant pom files. Removes some unused (`test` scoped) dependencies. The pinning of commons-io is a bit unfortunate, but the CVE is new and there isn't a released parent version that is new enough.
Also, I had to split the maven versioning defines, otherwise the version of maven used to build it also needs to match latest.

## How Has This Been Tested?
Full build.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

