### PR TITLE
klv: fix parsing when byte array has multiple messages

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/KlvParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/KlvParser.java
@@ -35,7 +35,7 @@ public class KlvParser {
 
         while (pos < bytes.length) {
             // Get the next full message including UL (key), length, and value
-            byte[] nextMessage = getNextMessage(bytes);
+            byte[] nextMessage = getNextMessage(bytes, pos);
             pos += nextMessage.length;
 
             try {
@@ -55,22 +55,24 @@ public class KlvParser {
      * Extract the next top-level message.
      *
      * @param bytes The original byte array, assumed to begin with 16-byte UL
+     * @param pos the offset into the byte array to start parsing from
      * @return Byte array containing the full top-level message, including UL key, length, and value
      * @throws KlvParseException if a parsing error occurs
      */
-    private static byte[] getNextMessage(byte[] bytes) throws KlvParseException {
+    private static byte[] getNextMessage(byte[] bytes, int pos) throws KlvParseException {
         // Length of the key field (UL)
         final int keyLength = UniversalLabel.LENGTH;
-        BerField lengthField = BerDecoder.decode(bytes, keyLength, false);
+        BerField lengthField = BerDecoder.decode(bytes, pos + keyLength, false);
         final int totalLength = keyLength + lengthField.getLength() + lengthField.getValue();
 
-        // If the lengths are equal, just return the original array; otherwise copy a subrange.
-        if (totalLength > bytes.length) {
+        if (pos + totalLength > bytes.length) {
             throw new KlvParseException("Length exceeds available bytes");
-        } else if (totalLength == bytes.length) {
+        }
+        // If the lengths are equal, just return the original array; otherwise copy a subrange.
+        if ((pos == 0) && (totalLength == bytes.length)) {
             return bytes;
         } else {
-            return Arrays.copyOfRange(bytes, 0, totalLength);
+            return Arrays.copyOfRange(bytes, pos, pos + totalLength);
         }
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/KlvParserTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/KlvParserTest.java
@@ -6,6 +6,10 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.st0102.ST0102Version;
+import org.jmisb.api.klv.st0102.SecurityMetadataKey;
+import org.jmisb.api.klv.st0102.localset.SecurityMetadataLocalSet;
+import org.jmisb.api.klv.st0102.universalset.SecurityMetadataUniversalSet;
 import org.jmisb.api.klv.st0601.*;
 import org.jmisb.core.klv.ArrayUtils;
 import org.testng.Assert;
@@ -120,14 +124,14 @@ public class KlvParserTest {
                     (byte) 0x2b,
                     (byte) 0x34,
                     (byte) 0x02,
-                    (byte) 0x0b,
+                    (byte) 0x03,
                     (byte) 0x01,
                     (byte) 0x01,
                     (byte) 0x0e,
                     (byte) 0x01,
                     (byte) 0x03,
-                    (byte) 0x01,
-                    (byte) 0x01,
+                    (byte) 0x03,
+                    (byte) 0x02,
                     (byte) 0x00,
                     (byte) 0x00,
                     (byte) 0x00,
@@ -138,6 +142,9 @@ public class KlvParserTest {
             List<IMisbMessage> messages = KlvParser.parseBytes(bytes);
             Assert.assertEquals(messages.size(), 2);
             check0601Parse(messages);
+            IMisbMessage secondMessage = messages.get(1);
+            Assert.assertTrue(secondMessage instanceof SecurityMetadataLocalSet);
+            Assert.assertEquals(secondMessage.getIdentifiers().size(), 0);
         } catch (KlvParseException e) {
             Assert.fail("Parse exception");
         }
@@ -380,5 +387,107 @@ public class KlvParserTest {
         } catch (KlvParseException e) {
             Assert.fail("Parse exception");
         }
+    }
+
+    @Test
+    public void testMultipleMessages() {
+        byte[] bytes =
+                new byte[] {
+                    (byte) 0x06,
+                    (byte) 0x0e,
+                    (byte) 0x2b,
+                    (byte) 0x34,
+                    (byte) 0x02,
+                    (byte) 0x0b,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x0e,
+                    (byte) 0x01,
+                    (byte) 0x03,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x14,
+                    (byte) 0x0d,
+                    (byte) 0x04,
+                    (byte) 0x3c,
+                    (byte) 0x4e,
+                    (byte) 0xad,
+                    (byte) 0xfa,
+                    (byte) 0x0e,
+                    (byte) 0x04,
+                    (byte) 0xcd,
+                    (byte) 0x6b,
+                    (byte) 0x78,
+                    (byte) 0x4e,
+                    (byte) 0x0f,
+                    (byte) 0x02,
+                    (byte) 0x1b,
+                    (byte) 0xc4,
+                    (byte) 0x01,
+                    (byte) 0x02,
+                    (byte) 0x2d,
+                    (byte) 0xc4,
+                    (byte) 0x06,
+                    (byte) 0x0e,
+                    (byte) 0x2b,
+                    (byte) 0x34,
+                    (byte) 0x02,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x02,
+                    (byte) 0x08,
+                    (byte) 0x02,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x13,
+                    (byte) 0x06,
+                    (byte) 0x0e,
+                    (byte) 0x2b,
+                    (byte) 0x34,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x0e,
+                    (byte) 0x01,
+                    (byte) 0x02,
+                    (byte) 0x05,
+                    (byte) 0x04,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x02,
+                    (byte) 0x00,
+                    (byte) 0x0c
+                };
+
+        try {
+            List<IMisbMessage> messages = KlvParser.parseBytes(bytes);
+            Assert.assertEquals(messages.size(), 2);
+            check0601Parse(messages);
+            check0102Parse(messages.get(1));
+        } catch (KlvParseException e) {
+            Assert.fail("Parse exception");
+        }
+    }
+
+    private void check0102Parse(IMisbMessage message) {
+        Assert.assertTrue(message instanceof SecurityMetadataUniversalSet);
+        SecurityMetadataUniversalSet securityMessage = (SecurityMetadataUniversalSet) message;
+        Assert.assertEquals(
+                securityMessage.getUniversalLabel(), KlvConstants.SecurityMetadataUniversalSetUl);
+        Assert.assertEquals(securityMessage.getKeys().size(), 1);
+        Assert.assertEquals(securityMessage.getIdentifiers().size(), 1);
+        Assert.assertTrue(securityMessage.getIdentifiers().contains(SecurityMetadataKey.Version));
+        ST0102Version version =
+                (ST0102Version) securityMessage.getField(SecurityMetadataKey.Version);
+        Assert.assertEquals(version.getVersion(), 12);
     }
 }


### PR DESCRIPTION
## Motivation and Context
See #316. 

## Description
Modifies the parsing logic to handle multiple messages within one byte array.

## How Has This Been Tested?
Added unit test (and updated an existing one that wasn't working - it wouldn't parse properly because it didn't have a checksum).
Used viewer application across test files. All looks reasonable. I did see (with debugger) a couple of files that appeared to have multiple "segments", although it wasn't visually different in the viewer.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/174642/136677475-0a047c0e-fc60-4ee6-9d50-060614c9371f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [x] All new and existing tests passed.

