### PR TITLE
st0601: add trivial unit test for CountryCodeKey

### DIFF
--- a/api/src/test/java/org/jmisb/api/klv/st0601/CountryCodesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0601/CountryCodesTest.java
@@ -167,4 +167,12 @@ public class CountryCodesTest {
     public void truncatedBad5() throws KlvParseException {
         new CountryCodes(new byte[] {0x01});
     }
+
+    @Test
+    public void testKeys() throws KlvParseException {
+        assertEquals(CountryCodeKey.CodingMethod.getIdentifier(), 0);
+        assertEquals(CountryCodeKey.OverflightCountry.getIdentifier(), 1);
+        assertEquals(CountryCodeKey.OperatorCountry.getIdentifier(), 2);
+        assertEquals(CountryCodeKey.CountryOfManufacture.getIdentifier(), 3);
+    }
 }


### PR DESCRIPTION
## Motivation and Context
This is a low-priority PR to add some missing test coverage for one class in the ST 0601 implementation

## Description
Adds one unit test for the `CountryCodeKey` class.

## How Has This Been Tested?
Ran build to execute unit tests, and verified improved coverage through jacoco report.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

