### PR TITLE
2.x: migrate to java modules

### DIFF
--- a/api-ffmpeg/src/main/java/module-info.java
+++ b/api-ffmpeg/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+module org.jmisb.api.ffmpeg {
+    requires org.jmisb.api;
+    requires org.jmisb.core;
+    requires org.bytedeco.ffmpeg.platform;
+    requires org.bytedeco.javacpp.platform;
+    requires org.bytedeco.ffmpeg;
+    requires org.slf4j;
+    // TODO: refactor to not require this
+    requires java.desktop;
+    // TODO: possibly a different namespace?
+    exports org.jmisb.api.video;
+}

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,47 @@
+module org.jmisb.api {
+    requires org.jmisb.core;
+    requires org.slf4j;
+    // TODO: refactor to avoid needing this
+    requires java.desktop;
+
+    exports org.jmisb.api.common;
+    exports org.jmisb.api.klv;
+    exports org.jmisb.api.klv.eg0104;
+    exports org.jmisb.api.klv.st0102;
+    exports org.jmisb.api.klv.st0102.localset;
+    exports org.jmisb.api.klv.st0102.universalset;
+    exports org.jmisb.api.klv.st0601;
+    exports org.jmisb.api.klv.st0601.dto;
+    exports org.jmisb.api.klv.st0603;
+    exports org.jmisb.api.klv.st0805;
+    exports org.jmisb.api.klv.st0806;
+    exports org.jmisb.api.klv.st0806.poiaoi;
+    exports org.jmisb.api.klv.st0806.userdefined;
+    exports org.jmisb.api.klv.st0808;
+    exports org.jmisb.api.klv.st0903;
+    exports org.jmisb.api.klv.st0903.algorithm;
+    exports org.jmisb.api.klv.st0903.ontology;
+    exports org.jmisb.api.klv.st0903.shared;
+    exports org.jmisb.api.klv.st0903.vchip;
+    exports org.jmisb.api.klv.st0903.vfeature;
+    exports org.jmisb.api.klv.st0903.vmask;
+    exports org.jmisb.api.klv.st0903.vobject;
+    exports org.jmisb.api.klv.st0903.vtarget;
+    exports org.jmisb.api.klv.st0903.vtrack;
+    exports org.jmisb.api.klv.st0903.vtracker;
+    exports org.jmisb.api.klv.st1108;
+    exports org.jmisb.api.klv.st1201;
+    exports org.jmisb.api.klv.st1204;
+    exports org.jmisb.api.klv.st1206;
+    exports org.jmisb.api.klv.st1303;
+    exports org.jmisb.api.klv.st1403;
+    exports org.jmisb.api.klv.st1902;
+    exports org.jmisb.api.klv.st1903;
+    exports org.jmisb.api.klv.st1904;
+    exports org.jmisb.api.klv.st1905;
+    exports org.jmisb.api.klv.st1906;
+    exports org.jmisb.api.klv.st1907;
+    exports org.jmisb.api.klv.st1908;
+    exports org.jmisb.api.klv.st1909;
+
+}

--- a/api/src/test/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/localset/SecurityMetadataLocalSetTest.java
@@ -64,7 +64,7 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks {
     }
 
     @Test
-    void testUniversalLabel() {
+    public void testUniversalLabel() {
         // Check that the correct universal label is applied
         Assert.assertEquals(localSet.getUniversalLabel(), KlvConstants.SecurityMetadataLocalSetUl);
     }

--- a/api/src/test/java/org/jmisb/api/klv/st0102/universalset/SecurityMetadataUniversalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0102/universalset/SecurityMetadataUniversalSetTest.java
@@ -46,7 +46,7 @@ public class SecurityMetadataUniversalSetTest {
     }
 
     @Test
-    void testUniversalLabel() {
+    public void testUniversalLabel() {
         // Check that the correct universal label is applied
         Assert.assertEquals(
                 universalSet.getUniversalLabel(), KlvConstants.SecurityMetadataUniversalSetUl);

--- a/api/src/test/java/org/jmisb/api/klv/st0806/RvtLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0806/RvtLocalSetTest.java
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
 
 /** Tests for the ST0806 Remote Video Terminal Local Set. */
 public class RvtLocalSetTest extends LoggerChecks {
-    RvtLocalSetTest() {
+    public RvtLocalSetTest() {
         super(RvtLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSetFactoryTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSetFactoryTest.java
@@ -10,7 +10,7 @@ import org.testng.annotations.Test;
 
 /** Tests for the ST0808 Ancillary Text Local Set Factory. */
 public class AncillaryTextLocalSetFactoryTest extends LoggerChecks {
-    AncillaryTextLocalSetFactoryTest() {
+    public AncillaryTextLocalSetFactoryTest() {
         super(AncillaryTextLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSetTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 
 /** Tests for the ST0808 Ancillary Text Local Set. */
 public class AncillaryTextLocalSetTest extends LoggerChecks {
-    AncillaryTextLocalSetTest() {
+    public AncillaryTextLocalSetTest() {
         super(AncillaryTextLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetOneWithTheLotLegacyModeTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetOneWithTheLotLegacyModeTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
  * <p>Some of the fields here may not be valid in ST0903.3, and are used for testing purposes only.
  */
 public class VmtiLocalSetOneWithTheLotLegacyModeTest extends LoggerChecks {
-    VmtiLocalSetOneWithTheLotLegacyModeTest() {
+    public VmtiLocalSetOneWithTheLotLegacyModeTest() {
         super(VmtiLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetOneWithTheLotTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetOneWithTheLotTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 /** Tests for the ST0903 VMTI Local Set including nested parts */
 public class VmtiLocalSetOneWithTheLotTest extends LoggerChecks {
-    VmtiLocalSetOneWithTheLotTest() {
+    public VmtiLocalSetOneWithTheLotTest() {
         super(VmtiLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VmtiLocalSetTest.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 
 /** Tests for the ST0903 VMTI Local Set. */
 public class VmtiLocalSetTest extends LoggerChecks {
-    VmtiLocalSetTest() {
+    public VmtiLocalSetTest() {
         super(VmtiLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetFactoryTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetFactoryTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 
 /** Tests for the ST0903 VTrack Local Set. */
 public class VTrackLocalSetFactoryTest extends LoggerChecks {
-    VTrackLocalSetFactoryTest() {
+    public VTrackLocalSetFactoryTest() {
         super(VTrackLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSetTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 /** Tests for the ST0903 VTrack Local Set. */
 public class VTrackLocalSetTest extends LoggerChecks {
-    VTrackLocalSetTest() {
+    public VTrackLocalSetTest() {
         super(VTrackLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st1108/InterpretabilityQualityLocalSetFactoryTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1108/InterpretabilityQualityLocalSetFactoryTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 
 /** Tests for the ST 1108 Interpretability and Quality Local Set Factory. */
 public class InterpretabilityQualityLocalSetFactoryTest extends LoggerChecks {
-    InterpretabilityQualityLocalSetFactoryTest() {
+    public InterpretabilityQualityLocalSetFactoryTest() {
         super(IQLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st1108/st1108_2/LegacyIQLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1108/st1108_2/LegacyIQLocalSetTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 
 /** Tests for the (legacy) ST 1108.2 Interpretability and Quality Local Set. */
 public class LegacyIQLocalSetTest extends LoggerChecks {
-    LegacyIQLocalSetTest() {
+    public LegacyIQLocalSetTest() {
         super(LegacyIQLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st1108/st1108_3/IQLocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1108/st1108_3/IQLocalSetTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 
 /** Tests for the ST 1108 Interpretability and Quality Local Set. */
 public class IQLocalSetTest extends LoggerChecks {
-    IQLocalSetTest() {
+    public IQLocalSetTest() {
         super(IQLocalSet.class);
     }
 

--- a/api/src/test/java/org/jmisb/api/klv/st1206/SARMILocalSetTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1206/SARMILocalSetTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 /** Tests for the ST1206 SAR Motion Imagery Local Set. */
 public class SARMILocalSetTest extends LoggerChecks {
 
-    SARMILocalSetTest() {
+    public SARMILocalSetTest() {
         super(SARMILocalSet.class);
     }
 

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module org.jmisb.core {
+    requires org.slf4j;
+
+    exports org.jmisb.core.klv;
+    exports org.jmisb.core.video;
+}

--- a/elevation/geoid/src/main/java/module-info.java
+++ b/elevation/geoid/src/main/java/module-info.java
@@ -1,0 +1,2 @@
+module org.jmisb.elevation.geoid {
+}

--- a/examples/cotconverter/pom.xml
+++ b/examples/cotconverter/pom.xml
@@ -17,6 +17,10 @@
             <artifactId>jmisb-api-ffmpeg</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/examples/cotconverter/src/main/java/module-info.java
+++ b/examples/cotconverter/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module org.jmisb.examples.cotconverter {
+    requires org.jmisb.api.ffmpeg;
+    requires org.jmisb.api;
+    requires org.jmisb.core;
+    requires org.slf4j;
+    requires org.slf4j.simple;
+}

--- a/examples/cotconverter/src/main/java/org/jmisb/examples/cotconverter/Converter.java
+++ b/examples/cotconverter/src/main/java/org/jmisb/examples/cotconverter/Converter.java
@@ -10,8 +10,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.jmisb.api.klv.IMisbMessage;
 import org.jmisb.api.klv.st0601.IUasDatalinkValue;
 import org.jmisb.api.klv.st0601.PrecisionTimeStamp;
@@ -26,9 +24,12 @@ import org.jmisb.api.video.IVideoFileInput;
 import org.jmisb.api.video.MetadataFrame;
 import org.jmisb.api.video.VideoFileInput;
 import org.jmisb.api.video.VideoFileInputOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Converter implements IMetadataListener, IFileEventListener {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Converter.class);
     private IVideoFileInput fileInput;
     private final KlvToCot conv = new KlvToCot();
     private final InetAddress address;
@@ -72,7 +73,7 @@ public class Converter implements IMetadataListener, IFileEventListener {
         try {
             socket.send(packet);
         } catch (IOException ex) {
-            Logger.getLogger(Converter.class.getName()).log(Level.SEVERE, null, ex);
+            LOGGER.error("Failed to send UDP: " + ex.getMessage());
         }
     }
 

--- a/examples/generator/src/main/java/module-info.java
+++ b/examples/generator/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module org.jmisb.examples.generator {
+    requires org.jmisb.api.ffmpeg;
+    requires org.jmisb.api;
+    requires org.jmisb.core;
+    requires commons.cli;
+    requires java.desktop;
+}

--- a/examples/gstsink/src/main/java/module-info.java
+++ b/examples/gstsink/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module org.jmisb.examples.gstsink {
+    requires org.jmisb.api;
+    requires org.jmisb.core;
+    requires org.slf4j;
+    requires org.slf4j.simple;
+    requires org.freedesktop.gstreamer;
+}

--- a/examples/mimdgenerator/src/main/java/module-info.java
+++ b/examples/mimdgenerator/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module org.jmisb.examples.mimdgenerator {
+    requires org.jmisb.api.ffmpeg;
+    requires org.jmisb.api;
+    requires org.jmisb.core;
+    requires org.slf4j;
+    requires org.slf4j.simple;
+    requires java.desktop;
+}

--- a/examples/movingfeatures/src/main/java/module-info.java
+++ b/examples/movingfeatures/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module org.jmisb.examples.movingfeatures {
+    requires org.jmisb.api.ffmpeg;
+    requires org.jmisb.api;
+    requires org.jmisb.core;
+    requires com.fasterxml.jackson.databind;
+}
+

--- a/examples/parserplugin/src/main/java/module-info.java
+++ b/examples/parserplugin/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module org.jmisb.examples.parserplugin {
+    requires org.jmisb.api;
+    requires org.jmisb.core;
+    requires org.jmisb.api.ffmpeg;
+}

--- a/examples/rawklv/src/main/java/module-info.java
+++ b/examples/rawklv/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module org.jmisb.examples.rawklv {
+    requires org.jmisb.api;
+    requires org.jmisb.core;
+    requires org.slf4j;
+    requires org.slf4j.simple;
+}

--- a/examples/systemout/src/main/java/module-info.java
+++ b/examples/systemout/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module org.jmisb.examples.systemout {
+    requires org.jmisb.api.ffmpeg;
+    requires org.jmisb.api;
+    requires org.jmisb.core;
+    requires org.slf4j;
+    requires org.slf4j.simple;
+}

--- a/viewer/src/main/java/module-info.java
+++ b/viewer/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+module org.jmisb.viewer {
+    requires org.jmisb.api.ffmpeg;
+    requires org.jmisb.api;
+    requires org.slf4j;
+    requires com.miglayout.swing;
+    requires jxmapviewer2;
+    requires net.harawata.appdirs;
+    requires java.desktop;
+    requires java.prefs;
+}


### PR DESCRIPTION

## Motivation and Context
Java 11 compatibility really needs support for the modules system (JSR 376). This PR adds that.

## Description
A couple of problems with visibility that have been corrected.

Some changes in the CoT converter to clean up logging.

This doesn't do refactoring to remove the AWT dependency (java.desktop module).
That seems more intrusive and will be done as a separate commit.

I assume this could be breaking for existing Java 11 users, since the names of the modules will not longer match what was previously generated.

## How Has This Been Tested?
Full rebuild to exercise all unit tests.
Viewer application.
Each example app (some where only validated to "it runs" level, such as CoT converter - I assume if the XML comes out as UDP traffic, then the content is still OK). Note that since we don't have the GPL part enabled in 2.x branch at the moment, some of the generator code will only work with OpenH264.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

