### PR TITLE
mimdgenerator: fix deprecated API usage

### DIFF
--- a/examples/mimdgenerator/src/main/java/org/jmisb/examples/mimdgenerator/Generator.java
+++ b/examples/mimdgenerator/src/main/java/org/jmisb/examples/mimdgenerator/Generator.java
@@ -53,6 +53,7 @@ import org.jmisb.api.klv.st1908.ImagerSystem_Name;
 import org.jmisb.api.klv.st1908.MIIS;
 import org.jmisb.api.klv.st1908.MinorCoreId;
 import org.jmisb.api.klv.st1908.MinorCoreId_Uuid;
+import org.jmisb.api.video.CodecIdentifier;
 import org.jmisb.api.video.IVideoFileOutput;
 import org.jmisb.api.video.KlvFormat;
 import org.jmisb.api.video.MetadataFrame;
@@ -89,7 +90,13 @@ public class Generator {
 
         VideoOutputOptions options =
                 new VideoOutputOptions(
-                        width, height, bitRate, frameRate, gopSize, KlvFormat.Asynchronous);
+                        width,
+                        height,
+                        bitRate,
+                        frameRate,
+                        gopSize,
+                        KlvFormat.Asynchronous,
+                        CodecIdentifier.H264);
         try (IVideoFileOutput output = new VideoFileOutput(options)) {
             output.open(filename);
 


### PR DESCRIPTION
## Motivation and Context
Fixes a deprecated API warning during compilation. Its better if the examples show good usage of the API, and this one is a bit dated.

## Description
Updates the constructor usage to be explicit about the required format. Only affects that one example.

## How Has This Been Tested?
Ran the MIMD generator, and tested the output still works in the viewer application.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

