### PR TITLE
viewer: close previous input when opening stream

### DIFF
--- a/viewer/src/main/java/org/jmisb/viewer/MisbViewer.java
+++ b/viewer/src/main/java/org/jmisb/viewer/MisbViewer.java
@@ -358,7 +358,9 @@ public class MisbViewer extends JFrame implements ActionListener {
                         if (url != null) {
                             try {
                                 VideoStreamInputOptions options = new VideoStreamInputOptions();
-
+                                if (videoInput != null) {
+                                    videoInput.close();
+                                }
                                 videoInput = new VideoStreamInput(options);
 
                                 videoInput.open(url);


### PR DESCRIPTION
## Motivation and Context
Resolves #287 

## Description
Only affects viewer logic. Ensures that when a stream (e.g. UDP, although I have SRT in work too) is opened in the UI, any existing `videoInput` sources are closed.

## How Has This Been Tested?
Manual viewer tests.
Tested the problem case (file -> stream).
Tested just opening a stream (i.e. no currently open file).

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

