### PR TITLE
deps: upgrade jackson-databind to 2.13.1 (2.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <googleformatter.maven.plugin.version>1.7.5</googleformatter.maven.plugin.version>
         <gstreamer.version>1.4.0</gstreamer.version>
         <guava.version>31.0.1-jre</guava.version>
-        <jackson.version>2.13.0</jackson.version>
+        <jackson.version>2.13.1</jackson.version>
         <jacoco.version>0.8.7</jacoco.version>
         <javacpp.logging.debug>false</javacpp.logging.debug>
         <jqf.plugin.version>1.7</jqf.plugin.version>


### PR DESCRIPTION
## Motivation and Context

Patch-level upgrade to jackson-databind (which brings in some other jackson dependencies too). The changes are shown in https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13.1

We don't use this much - some testing data that was convenient to make in JSON format, and one example for making OGC Moving Features. However its probably worth keeping up.

## Description

Just bumped the version in managed dependencies.

## How Has This Been Tested?

Full build to ensure the tests still work, and ran the moving features example with some VMTI data. Seemed OK.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

