### PR TITLE
examples: add example to decode and display raw KLV

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -39,6 +39,13 @@ This example is a work-in-progress. See [its README](movingfeatures/README.md) f
 It shows how to parse an unsupported KLV blob (perhaps a local set or universal set) without changing jMISB.
 This example considered complete. See [its README](parserplugin/README.md) for more information.
 
+## rawklv
+
+It does a console dump of the raw KLV in a file to standard output. In this context, "raw" is the de-multiplexed stream content.
+This example is considered complete. See [its README](rawklv/README.md) for more information.
+
 ## systemout
 
-It does a console dump of the KLV metadata in a file to standard output (`System.out` in Java, hence the name). This example is considered complete. See [its README](systemout/README.md) for more information.
+It does a console dump of the KLV metadata in a file to standard output (`System.out` in Java, hence the name).
+This example differs from the rawklv example in that it takes an MPEG Transport Stream (typical format) rather than a de-multiplexed stream.
+This example is considered complete. See [its README](systemout/README.md) for more information.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,6 +19,7 @@
         <module>parserplugin</module>
         <module>mimdgenerator</module>
         <module>cotconverter</module>
+        <module>rawklv</module>
     </modules>
 
     <dependencyManagement>

--- a/examples/rawklv/README.md
+++ b/examples/rawklv/README.md
@@ -1,0 +1,87 @@
+# Dump raw KLV as text
+
+This is demonstration / example code for <https://github.com/WestRidgeSystems/jmisb>
+
+It does a console dump of the raw KLV data in a file to standard output (`System.out` in Java). In this context, "raw" is the de-multiplexed stream content,
+which is not normally used. It is more common to find the KLV multiplexed with the video stream in an MPEG Transport Stream (TS) or an encoding like CMAF.
+If you are looking for an example using TS, see the systemout example.
+
+## Building
+
+To build it, use maven.
+
+``` sh
+mvn clean install
+```
+
+## Using
+
+There are several ways to invoke it. One way is:
+
+``` sh
+java -jar target/rawklv-1.11.0-SNAPSHOT-jar-with-dependencies.jar  {filename}
+```
+
+For example:
+
+``` sh
+java -jar target/rawklv-1.11.0-SNAPSHOT-jar-with-dependencies.jar ~/MIMD_0.01.bin
+```
+
+You should adjust the version part to match the current version number.
+
+That will produce console output - you can redirect it to a file using standard command line functionality,
+since there could be a lot of output.
+
+The output depends on the input file, but might look like:
+
+``` txt
+MIMD
+        Security: REF<Security>(1, 0)
+        CompositeProductSecurity: REF<Security>(1, 0)
+        Timers: LIST[Timer]
+                Timer: [Timer]
+                        MIMD Id: [4, 0]
+                        NanoPrecisionTimestamp: 1624293300565345 ns
+                        UtcLeapSeconds: 18 s
+                        TimeTransferMethod: Inter-range Instrumentation Group (IRIG-B)
+        Platforms: LIST[Platform]
+                Platform: [Platform]
+                        Name: Test Platform
+                        Identity: MISB Test 002
+                        PlatformType: Trailer. See NTAX for detailed description
+                        Stages: LIST[Stage]
+                                Stage: [Stage]
+                                        MIMD Id: [2, 0]
+                                        Position: [Position]
+                                                AbsGeodetic: [AbsGeodetic]
+                                                        Lat: 0.564206 rad
+                                                        Lon: -1.863583 rad
+                                                        Hae: 1188.719999 m
+                                Stage: [Stage]
+                                        MIMD Id: [3, 0]
+                                        ParentStage: REF<Stage>(2, 0)
+                                        Position: [Position]
+                                                RelPosition: [RelPosition]
+                                                        X: 0.099609 m
+                                                        Y: 0.199219 m
+                                                        Z: 0.299805 m
+                                        Orientation: [Orientation]
+                                                AbsEnu: [AbsEnu]
+                                                        RotAboutUp: 0.610865 rad
+                        Payloads: LIST[Payload]
+                                Payload: [Payload]
+                                        Stages: LIST[Stage]
+                                                Stage: [Stage]
+                                                        Timer: REF<Timer>(4, 0)
+                                                        ParentStage: REF<Stage>(3, 0)
+                                                        Orientation: [Orientation]
+                                                                RelOrientation: [RelOrientation]
+                                                                        Alpha: 2.617994 rad
+                                                                        Beta: 0.959931 rad
+        SecurityOptions: LIST[Security]
+                Security: [Security]
+                        MIMD Id: [1, 0]
+                        ClassifyingMethod: US-1
+                        Classification: UNCLASSIFIED//REL TO USA, AUS, CAN, GBR
+```

--- a/examples/rawklv/pom.xml
+++ b/examples/rawklv/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jmisb</groupId>
+        <artifactId>examples</artifactId>
+        <version>1.11.0-SNAPSHOT</version>
+    </parent>
+    <groupId>org.jmisb.examples</groupId>
+    <artifactId>rawklv</artifactId>
+    <packaging>jar</packaging>
+    <name>Raw KLV parser example</name>
+    <description>Example code that dumps raw KLV to standard output.</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.jmisb</groupId>
+            <artifactId>jmisb-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <!-- java source code formatter -->
+                <groupId>com.theoryinpractise</groupId>
+                <artifactId>googleformatter-maven-plugin</artifactId>
+                <version>${googleformatter.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>reformat-sources</id>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                        <configuration>
+                            <style>AOSP</style>
+                            <fixImports>true</fixImports>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven.assembly.plugin.version}</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>org.jmisb.examples.rawklv.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/rawklv/src/main/java/org/jmisb/examples/rawklv/Main.java
+++ b/examples/rawklv/src/main/java/org/jmisb/examples/rawklv/Main.java
@@ -1,0 +1,15 @@
+package org.jmisb.examples.rawklv;
+
+import java.io.IOException;
+import org.jmisb.api.common.KlvParseException;
+
+public class Main {
+    public static void main(String[] args) throws IOException, KlvParseException {
+        if (args.length < 1) {
+            System.out.println("Need to specify the file name on the command line");
+            System.exit(1);
+        }
+        MetadataPlayer player = new MetadataPlayer();
+        player.play(args[0]);
+    }
+}

--- a/examples/rawklv/src/main/java/org/jmisb/examples/rawklv/MetadataPlayer.java
+++ b/examples/rawklv/src/main/java/org/jmisb/examples/rawklv/MetadataPlayer.java
@@ -1,0 +1,75 @@
+package org.jmisb.examples.rawklv;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import org.jmisb.api.common.InvalidDataHandler;
+import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.IKlvKey;
+import org.jmisb.api.klv.IKlvValue;
+import org.jmisb.api.klv.IMisbMessage;
+import org.jmisb.api.klv.INestedKlvValue;
+import org.jmisb.api.klv.KlvParser;
+import org.jmisb.core.klv.ArrayUtils;
+
+public class MetadataPlayer {
+
+    public MetadataPlayer() {
+        setUpErrorHandlers();
+    }
+
+    private void setUpErrorHandlers() {
+        InvalidDataHandler.getInstance()
+                .setInvalidFieldEncodingStrategy(new PrintOnInvalidDataStrategy());
+        InvalidDataHandler.getInstance()
+                .setInvalidChecksumStrategy(new PrintOnInvalidDataStrategy());
+    }
+
+    public void play(String filename) throws IOException, KlvParseException {
+        byte[] bytes = Files.readAllBytes(Paths.get(filename));
+        List<IMisbMessage> messages = KlvParser.parseBytes(bytes);
+        messages.forEach(
+                message -> {
+                    outputTopLevelMessageHeader(message);
+                    outputNestedKlvValue(message, 1);
+                });
+    }
+
+    private void outputTopLevelMessageHeader(IMisbMessage misbMessage) {
+        String displayHeader = misbMessage.displayHeader();
+        if (displayHeader.equalsIgnoreCase("Unknown")) {
+            System.out.println(
+                    displayHeader
+                            + " ["
+                            + ArrayUtils.toHexString(misbMessage.getUniversalLabel().getBytes())
+                                    .trim()
+                            + "]");
+            outputUnknownMessageContent(misbMessage.frameMessage(true));
+        } else {
+            System.out.println(displayHeader);
+        }
+    }
+
+    private void outputUnknownMessageContent(byte[] frameMessage) {
+        System.out.println(ArrayUtils.toHexString(frameMessage, 16, true));
+    }
+
+    private void outputNestedKlvValue(INestedKlvValue nestedKlvValue, int indentationLevel) {
+        for (IKlvKey identifier : nestedKlvValue.getIdentifiers()) {
+            IKlvValue value = nestedKlvValue.getField(identifier);
+            outputValueWithIndentation(value, indentationLevel);
+            // if this has nested content, output that at the next indentation level
+            if (value instanceof INestedKlvValue) {
+                outputNestedKlvValue((INestedKlvValue) value, indentationLevel + 1);
+            }
+        }
+    }
+
+    private void outputValueWithIndentation(IKlvValue value, int indentationLevel) {
+        for (int i = 0; i < indentationLevel; ++i) {
+            System.out.print("\t");
+        }
+        System.out.println(value.getDisplayName() + ": " + value.getDisplayableValue());
+    }
+}

--- a/examples/rawklv/src/main/java/org/jmisb/examples/rawklv/PrintOnInvalidDataStrategy.java
+++ b/examples/rawklv/src/main/java/org/jmisb/examples/rawklv/PrintOnInvalidDataStrategy.java
@@ -1,0 +1,14 @@
+package org.jmisb.examples.rawklv;
+
+import org.jmisb.api.common.IInvalidDataHandlerStrategy;
+import org.jmisb.api.common.KlvParseException;
+import org.slf4j.Logger;
+
+/** Invalid data strategy implementation that just dumps to System.out. */
+public class PrintOnInvalidDataStrategy implements IInvalidDataHandlerStrategy {
+
+    @Override
+    public void process(Logger logger, String message) throws KlvParseException {
+        System.out.println(message);
+    }
+}


### PR DESCRIPTION
## Motivation and Context
While doing some interoperability testing with the MISB and ranges team, I needed to test raw (not TS multiplexed) KLV dumping. We don't have an example of that, although there is some discussion in various MISB documents about KLV as a separate feed (e.g. VMTI metadata only) and we do have support for it.

## Description
Adds a very simple example of parsing and displaying raw KLV. It is based on the systemout example.

No functional changes to the "real" code.

## How Has This Been Tested?
Ran it on some MIMD test data provided by the MISB.

Also did a full build.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

