### PR TITLE
doc: update MISB home page link (2.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## About
 
 jmisb is an open source Java library implementing various
-[MISB](http://www.gwg.nga.mil/misb/ "MISB home page") standards.
+[MISB](https://gwg.nga.mil/gwg/focus-groups/misb/ "MISB home page") standards.
 It leverages the excellent work by
 [bytedeco](https://github.com/bytedeco) on bringing video support to Java.
 Stay tuned here for updates, and please join us on [gitter](https://gitter.im/jmisb/community) if you need help
@@ -32,7 +32,7 @@ The MISB has been quite prolific in creation of new standards since its
 inception in 2000. As of April 2021, over four dozen standards are listed
 on its web site. While the scope of the jmisb project is to support as many of
 these standards as possible, the initial focus will be on those
-in most widespread use. 
+in most widespread use.
 
 The table below lists the status of currently-supported standards:
 


### PR DESCRIPTION
The old page is 404.

## Motivation and Context
The GWG is migrating all the focus group home pages. The old pages are gone (probably permanently).

## Description
Updates readme link to new page. Also removed one trailing whitespace entry.

## How Has This Been Tested?
N/A.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

