### PR TITLE
deps: version bump on maven annotations plugin to 3.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <jqf.version>1.8</jqf.version>
         <jxmapviewer.version>2.6</jxmapviewer.version>
         <log4j.version>2.17.1</log4j.version>
-        <maven.annotations.version>3.6.2</maven.annotations.version>
+        <maven.annotations.version>3.6.4</maven.annotations.version>
         <maven.assembly.plugin.version>3.3.0</maven.assembly.plugin.version>
         <maven.checkstyle.plugin>3.1.2</maven.checkstyle.plugin>
         <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>


### PR DESCRIPTION
## Motivation and Context
This is a micro version upgrade on a maven plugin. The release is part of the maven-plugin-tools release, see https://lists.apache.org/thread/lq00sgpx6wn322xbgts6tzdym7yzrg0z for the release notes (its not clear what happened to 3.6.3 - I had a scan of the mailing list, but didn't see anything).

There isn't anything in here that affects us - we only use the annotations for the MIML plugin.

## Description
Updates version in managed dependencies.

## How Has This Been Tested?
Full build only. Since this is only used for maven plugin at compile time, I think that is sufficient.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

