### PR TITLE
ci: add api-awt to codecov reporting

### DIFF
--- a/.github/workflows/jdk11.yml
+++ b/.github/workflows/jdk11.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           file: ./api/target/site/jacoco/jacoco.xml
           flags: unittests-api
+      - name: Upload api-awt test results to Codecov
+        uses: codecov/codecov-action@v1.5.0
+        with:
+          file: ./api-awt/target/site/jacoco/jacoco.xml
+          flags: unittests-awt
       - name: Upload api-ffmpeg test results to Codecov
         uses: codecov/codecov-action@v1.5.0
         with:


### PR DESCRIPTION
## Motivation and Context
Codecov provides reporting for some modules, but not all of them. In particular, we're generating coverage for the MIML plugin (which isn't very important) and api-awt, but not uploading that. This enables uploading of api-awt jacoco reporting.

MIML might be useful later.

## Description
Updates JDK 11 github workflow CI action to upload the relevant test report. Its basically copy-n-paste from the equivalent api step.

## How Has This Been Tested?
Only on GH workflow run.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

