### PR TITLE
update spotbugs checks and fix / suppress issues

### DIFF
--- a/api/SpotBugsFilter.xml
+++ b/api/SpotBugsFilter.xml
@@ -4,7 +4,9 @@
     <Match>
         <Bug code="Wa,UR" />
     </Match>
-
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP,MS_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
     <!-- All bugs in test classes, except for JUnit-specific bugs -->
     <Match>
         <Class name="~.*\.*Test" />

--- a/core/SpotBugsFilter.xml
+++ b/core/SpotBugsFilter.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<FindBugsFilter xmlns="https://github.com/spotbugs/filter/3.0.0"
+<FindBugsFilter xmlns="https://github.com/spotbugs/filter/3.0.0" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
     <Match>
-        <Class name="org.jmisb.viewer.MisbViewer" />
-        <Bug pattern="DM_EXIT" />
-    </Match>
-    <Match>
-        <Bug pattern="EI_EXPOSE_REP2" />
+        <Bug pattern="EI_EXPOSE_REP" />
     </Match>
 </FindBugsFilter>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -76,6 +76,9 @@
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs.maven.version}</version>
+                <configuration>
+                    <excludeFilterFile>SpotBugsFilter.xml</excludeFilterFile>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>com.github.spotbugs</groupId>

--- a/miml-maven-plugin/src/main/java/org/jmisb/maven/ClassModel.java
+++ b/miml-maven-plugin/src/main/java/org/jmisb/maven/ClassModel.java
@@ -3,6 +3,7 @@ package org.jmisb.maven;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ClassModel extends AbstractModel {
 
@@ -38,7 +39,7 @@ public class ClassModel extends AbstractModel {
     }
 
     public List<ClassModelEntry> getEntries() {
-        return entries;
+        return entries.stream().collect(Collectors.toList());
     }
 
     public void addEntry(ClassModelEntry entry) {
@@ -86,7 +87,7 @@ public class ClassModel extends AbstractModel {
         this.needListForm = needListForm;
     }
 
-    public void setParent(Models parent) {
+    void setParent(Models parent) {
         this.parent = parent;
     }
 }

--- a/miml-maven-plugin/src/main/java/org/jmisb/maven/EnumerationModel.java
+++ b/miml-maven-plugin/src/main/java/org/jmisb/maven/EnumerationModel.java
@@ -2,12 +2,13 @@ package org.jmisb.maven;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class EnumerationModel extends AbstractModel {
-    private List<EnumerationModelEntry> entries = new ArrayList<>();
+    private final List<EnumerationModelEntry> entries = new ArrayList<>();
 
     public List<EnumerationModelEntry> getEntries() {
-        return entries;
+        return entries.stream().collect(Collectors.toList());
     }
 
     public void addEntry(EnumerationModelEntry entry) {

--- a/miml-maven-plugin/src/main/java/org/jmisb/maven/Models.java
+++ b/miml-maven-plugin/src/main/java/org/jmisb/maven/Models.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /** Collection of class and enumeration models for this MIML instance. */
-public class Models {
+class Models {
 
     private final List<EnumerationModel> enumerationModels = new ArrayList<>();
     private final List<ClassModel> classModels = new ArrayList<>();

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
         <owasp.version>6.1.6</owasp.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sortpom.version>2.15.0</sortpom.version>
-        <spotbugs.maven.version>4.0.0</spotbugs.maven.version>
-        <spotbugs.version>4.0.2</spotbugs.version>
+        <spotbugs.maven.version>4.2.0</spotbugs.maven.version>
+        <spotbugs.version>4.3.0</spotbugs.version>
         <surefire.verbosity>0</surefire.verbosity>
         <surefire.version>2.22.2</surefire.version>
     </properties>


### PR DESCRIPTION
## Motivation and Context
This updates the version of spotbugs we're using from 4.0.2 (release April 2020) to 4.3.0 (most recent release - 1 July 2021). The maven plugin is also updated. This is just routine maintenance, no specific motivating feature.

## Description
Update versions. 4.3.0 adds new checks for exposing the internal representation of an object. However fixing that mostly involves copying objects, and I don't want to pay that penalty in general. I'm OK with fixing it for the code generator, but otherwise I'm suppressing the bug. Also, the viewer application actually relies on being able to mutate some of the values for the map display. 

## How Has This Been Tested?
Ran full build, including all unit tests.
Checked the viewer application is still OK.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

