### PR TITLE
ci: retry linux and qa builds on failure

### DIFF
--- a/.github/workflows/jdk11.yml
+++ b/.github/workflows/jdk11.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build and install
-        run: mvn -B install -Pdebug
+        run: mvn -B install -Pdebug || mvn -B install -Pdebug || mvn -B install -Pdebug
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           java-version: 1.11
       - name: Build and check dependencies
-        run: mvn -B install --file pom.xml -Pdependencycheck -DskipTests
+        run: mvn -B verify -Pdependencycheck -DskipTests || mvn -B verify -Pdependencycheck -DskipTests || mvn -B verify -Pdependencycheck -DskipTests


### PR DESCRIPTION
## Motivation and Context
The failing PR thing is annoying and requires manual retry. I can only do that by closing and re-opening the PR (can't restart a single job). 

Some failures are really transient, and do not represent problems in jmisb - the "failed to transfer artifact" problem is a good example. In that case, a retry is the right thing to do.

## Description
Changes the JDK11 and QA builds to retry the build step if they fail, up to three times.

Also changes the QA build to just `verify`(rather than `install`) since the packaging part is irrelevant for that.

## How Has This Been Tested?
Only affects the workflow, so testing needs to be online.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

