### PR TITLE
viewer: fix unchecked usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,9 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/viewer/src/main/java/org/jmisb/viewer/map/SensorFootprintPainter.java
+++ b/viewer/src/main/java/org/jmisb/viewer/map/SensorFootprintPainter.java
@@ -44,7 +44,7 @@ public class SensorFootprintPainter implements Painter<JXMapViewer> {
         int firstX = 0;
         int firstY = 0;
         boolean first = true;
-        List<GeoPosition> localCorners = new ArrayList(corners);
+        List<GeoPosition> localCorners = new ArrayList<>(corners);
         if (localCorners.size() != 4) {
             return;
         }

--- a/viewer/src/main/java/org/jmisb/viewer/map/SensorLocationPainter.java
+++ b/viewer/src/main/java/org/jmisb/viewer/map/SensorLocationPainter.java
@@ -59,7 +59,7 @@ public class SensorLocationPainter implements Painter<JXMapViewer> {
                 (int) sensorCentrePoint.getY() - RADIUS,
                 RADIUS * 2,
                 RADIUS * 2);
-        List<GeoPosition> localCorners = new ArrayList(corners);
+        List<GeoPosition> localCorners = new ArrayList<>(corners);
         if (localCorners.size() != 4) {
             return;
         }


### PR DESCRIPTION
## Motivation and Context
There are a couple of cases of unchecked class usage in the map part of the viewer application.
They were being flagged by the compiler, but not identified.

## Description
Add the `unchecked` lint flag to the compiler (at the top level, to help with this should it happen again), and fix the unchecked usage.

## How Has This Been Tested?
Full compile with unit tests.

Ran viewer application and checked the painting of footprint and sensor location is still OK.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

