### PR TITLE
st0601: add support for multiple Control Command entries

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommands.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommands.java
@@ -1,0 +1,96 @@
+package org.jmisb.api.klv.st0601;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import org.jmisb.api.klv.ArrayBuilder;
+import org.jmisb.api.klv.IKlvKey;
+import org.jmisb.api.klv.IKlvValue;
+import org.jmisb.api.klv.INestedKlvValue;
+
+/**
+ * Control Commands.
+ *
+ * <p>This class represents any number (zero or more) of {@code ControlCommand} packs that may occur
+ * within an ST 0601 Local Set. Unlike most of the entries supported in ST 0601, {@code
+ * ControlCommand} can repeat.
+ */
+public class ControlCommands implements IUasDatalinkValue, INestedKlvValue, ISpecialFraming {
+
+    public List<ControlCommand> controlCommands = new ArrayList<>();
+
+    /**
+     * Create from a single command.
+     *
+     * @param command the command to add.
+     */
+    public ControlCommands(ControlCommand command) {
+        controlCommands.add(command);
+    }
+
+    /**
+     * Create from multiple commands.
+     *
+     * @param commands the commands to add.
+     */
+    public ControlCommands(List<ControlCommand> commands) {
+        this.controlCommands.addAll(commands);
+    }
+
+    @Override
+    public String getDisplayableValue() {
+        return "[Control Commands]";
+    }
+
+    @Override
+    public final String getDisplayName() {
+        return "Control Commands";
+    }
+
+    @Override
+    public IKlvValue getField(IKlvKey tag) {
+        int i = tag.getIdentifier();
+        for (ControlCommand controlCommand : controlCommands) {
+            if (controlCommand.getCommandId() == i) {
+                return controlCommand;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Set<? extends IKlvKey> getIdentifiers() {
+        Set<ControlCommandsKey> identifiers = new TreeSet<>();
+        for (ControlCommand controlCommand : controlCommands) {
+            identifiers.add(new ControlCommandsKey(controlCommand.getCommandId()));
+        }
+        return identifiers;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        throw new UnsupportedOperationException("use getEncodedValue()");
+    }
+
+    /**
+     * Append a control command to the set of commands.
+     *
+     * @param controlCommand the command to add.
+     */
+    public void add(ControlCommand controlCommand) {
+        controlCommands.add(controlCommand);
+    }
+
+    @Override
+    public byte[] getEncodedValue() {
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
+        for (ControlCommand controlCommand : controlCommands) {
+            arrayBuilder.appendAsOID(UasDatalinkTag.ControlCommand.getCode());
+            byte[] bytes = controlCommand.getBytes();
+            arrayBuilder.appendAsBerLength(bytes.length);
+            arrayBuilder.append(bytes);
+        }
+        return arrayBuilder.toBytes();
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommandsKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommandsKey.java
@@ -1,0 +1,51 @@
+package org.jmisb.api.klv.st0601;
+
+import java.util.Objects;
+import org.jmisb.api.klv.IKlvKey;
+
+/** Pseudo-key value to track the various {@code ControlCommand} instances. */
+public class ControlCommandsKey implements IKlvKey, Comparable<ControlCommandsKey> {
+
+    private final Integer identifier;
+
+    ControlCommandsKey(int id) {
+        this.identifier = id;
+    }
+
+    @Override
+    public int getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public int compareTo(ControlCommandsKey o) {
+        return identifier.compareTo(o.identifier);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 67 * hash + Objects.hashCode(this.identifier);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ControlCommandsKey other = (ControlCommandsKey) obj;
+        return Objects.equals(this.identifier, other.identifier);
+    }
+
+    @Override
+    public String toString() {
+        return "Command " + identifier;
+    }
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ISpecialFraming.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ISpecialFraming.java
@@ -1,0 +1,19 @@
+package org.jmisb.api.klv.st0601;
+
+/**
+ * Interface that indicates the KLV Value requires special treatment.
+ *
+ * <p>If a class implements this interface, it will be used to provide the required bytes when
+ * framing (encoding) a {@code UasDatalinkMessage}.
+ */
+public interface ISpecialFraming {
+
+    /**
+     * Get the bytes that correspond to a full KLV encoding of this value.
+     *
+     * <p>This may include multiple entries (i.e. sequences of Tag-Length-Value encodings).
+     *
+     * @return byte array corresponding to the encoded KLV value.
+     */
+    public byte[] getEncodedValue();
+}

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -395,7 +395,7 @@ public enum UasDatalinkTag implements IKlvKey {
      * RadarAltimeter}.
      */
     RadarAltimeter(114),
-    /** Tag 115; Record of command from GCS to Aircraft; Value is a {@link ControlCommand}. */
+    /** Tag 115; Record of command from GCS to Aircraft; Value is a {@link ControlCommands}. */
     ControlCommand(115),
     /**
      * Tag 116; Acknowledgment of one or more control commands were received by the platform; Value

--- a/api/src/test/java/org/jmisb/api/klv/st0601/ControlCommandTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/ControlCommandTest.java
@@ -9,7 +9,7 @@ import org.jmisb.api.common.KlvParseException;
 import org.testng.annotations.Test;
 
 public class ControlCommandTest {
-    private final byte[] ST_EXAMPLE_BYTES =
+    private static final byte[] ST_EXAMPLE_BYTES =
             new byte[] {
                 (byte) 0x05,
                 (byte) 0x11,
@@ -31,8 +31,8 @@ public class ControlCommandTest {
                 (byte) 0x20,
                 (byte) 0x31
             };
-    private final int ST_EXAMPLE_ID = 5;
-    private final String ST_EXAMPLE_COMMAND = "Fly to Waypoint 1";
+    public static final int ST_EXAMPLE_ID = 5;
+    public static final String ST_EXAMPLE_COMMAND = "Fly to Waypoint 1";
     private final long EXAMPLE_TIMESTAMP = 1587194489117472L;
 
     private final byte[] ST_EXAMPLE_BYTES_PLUS_TIMESTAMP =
@@ -106,7 +106,7 @@ public class ControlCommandTest {
         checkValuesForExamplePlusPTS(controlCommand);
     }
 
-    private void checkValuesForExample(ControlCommand controlCommand) {
+    public static void checkValuesForExample(ControlCommand controlCommand) {
         assertEquals(controlCommand.getBytes(), ST_EXAMPLE_BYTES);
         assertEquals(controlCommand.getCommandId(), ST_EXAMPLE_ID);
         assertEquals(controlCommand.getCommand(), ST_EXAMPLE_COMMAND);

--- a/api/src/test/java/org/jmisb/api/klv/st0601/ControlCommandsKeyTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/ControlCommandsKeyTest.java
@@ -1,0 +1,40 @@
+package org.jmisb.api.klv.st0601;
+
+import static org.testng.Assert.*;
+
+import org.jmisb.api.klv.st1108.st1108_3.metric.*;
+import org.testng.annotations.Test;
+
+/** @author bradh */
+public class ControlCommandsKeyTest {
+
+    public ControlCommandsKeyTest() {}
+
+    @Test
+    public void checkToString() {
+        ControlCommandsKey key = new ControlCommandsKey(2);
+        assertEquals(key.toString(), "Command 2");
+    }
+
+    @Test
+    public void checkHash() {
+        ControlCommandsKey key = new ControlCommandsKey(2);
+        assertEquals(key.hashCode(), 337);
+    }
+
+    @Test
+    public void checkCompareTo() {
+        ControlCommandsKey key = new ControlCommandsKey(2);
+        ControlCommandsKey keyHigher = new ControlCommandsKey(4);
+        assertTrue(key.compareTo(keyHigher) < 0);
+    }
+
+    @Test
+    public void checkEquals() {
+        ControlCommandsKey key = new ControlCommandsKey(2);
+        assertFalse(key.equals(null));
+        assertFalse(key.equals(new ControlCommandsKey(3)));
+        assertFalse(key.equals(2));
+        assertTrue(key.equals(key));
+    }
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0601/ControlCommandsTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/ControlCommandsTest.java
@@ -1,0 +1,246 @@
+package org.jmisb.api.klv.st0601;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IKlvValue;
+import org.testng.annotations.Test;
+
+public class ControlCommandsTest {
+    private final byte[] ST_EXAMPLE_BYTES =
+            new byte[] {
+                (byte) 0x05,
+                (byte) 0x11,
+                (byte) 0x46,
+                (byte) 0x6C,
+                (byte) 0x79,
+                (byte) 0x20,
+                (byte) 0x74,
+                (byte) 0x6F,
+                (byte) 0x20,
+                (byte) 0x57,
+                (byte) 0x61,
+                (byte) 0x79,
+                (byte) 0x70,
+                (byte) 0x6F,
+                (byte) 0x69,
+                (byte) 0x6E,
+                (byte) 0x74,
+                (byte) 0x20,
+                (byte) 0x31
+            };
+
+    private final byte[] ST_EXAMPLE_BYTES_IN_601 =
+            new byte[] {
+                0x06,
+                0x0e,
+                0x2b,
+                0x34,
+                0x02,
+                0x0b,
+                0x01,
+                0x01,
+                0x0e,
+                0x01,
+                0x03,
+                0x01,
+                0x01,
+                0x00,
+                0x00,
+                0x00,
+                0x19,
+                0x73,
+                0x13,
+                (byte) 0x05,
+                (byte) 0x11,
+                (byte) 0x46,
+                (byte) 0x6C,
+                (byte) 0x79,
+                (byte) 0x20,
+                (byte) 0x74,
+                (byte) 0x6F,
+                (byte) 0x20,
+                (byte) 0x57,
+                (byte) 0x61,
+                (byte) 0x79,
+                (byte) 0x70,
+                (byte) 0x6F,
+                (byte) 0x69,
+                (byte) 0x6E,
+                (byte) 0x74,
+                (byte) 0x20,
+                (byte) 0x31,
+                0x01,
+                0x02,
+                (byte) 0x4f,
+                (byte) 0xfc
+            };
+
+    private final byte[] TWO_COMMANDS_BYTES_IN_601 =
+            new byte[] {
+                0x06,
+                0x0e,
+                0x2b,
+                0x34,
+                0x02,
+                0x0b,
+                0x01,
+                0x01,
+                0x0e,
+                0x01,
+                0x03,
+                0x01,
+                0x01,
+                0x00,
+                0x00,
+                0x00,
+                0x2E,
+                0x73,
+                0x13,
+                (byte) 0x05,
+                (byte) 0x11,
+                (byte) 0x46,
+                (byte) 0x6C,
+                (byte) 0x79,
+                (byte) 0x20,
+                (byte) 0x74,
+                (byte) 0x6F,
+                (byte) 0x20,
+                (byte) 0x57,
+                (byte) 0x61,
+                (byte) 0x79,
+                (byte) 0x70,
+                (byte) 0x6F,
+                (byte) 0x69,
+                (byte) 0x6E,
+                (byte) 0x74,
+                (byte) 0x20,
+                (byte) 0x31,
+                0x73,
+                0x13,
+                (byte) 0x04,
+                (byte) 0x11,
+                (byte) 0x46,
+                (byte) 0x6C,
+                (byte) 0x79,
+                (byte) 0x20,
+                (byte) 0x74,
+                (byte) 0x6F,
+                (byte) 0x20,
+                (byte) 0x57,
+                (byte) 0x61,
+                (byte) 0x79,
+                (byte) 0x70,
+                (byte) 0x6F,
+                (byte) 0x69,
+                (byte) 0x6E,
+                (byte) 0x74,
+                (byte) 0x20,
+                (byte) 0x33,
+                0x01,
+                0x02,
+                (byte) 0x13,
+                (byte) 0xe7
+            };
+
+    @Test
+    public void testConstructFromValue() {
+        ControlCommands controlCommands =
+                new ControlCommands(
+                        new ControlCommand(
+                                ControlCommandTest.ST_EXAMPLE_ID,
+                                ControlCommandTest.ST_EXAMPLE_COMMAND));
+        validateControlCommands(controlCommands);
+    }
+
+    private void validateControlCommands(ControlCommands controlCommands) {
+        assertNotNull(controlCommands);
+        assertEquals(controlCommands.getDisplayName(), "Control Commands");
+        assertEquals(controlCommands.getDisplayableValue(), "[Control Commands]");
+        assertEquals(controlCommands.getIdentifiers().size(), 1);
+        controlCommands
+                .getIdentifiers()
+                .forEach(
+                        identifier -> {
+                            assertTrue(identifier instanceof ControlCommandsKey);
+                            IKlvValue value = controlCommands.getField(identifier);
+                            assertTrue(value instanceof ControlCommand);
+                            ControlCommand controlCommand = (ControlCommand) value;
+                            ControlCommandTest.checkValuesForExample(controlCommand);
+                        });
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> messageValues = new TreeMap<>();
+        messageValues.put(UasDatalinkTag.ControlCommand, controlCommands);
+        UasDatalinkMessage msg = new UasDatalinkMessage(messageValues);
+        assertEquals(msg.frameMessage(false), ST_EXAMPLE_BYTES_IN_601);
+    }
+
+    @Test
+    public void testFactory() throws KlvParseException {
+        UasDatalinkMessage msg = new UasDatalinkMessage(ST_EXAMPLE_BYTES_IN_601);
+        assertTrue(msg.getIdentifiers().contains(UasDatalinkTag.ControlCommand));
+        IUasDatalinkValue v = msg.getField(UasDatalinkTag.ControlCommand);
+        assertTrue(v instanceof ControlCommands);
+        ControlCommands controlCommands = (ControlCommands) v;
+        validateControlCommands(controlCommands);
+        ControlCommandsKey noSuchKey = new ControlCommandsKey(0);
+        assertNull(controlCommands.getField(noSuchKey));
+    }
+
+    @Test
+    public void testFactoryTwoMessages() throws KlvParseException {
+        UasDatalinkMessage msg = new UasDatalinkMessage(TWO_COMMANDS_BYTES_IN_601);
+        assertTrue(msg.getIdentifiers().contains(UasDatalinkTag.ControlCommand));
+        IUasDatalinkValue v = msg.getField(UasDatalinkTag.ControlCommand);
+        assertTrue(v instanceof ControlCommands);
+        ControlCommands controlCommands = (ControlCommands) v;
+        validateTwoControlCommands(controlCommands);
+    }
+
+    private void validateTwoControlCommands(ControlCommands controlCommands) {
+        assertNotNull(controlCommands);
+        assertEquals(controlCommands.getDisplayName(), "Control Commands");
+        assertEquals(controlCommands.getDisplayableValue(), "[Control Commands]");
+        assertEquals(controlCommands.getIdentifiers().size(), 2);
+        assertTrue(controlCommands.getIdentifiers().contains(new ControlCommandsKey(5)));
+        ControlCommand controlCommand5 =
+                (ControlCommand) controlCommands.getField(new ControlCommandsKey(5));
+        ControlCommandTest.checkValuesForExample(controlCommand5);
+        assertTrue(controlCommands.getIdentifiers().contains(new ControlCommandsKey(4)));
+        ControlCommand controlCommand4 =
+                (ControlCommand) controlCommands.getField(new ControlCommandsKey(4));
+        assertEquals(controlCommand4.getCommandId(), 4);
+        assertEquals(controlCommand4.getCommand(), "Fly to Waypoint 3");
+        SortedMap<UasDatalinkTag, IUasDatalinkValue> messageValues = new TreeMap<>();
+        messageValues.put(UasDatalinkTag.ControlCommand, controlCommands);
+        UasDatalinkMessage msg = new UasDatalinkMessage(messageValues);
+        assertEquals(msg.frameMessage(false), TWO_COMMANDS_BYTES_IN_601);
+    }
+
+    @Test
+    public void fromValues() {
+        List<ControlCommand> commands = new ArrayList<>();
+        ControlCommand controlCommand = new ControlCommand(5, "Fly to Waypoint 1");
+        commands.add(controlCommand);
+        ControlCommand secondControlCommand = new ControlCommand(4, "Fly to Waypoint 3");
+        commands.add(secondControlCommand);
+        ControlCommands controlCommands = new ControlCommands(commands);
+        validateTwoControlCommands(controlCommands);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testBadGetBytes() throws KlvParseException {
+        UasDatalinkMessage msg = new UasDatalinkMessage(ST_EXAMPLE_BYTES_IN_601);
+        List<ControlCommand> commands = new ArrayList<>();
+        ControlCommand controlCommand = new ControlCommand(5, "Fly to Waypoint 1");
+        commands.add(controlCommand);
+        ControlCommands controlCommands = new ControlCommands(commands);
+        controlCommands.getBytes();
+    }
+}


### PR DESCRIPTION
Resolves #140


## Motivation and Context
The Control Command pack can be repeated in a single ST 0601 local set. We don't currently support that, and will overwrite any earlier entries with the last encountered entry. This is currently tracked as #140.

## Description
Adds a "holder" class to capture each entry. Its not really clean because of how we serialise out the entries as shown in https://github.com/WestRidgeSystems/jmisb/blob/develop/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkMessage.java#L138-L145

I've introduced a special "marker" interface to handle the special case. Currently this is the only class that implements it, but there are more coming (we just don't implement that functionality yet). There are other ways to do this, but this seemed a way to avoid changing existing code everywhere.

## How Has This Been Tested?
Unit testing only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

