### PR TITLE
miml: avoid verbose logging

### DIFF
--- a/miml-maven-plugin/src/main/java/org/jmisb/maven/CodeGeneratorListener.java
+++ b/miml-maven-plugin/src/main/java/org/jmisb/maven/CodeGeneratorListener.java
@@ -391,7 +391,7 @@ public class CodeGeneratorListener implements MIML_v3Listener {
     }
 
     private void log(String message) {
-        System.out.println(message);
+        // System.out.println(message);
     }
 
     @Override
@@ -414,7 +414,7 @@ public class CodeGeneratorListener implements MIML_v3Listener {
                     "We only support Grammar Version 3.0, but this one claims to be "
                             + mimlVersion);
         }
-        System.out.println("Parsing as grammar version " + mimlVersion);
+        // System.out.println("Parsing as grammar version " + mimlVersion);
     }
 
     @Override
@@ -422,7 +422,7 @@ public class CodeGeneratorListener implements MIML_v3Listener {
 
     @Override
     public void enterModelVer(MIML_v3Parser.ModelVerContext ctx) {
-        System.out.println("Model version: " + ctx.MODELVERNUM());
+        // System.out.println("Model version: " + ctx.MODELVERNUM());
     }
 
     @Override


### PR DESCRIPTION
## Motivation and Context
The MIML Maven plugin is pretty verbose. That was useful when I was less confident on it, but its now masking other stuff, and isn't appropriate.

## Description
Remove output.

## How Has This Been Tested?
Full build.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

