### PR TITLE
miml: rename variable in generated tests

### DIFF
--- a/miml-maven-plugin/src/main/resources/templates/compositeClassTest.ftl
+++ b/miml-maven-plugin/src/main/resources/templates/compositeClassTest.ftl
@@ -37,9 +37,9 @@ public class ${name}Test extends LoggerChecks {
 
    <#elseif entry.name == "mimdId">
         // mimdId
-        IMimdMetadataValue id = ${name}.createValue(${name}MetadataKey.${entry.name}, new byte[]{(byte) 0x01});
-        assertTrue(id instanceof MimdId);
-        values.put(${name}MetadataKey.${entry.name}, id);
+        IMimdMetadataValue _id = ${name}.createValue(${name}MetadataKey.${entry.name}, new byte[]{(byte) 0x01});
+        assertTrue(_id instanceof MimdId);
+        values.put(${name}MetadataKey.${entry.name}, _id);
 
     <#elseif entry.ref && ! entry.array>
         // Ref


### PR DESCRIPTION
## Motivation and Context
This is a minor change in the MIMD generator plugin template.

The generated tests use "id" as a local variable, which is OK at the moment,
but causes a duplicate definition if a composite class uses "id" for a
parameter. This is proposed to happen in a future MIMD change.

## Description
Renames the generated test code variable to be `_id`. Only affects tests.

## How Has This Been Tested?
Full build. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

