### PR TITLE
st1206: minor cleanups for method name and docs

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st1206/ISARMIMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/ISARMIMetadataValue.java
@@ -5,7 +5,8 @@ import org.jmisb.api.klv.IKlvValue;
 /**
  * SAR Motion Imagery (SARMI) metadata value.
  *
- * <p>All values for the SARMI local set implement this interface. It is unliely .
+ * <p>All values for the SARMI local set implement this interface. It is unlikely you will need to
+ * implement this interface.
  */
 public interface ISARMIMetadataValue extends IKlvValue {
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st1206/MinimumDetectableVelocity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/MinimumDetectableVelocity.java
@@ -8,23 +8,23 @@ import org.jmisb.api.klv.st1201.OutOfRangeBehaviour;
  *
  * <p>SARMI is essentially a form of Ground Moving Target Indicators (GMTI) displayed on full-
  * resolution Endo-clutter SAR frames rather than the classic 'blips' on a range-Doppler image. The
- * GMTI radial velocity is the projection of the mover's velocity vector upon the radar's line-of-
- * sight vector to the target. Hence, the radial velocity is not only a function of target velocity,
- * but also scene geometry.
+ * GMTI radial velocity is the projection of the mover's velocity vector upon the radar's
+ * line-of-sight vector to the target. Hence, the radial velocity is not only a function of target
+ * velocity, but also scene geometry.
  *
  * <p>The Minimum Detectable Velocity (MDV) is defined as the radial velocity when a target located
- * at the antenna beam’s cross-range center line transcends from the Endo- clutter (visible SAR
+ * at the antenna beam’s cross-range center line transcends from the Endo-clutter (visible SAR
  * image) boundary into Exo-clutter (not visible). Technically, the MDV could change within a SAR
  * image. However, for simplicity, assume the MDV is constant over the SAR coherent processing
- * interval. Estimation of the MDV using aforementioned SARMI metadata requires additional a priori
- * knowledge of sensor parameters. Hence, it is desirable to specify the MDV explicitly.
+ * interval. Estimation of the MDV using aforementioned SARMI metadata requires additional <i>a
+ * priori</i> knowledge of sensor parameters. Hence, it is desirable to specify the MDV explicitly.
  */
 public class MinimumDetectableVelocity implements ISARMIMetadataValue {
 
-    protected static final double MIN_VAL = 0.0;
-    protected static final double MAX_VAL = 100.0;
-    protected static final int NUM_BYTES = 2;
-    protected double value;
+    private static final double MIN_VAL = 0.0;
+    private static final double MAX_VAL = 100.0;
+    private static final int NUM_BYTES = 2;
+    private double value;
 
     /**
      * Create from value.
@@ -76,11 +76,11 @@ public class MinimumDetectableVelocity implements ISARMIMetadataValue {
     }
 
     /**
-     * Get the Transmit RF Bandwidth.
+     * Get the minimum detectable velocity.
      *
-     * @return bandwidth in Hertz
+     * @return velocity in m/s.
      */
-    public double getBandwidth() {
+    public double getVelocity() {
         return value;
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st1206/ReferenceFrameRangeLayoverAngleRelativeToTrueNorth.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/ReferenceFrameRangeLayoverAngleRelativeToTrueNorth.java
@@ -7,7 +7,7 @@ package org.jmisb.api.klv.st1206;
  * perpendicular to the sensor ground track angle at the aperture center of the reference SAR image
  * used in the creation of the SAR coherent products. The compliment for the current SAR image used
  * in the creation of the SAR coherent change products is defined
- * in @link{RangeLayoverAngleRelativeToTrueNorth}. .
+ * in @link{RangeLayoverAngleRelativeToTrueNorth}.
  *
  * <p>See ST1206 Section 6.3 for more information.
  */

--- a/api/src/main/java/org/jmisb/api/klv/st1206/package-info.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/package-info.java
@@ -3,7 +3,6 @@
  *
  * <p>This standard defines the content and Local Set Key-Length-Value (KLV) representation of
  * metadata necessary to exploit both sequential synthetic aperture radar (SAR) imagery and
- * sequential SAR coherent change products as motion imagery. In addition, background information
- * regarding typical SAR collections and terminology are provided for context.
+ * sequential SAR coherent change products as motion imagery.
  */
 package org.jmisb.api.klv.st1206;

--- a/api/src/test/java/org/jmisb/api/klv/st1206/MinimumDetectableVelocityTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1206/MinimumDetectableVelocityTest.java
@@ -13,7 +13,7 @@ public class MinimumDetectableVelocityTest {
         assertEquals(uut.getBytes(), new byte[] {(byte) 0x0a, (byte) 0x0});
         assertEquals(uut.getDisplayName(), "Minimum Detectable Velocity");
         assertEquals(uut.getDisplayableValue(), "10.000m/s");
-        assertEquals(uut.getBandwidth(), 10.0, 0.01);
+        assertEquals(uut.getVelocity(), 10.0, 0.01);
     }
 
     @Test
@@ -23,7 +23,7 @@ public class MinimumDetectableVelocityTest {
         assertEquals(uut.getBytes(), new byte[] {(byte) 0x00, (byte) 0x01});
         assertEquals(uut.getDisplayName(), "Minimum Detectable Velocity");
         assertEquals(uut.getDisplayableValue(), "0.004m/s");
-        assertEquals(uut.getBandwidth(), 0.004, 0.001);
+        assertEquals(uut.getVelocity(), 0.004, 0.001);
     }
 
     @Test
@@ -37,7 +37,7 @@ public class MinimumDetectableVelocityTest {
         assertEquals(uut.getBytes(), new byte[] {(byte) 0x01, (byte) 0x03});
         assertEquals(uut.getDisplayName(), "Minimum Detectable Velocity");
         assertEquals(uut.getDisplayableValue(), "1.012m/s");
-        assertEquals(uut.getBandwidth(), 1.012, 0.001);
+        assertEquals(uut.getVelocity(), 1.012, 0.001);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
## Motivation and Context
During development of another set, I noted a bit of incomplete documentation on the ST 1206 set. Looks like I just didn't pay enough attention to the javadoc at the time.

Also found a method that was mis-named (cut-n-paste error).

## Description
Minor updates to the javadoc and one method. The method renaming required test changes.

## How Has This Been Tested?
Just a full build and inspection of the resulting documentation.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests  (modified existing) to cover my changes.
- [ ] All new and existing tests passed.

