### PR TITLE
st0903: harden BitMaskSeries parsing (develop)

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st0903/vmask/BitMaskSeries.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vmask/BitMaskSeries.java
@@ -50,7 +50,8 @@ public class BitMaskSeries implements IVmtiMetadataValue {
      * Create from encoded bytes.
      *
      * @param bytes Encoded byte array comprising the bit mask
-     * @throws KlvParseException if the byte array could not be parsed.
+     * @throws KlvParseException if there are too few bytes to parse or the parsing is otherwise
+     *     invalid
      */
     public BitMaskSeries(byte[] bytes) throws KlvParseException {
         int index = 0;
@@ -107,7 +108,7 @@ public class BitMaskSeries implements IVmtiMetadataValue {
         return bitMask;
     }
 
-    private PixelRunPair parsePixelRunPair(byte[] valueBytes) {
+    private PixelRunPair parsePixelRunPair(byte[] valueBytes) throws KlvParseException {
         int index = 0;
         BerField lengthField = BerDecoder.decode(valueBytes, 0, false);
         index += lengthField.getLength();
@@ -115,6 +116,9 @@ public class BitMaskSeries implements IVmtiMetadataValue {
             throw new IllegalArgumentException("Pixel number encoding is up to 6 bytes");
         }
         long pixelNumber = 0;
+        if (valueBytes.length < index + lengthField.getValue()) {
+            throw new KlvParseException("Too few bytes to parse BitMaskSeries pixel pairs");
+        }
         for (int i = index; i < (index + lengthField.getValue()); ++i) {
             pixelNumber = pixelNumber << 8;
             pixelNumber += ((int) valueBytes[i] & 0xFF);

--- a/api/src/test/java/org/jmisb/api/klv/st0903/VTargetSeriesTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st0903/VTargetSeriesTest.java
@@ -1,5 +1,6 @@
 package org.jmisb.api.klv.st0903;
 
+import static org.jmisb.api.klv.st0903.VmtiMetadataKey.VTargetSeries;
 import static org.testng.Assert.*;
 
 import java.util.ArrayList;
@@ -8,6 +9,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.IKlvValue;
+import org.jmisb.api.klv.st0903.shared.EncodingMode;
 import org.jmisb.api.klv.st0903.vtarget.CentroidPixelColumn;
 import org.jmisb.api.klv.st0903.vtarget.CentroidPixelRow;
 import org.jmisb.api.klv.st0903.vtarget.TargetHAE;
@@ -140,5 +142,78 @@ public class VTargetSeriesTest {
     @Test
     public void testGetDisplayName() {
         assertEquals(vTargetSeriesFromBytes.getDisplayName(), "Target Series");
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testBitMaskSeries_fuzz_363_0() throws KlvParseException {
+        byte bytes[] =
+                new byte[] {
+                    0x06,
+                    0x26,
+                    0x65,
+                    0x05,
+                    0x02,
+                    0x03,
+                    0x01,
+                    0x05,
+                    (byte) 0xce,
+                    0x4f,
+                    (byte) 0x89,
+                    (byte) 0xe1,
+                    0x29,
+                    (byte) 0xb0,
+                    (byte) 0x8c,
+                    (byte) 0x84,
+                    0x60,
+                    0x34,
+                    (byte) 0xb9,
+                    0x53,
+                    (byte) 0x94,
+                    0x04
+                };
+        IVmtiMetadataValue v = VmtiLocalSet.createValue(VTargetSeries, bytes, EncodingMode.IMAPB);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testBitMaskSeries_fuzz_363_1() throws KlvParseException {
+        byte bytes[] =
+                new byte[] {
+                    0x06,
+                    0x26,
+                    0x65,
+                    0x05,
+                    0x02,
+                    0x03,
+                    0x01,
+                    0x02,
+                    (byte) 0xc7,
+                    (byte) 0xaa,
+                    0x05,
+                    (byte) 0xda,
+                    0x26,
+                    0x0e,
+                    0x5c,
+                    (byte) 0x90,
+                    0x2e,
+                    0x79,
+                    (byte) 0xb9,
+                    0x53,
+                    (byte) 0xa4,
+                    0x04,
+                    0x71,
+                    (byte) 0x96,
+                    0x44,
+                    (byte) 0xc8,
+                    (byte) 0xfa,
+                    (byte) 0xf3,
+                    (byte) 0xc7,
+                    (byte) 0x88,
+                    0x28,
+                    (byte) 0x84,
+                    (byte) 0xd2,
+                    0x2e,
+                    0x02,
+                };
+        IVmtiMetadataValue v = VmtiLocalSet.createValue(VTargetSeries, bytes, EncodingMode.IMAPB);
     }
 }


### PR DESCRIPTION
## Motivation and Context
Adds a check in the BitMaskSeries part of ST 0903 VMask for invalid values. This came up during some fuzz testing.

Resolves #363 (along with #364, which resolves it for the 2.x branch)

## Description
Additional check, so we throw KlvParseException. Includes tests replicating the fuzz results.

## How Has This Been Tested?
Unit testing only. I don't have any data that uses this part of ST 0903.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

