### PR TITLE
st1108: use Utf8String class

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st1108/st1108_3/CompressionLevel.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1108/st1108_3/CompressionLevel.java
@@ -1,7 +1,7 @@
 package org.jmisb.api.klv.st1108.st1108_3;
 
-import java.nio.charset.StandardCharsets;
 import org.jmisb.api.klv.ArrayBuilder;
+import org.jmisb.api.klv.st0107.Utf8String;
 import org.jmisb.api.klv.st1108.IInterpretabilityQualityMetadataValue;
 
 /**
@@ -20,7 +20,7 @@ import org.jmisb.api.klv.st1108.IInterpretabilityQualityMetadataValue;
  * </blockquote>
  */
 public class CompressionLevel implements IInterpretabilityQualityMetadataValue {
-    private final String level;
+    private final Utf8String level;
     private static final int MAX_LENGTH = 3;
 
     /**
@@ -33,7 +33,7 @@ public class CompressionLevel implements IInterpretabilityQualityMetadataValue {
             throw new IllegalArgumentException(
                     this.getDisplayName() + " maximum length is " + MAX_LENGTH);
         }
-        this.level = compressionLevel;
+        this.level = new Utf8String(compressionLevel);
     }
 
     /**
@@ -46,7 +46,7 @@ public class CompressionLevel implements IInterpretabilityQualityMetadataValue {
             throw new IllegalArgumentException(
                     this.getDisplayName() + " maximum length is " + MAX_LENGTH);
         }
-        this.level = new String(bytes, StandardCharsets.UTF_8);
+        this.level = new Utf8String(bytes);
     }
 
     /**
@@ -55,7 +55,7 @@ public class CompressionLevel implements IInterpretabilityQualityMetadataValue {
      * @return The compression level as a String
      */
     public String getCompressionLevel() {
-        return level;
+        return level.getValue();
     }
 
     @Override
@@ -71,7 +71,7 @@ public class CompressionLevel implements IInterpretabilityQualityMetadataValue {
     @Override
     public void appendBytesToBuilder(ArrayBuilder arrayBuilder) {
         arrayBuilder.appendAsOID(IQMetadataKey.CompressionLevel.getIdentifier());
-        byte[] valueBytes = level.getBytes(StandardCharsets.UTF_8);
+        byte[] valueBytes = level.getBytesWithLimit(MAX_LENGTH);
         arrayBuilder.appendAsBerLength(valueBytes.length);
         arrayBuilder.append(valueBytes);
     }

--- a/api/src/main/java/org/jmisb/api/klv/st1108/st1108_3/metric/MetricName.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1108/st1108_3/metric/MetricName.java
@@ -1,6 +1,6 @@
 package org.jmisb.api.klv.st1108.st1108_3.metric;
 
-import java.nio.charset.StandardCharsets;
+import org.jmisb.api.klv.st0107.Utf8String;
 
 /**
  * Metric Name.
@@ -29,7 +29,7 @@ import java.nio.charset.StandardCharsets;
  * </blockquote>
  */
 public class MetricName implements IMetricLocalSetValue {
-    private final String name;
+    private final Utf8String name;
 
     /**
      * Create from value.
@@ -37,7 +37,7 @@ public class MetricName implements IMetricLocalSetValue {
      * @param metricName the name of the metric (from the MISB defined list, or user defined).
      */
     public MetricName(String metricName) {
-        name = metricName;
+        name = new Utf8String(metricName);
     }
 
     /**
@@ -46,12 +46,12 @@ public class MetricName implements IMetricLocalSetValue {
      * @param bytes Byte array of the metric name encoded in UTF-8.
      */
     public MetricName(byte[] bytes) {
-        name = new String(bytes, StandardCharsets.UTF_8);
+        name = new Utf8String(bytes);
     }
 
     @Override
     public byte[] getBytes() {
-        return name.getBytes(StandardCharsets.UTF_8);
+        return name.getBytes();
     }
 
     @Override
@@ -70,6 +70,6 @@ public class MetricName implements IMetricLocalSetValue {
      * @return the metric name
      */
     public String getName() {
-        return name;
+        return name.getValue();
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st1108/st1108_3/metric/MetricParameters.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1108/st1108_3/metric/MetricParameters.java
@@ -1,6 +1,6 @@
 package org.jmisb.api.klv.st1108.st1108_3.metric;
 
-import java.nio.charset.StandardCharsets;
+import org.jmisb.api.klv.st0107.Utf8String;
 
 /**
  * Metric Parameters.
@@ -17,7 +17,7 @@ import java.nio.charset.StandardCharsets;
  * </blockquote>
  */
 public class MetricParameters implements IMetricLocalSetValue {
-    private final String parameters;
+    private final Utf8String parameters;
 
     /**
      * Create from value.
@@ -25,7 +25,7 @@ public class MetricParameters implements IMetricLocalSetValue {
      * @param metricParameters the parameters for the metric calculation process.
      */
     public MetricParameters(String metricParameters) {
-        parameters = metricParameters;
+        parameters = new Utf8String(metricParameters);
     }
 
     /**
@@ -34,12 +34,12 @@ public class MetricParameters implements IMetricLocalSetValue {
      * @param bytes Byte array of the metric parameters encoded in UTF-8.
      */
     public MetricParameters(byte[] bytes) {
-        parameters = new String(bytes, StandardCharsets.UTF_8);
+        parameters = new Utf8String(bytes);
     }
 
     @Override
     public byte[] getBytes() {
-        return parameters.getBytes(StandardCharsets.UTF_8);
+        return parameters.getBytes();
     }
 
     @Override
@@ -58,6 +58,6 @@ public class MetricParameters implements IMetricLocalSetValue {
      * @return the metric parameters
      */
     public String getParameters() {
-        return parameters;
+        return parameters.getValue();
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st1108/st1108_3/metric/MetricVersion.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1108/st1108_3/metric/MetricVersion.java
@@ -1,6 +1,6 @@
 package org.jmisb.api.klv.st1108.st1108_3.metric;
 
-import java.nio.charset.StandardCharsets;
+import org.jmisb.api.klv.st0107.Utf8String;
 import org.jmisb.api.klv.st1108.*;
 
 /**
@@ -18,7 +18,7 @@ import org.jmisb.api.klv.st1108.*;
  * </blockquote>
  */
 public class MetricVersion implements IMetricLocalSetValue {
-    private final String version;
+    private final Utf8String version;
 
     /**
      * Create from value.
@@ -26,7 +26,7 @@ public class MetricVersion implements IMetricLocalSetValue {
      * @param metricVersion the version of the metric algorithm, or "human".
      */
     public MetricVersion(String metricVersion) {
-        version = metricVersion;
+        version = new Utf8String(metricVersion);
     }
 
     /**
@@ -35,12 +35,12 @@ public class MetricVersion implements IMetricLocalSetValue {
      * @param bytes Byte array of the metric version encoded in UTF-8.
      */
     public MetricVersion(byte[] bytes) {
-        version = new String(bytes, StandardCharsets.UTF_8);
+        version = new Utf8String(bytes);
     }
 
     @Override
     public byte[] getBytes() {
-        return version.getBytes(StandardCharsets.UTF_8);
+        return version.getBytes();
     }
 
     @Override
@@ -59,6 +59,6 @@ public class MetricVersion implements IMetricLocalSetValue {
      * @return the metric version
      */
     public String getVersion() {
-        return version;
+        return version.getValue();
     }
 }


### PR DESCRIPTION
## Motivation and Context
MISB has a slightly complicated definition of "utf8" type in ST 0107, which I implemented as part of the ST 0809 implementation. However I need to go back over existing places where I just used a plain String. 

This is part of the rework, covering ST 1108.

## Description
Changes most of the uses of `utf8` in ST 1108. There is one that is slightly messy, and is unlikely to trigger the special null case, so I'm going to ignore that for now.

## How Has This Been Tested?

Just a full build - no test data for this message. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

