### PR TITLE
api: minor javadoc update

### DIFF
--- a/api/src/main/java/org/jmisb/api/video/VideoOutput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoOutput.java
@@ -241,6 +241,7 @@ public abstract class VideoOutput extends VideoIO {
     /**
      * Open the video codec.
      *
+     * @param codecConfiguration special codec options, or null for defaults.
      * @return false if the codec could not be opened (e.g., unsupported by the OS/hardware)
      */
     private boolean openVideoCodec(CodecConfiguration codecConfiguration) {


### PR DESCRIPTION
## Motivation and Context
After cleanup of the MIML output, it was easier to see warnings. This one seemed minor, but was trivial to fix.

## Description
Adds one `@param` javadoc entry.

## How Has This Been Tested?
Full build.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

