### PR TITLE
ci: add JDK 8 and JDK 14 builds

### DIFF
--- a/.github/workflows/jdk11.yml
+++ b/.github/workflows/jdk11.yml
@@ -14,4 +14,22 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build and install
         run: mvn -B install -Pdebug || mvn -B install -Pdebug || mvn -B install -Pdebug
+      - name: Upload core-common test results to Codecov
+        uses: codecov/codecov-action@v1.5.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./core/target/site/jacoco/jacoco.xml
+          flags: unittests
+      - name: Upload core test results to Codecov
+        uses: codecov/codecov-action@v1.5.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./core/target/site/jacoco/jacoco.xml
+          flags: unittests
+      - name: Upload api test results to Codecov
+        uses: codecov/codecov-action@v1.5.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./api/target/site/jacoco/jacoco.xml
+          flags: unittests
 

--- a/.github/workflows/jdk11.yml
+++ b/.github/workflows/jdk11.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Upload core-common test results to Codecov
         uses: codecov/codecov-action@v1.5.0
         with:
-          file: ./core/target/site/jacoco/jacoco.xml
+          file: ./core-common/target/site/jacoco/jacoco.xml
           flags: unittests-core-common
       - name: Upload core test results to Codecov
         uses: codecov/codecov-action@v1.5.0

--- a/.github/workflows/jdk11.yml
+++ b/.github/workflows/jdk11.yml
@@ -17,19 +17,16 @@ jobs:
       - name: Upload core-common test results to Codecov
         uses: codecov/codecov-action@v1.5.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./core/target/site/jacoco/jacoco.xml
-          flags: unittests
+          flags: unittests-core-common
       - name: Upload core test results to Codecov
         uses: codecov/codecov-action@v1.5.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./core/target/site/jacoco/jacoco.xml
-          flags: unittests
+          flags: unittests-core
       - name: Upload api test results to Codecov
         uses: codecov/codecov-action@v1.5.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./api/target/site/jacoco/jacoco.xml
-          flags: unittests
+          flags: unittests-api
 

--- a/.github/workflows/jdk14.yml
+++ b/.github/workflows/jdk14.yml
@@ -1,0 +1,21 @@
+name: JDK14 Build (Ubuntu 20.04)
+
+on:
+    push:
+      branches: [ develop ]
+    pull_request:
+      branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Build and install
+        run: mvn -B install -Pdebug || mvn -B install -Pdebug || mvn -B install -Pdebug
+

--- a/.github/workflows/jdk8.yml
+++ b/.github/workflows/jdk8.yml
@@ -1,0 +1,21 @@
+name: JDK8 Build (Ubuntu 18.04)
+
+on:
+    push:
+      branches: [ develop ]
+    pull_request:
+      branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Build and install
+        run: mvn -B install -Pdebug || mvn -B install -Pdebug || mvn -B install -Pdebug
+


### PR DESCRIPTION
## Motivation and Context
After Travis CI dropped out, we no longer have a JDK 8 build, and coveralls no longer works (last update was April).

Also, as JDKs move along, it is probably worth testing on JDK 14.

Resolves #301 

## Description
Adds an Ubuntu 18.04 + JDK 8 to GH actions.
Adds an Ubuntu 20.04 + JDK 14 to GH actions.
Adds codecov.io (instead of coveralls) to the actions.


## How Has This Been Tested?
Only as part of this PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

