### PR TITLE
update javadoc (2.x)

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,3 +1,8 @@
+/**
+ * Primary API for jmisb.
+ *
+ * <p>This module provides the implementation of the MISB standards.
+ */
 module org.jmisb.api {
     requires org.jmisb.core;
     requires org.slf4j;

--- a/api/src/main/java/org/jmisb/api/klv/Ber.java
+++ b/api/src/main/java/org/jmisb/api/klv/Ber.java
@@ -6,7 +6,10 @@ package org.jmisb.api.klv;
  * <p>BER is described in ST0107.4 "KLV Metadata in Motion Imagery" and the Motion Imagery Handbook.
  */
 public enum Ber {
+    /** The value is encoded in single-byte "Short Form". */
     SHORT_FORM,
+    /** The value is encoded in multiple-byte "Long Form". */
     LONG_FORM,
+    /** The value is encoded as an OID value. */
     OID
 }

--- a/api/src/main/java/org/jmisb/api/klv/IKlvValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/IKlvValue.java
@@ -5,16 +5,12 @@ public interface IKlvValue {
     /**
      * Get the human-readable name for the value.
      *
-     * <p>
-     *
      * @return The name of the type
      */
     String getDisplayName();
 
     /**
      * Return a string of the displayable value.
-     *
-     * <p>
      *
      * @return String representing the value
      */

--- a/api/src/main/java/org/jmisb/api/klv/UniversalLabel.java
+++ b/api/src/main/java/org/jmisb/api/klv/UniversalLabel.java
@@ -4,7 +4,9 @@ import java.util.Arrays;
 
 /** Represents a 16-byte Universal Label (UL). */
 public class UniversalLabel {
+    /** Length of a UniversalLabel in bytes. */
     public static final int LENGTH = 16;
+
     private final byte[] bytes;
     private static final int OID_FIELD = 0;
     private static final int UL_LENGTH_FIELD = 1;

--- a/api/src/main/java/org/jmisb/api/klv/eg0104/PredatorMetadataConstants.java
+++ b/api/src/main/java/org/jmisb/api/klv/eg0104/PredatorMetadataConstants.java
@@ -6,6 +6,7 @@ import org.jmisb.api.klv.UniversalLabel;
 public class PredatorMetadataConstants {
     private PredatorMetadataConstants() {}
 
+    /** Frame centre latitude. */
     public static final UniversalLabel FRAME_CENTRE_LATITUDE =
             new UniversalLabel(
                     new byte[] {
@@ -15,6 +16,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x02, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Frame centre longitude. */
     public static final UniversalLabel FRAME_CENTRE_LONGITUDE =
             new UniversalLabel(
                     new byte[] {
@@ -24,6 +26,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x04, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Frame centre elevation. */
     public static final UniversalLabel FRAME_CENTRE_ELEVATION =
             new UniversalLabel(
                     new byte[] {
@@ -33,6 +36,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x16, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Image Coordinate System. */
     public static final UniversalLabel IMAGE_COORDINATE_SYSTEM =
             new UniversalLabel(
                     new byte[] {
@@ -42,6 +46,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x00, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Target Width. */
     public static final UniversalLabel TARGET_WIDTH =
             new UniversalLabel(
                     new byte[] {
@@ -51,6 +56,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x00, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Start date-time in UTC. */
     public static final UniversalLabel START_DATE_TIME_UTC =
             new UniversalLabel(
                     new byte[] {
@@ -60,6 +66,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x01, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Event start date-time in UTC. */
     public static final UniversalLabel EVENT_START_DATE_TIME_UTC =
             new UniversalLabel(
                     new byte[] {
@@ -69,6 +76,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x01, (byte) 0x00, (byte) 0x00
                     });
 
+    /** User defined time stamp. */
     public static final UniversalLabel USER_DEFINED_TIME_STAMP =
             new UniversalLabel(
                     new byte[] {
@@ -78,6 +86,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x05, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Latitude of Corner Point 1. */
     public static final UniversalLabel CORNER_LATITUDE_POINT_1 =
             new UniversalLabel(
                     new byte[] {
@@ -87,6 +96,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x07, (byte) 0x01, (byte) 0x00
                     });
 
+    /** Latitude of Corner Point 2. */
     public static final UniversalLabel CORNER_LATITUDE_POINT_2 =
             new UniversalLabel(
                     new byte[] {
@@ -96,6 +106,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x08, (byte) 0x01, (byte) 0x00
                     });
 
+    /** Latitude of Corner Point 3. */
     public static final UniversalLabel CORNER_LATITUDE_POINT_3 =
             new UniversalLabel(
                     new byte[] {
@@ -105,6 +116,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x09, (byte) 0x01, (byte) 0x00
                     });
 
+    /** Latitude of Corner Point 4. */
     public static final UniversalLabel CORNER_LATITUDE_POINT_4 =
             new UniversalLabel(
                     new byte[] {
@@ -114,6 +126,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x0A, (byte) 0x01, (byte) 0x00
                     });
 
+    /** Longitude of Corner Point 1. */
     public static final UniversalLabel CORNER_LONGITUDE_POINT_1 =
             new UniversalLabel(
                     new byte[] {
@@ -123,6 +136,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x0B, (byte) 0x01, (byte) 0x00
                     });
 
+    /** Longitude of Corner Point 2. */
     public static final UniversalLabel CORNER_LONGITUDE_POINT_2 =
             new UniversalLabel(
                     new byte[] {
@@ -132,6 +146,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x0C, (byte) 0x01, (byte) 0x00
                     });
 
+    /** Longitude of Corner Point 3. */
     public static final UniversalLabel CORNER_LONGITUDE_POINT_3 =
             new UniversalLabel(
                     new byte[] {
@@ -141,6 +156,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x0D, (byte) 0x01, (byte) 0x00
                     });
 
+    /** Longitude of Corner Point 4. */
     public static final UniversalLabel CORNER_LONGITUDE_POINT_4 =
             new UniversalLabel(
                     new byte[] {
@@ -150,6 +166,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x0E, (byte) 0x01, (byte) 0x00
                     });
 
+    /** Slant Range. */
     public static final UniversalLabel SLANT_RANGE =
             new UniversalLabel(
                     new byte[] {
@@ -159,6 +176,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x00, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Sensor Roll Angle. */
     public static final UniversalLabel SENSOR_ROLL_ANGLE =
             new UniversalLabel(
                     new byte[] {
@@ -168,6 +186,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x00, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Angle to North. */
     public static final UniversalLabel ANGLE_TO_NORTH =
             new UniversalLabel(
                     new byte[] {
@@ -177,6 +196,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x00, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Obliquity Angle. */
     public static final UniversalLabel OBLIQUITY_ANGLE =
             new UniversalLabel(
                     new byte[] {
@@ -186,6 +206,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x00, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Platform Roll Angle. */
     public static final UniversalLabel PLATFORM_ROLL_ANGLE =
             new UniversalLabel(
                     new byte[] {
@@ -195,6 +216,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x00, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Platform Pitch Angle. */
     public static final UniversalLabel PLATFORM_PITCH_ANGLE =
             new UniversalLabel(
                     new byte[] {
@@ -204,6 +226,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x00, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Platform Heading Angle. */
     public static final UniversalLabel PLATFORM_HEADING_ANGLE =
             new UniversalLabel(
                     new byte[] {
@@ -213,6 +236,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x00, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Field of View - Horizontal. */
     public static final UniversalLabel FIELD_OF_VIEW_HORIZONTAL =
             new UniversalLabel(
                     new byte[] {
@@ -222,6 +246,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x08, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Field of View - Vertical. */
     public static final UniversalLabel FIELD_OF_VIEW_VERTICAL =
             new UniversalLabel(
                     new byte[] {
@@ -231,6 +256,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x0A, (byte) 0x01, (byte) 0x00
                     });
 
+    /** Device altitude. */
     public static final UniversalLabel DEVICE_ALTITUDE =
             new UniversalLabel(
                     new byte[] {
@@ -240,6 +266,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x02, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Device latitude. */
     public static final UniversalLabel DEVICE_LATITUDE =
             new UniversalLabel(
                     new byte[] {
@@ -249,6 +276,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x04, (byte) 0x02, (byte) 0x00
                     });
 
+    /** Device longitude. */
     public static final UniversalLabel DEVICE_LONGITUDE =
             new UniversalLabel(
                     new byte[] {
@@ -258,6 +286,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x06, (byte) 0x02, (byte) 0x00
                     });
 
+    /** Image Source Device. */
     public static final UniversalLabel IMAGE_SOURCE_DEVICE =
             new UniversalLabel(
                     new byte[] {
@@ -267,6 +296,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x01, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Episode Number. */
     public static final UniversalLabel EPISODE_NUMBER =
             new UniversalLabel(
                     new byte[] {
@@ -276,6 +306,7 @@ public class PredatorMetadataConstants {
                                 (byte) 0x00, (byte) 0x00, (byte) 0x00
                     });
 
+    /** Device Designation. */
     public static final UniversalLabel DEVICE_DESIGATION =
             new UniversalLabel(
                     new byte[] {

--- a/api/src/main/java/org/jmisb/api/klv/eg0104/PredatorMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/eg0104/PredatorMetadataKey.java
@@ -7,6 +7,11 @@ import org.jmisb.api.klv.UniversalLabel;
 
 /** EG 0104 key. */
 public enum PredatorMetadataKey implements IKlvKey {
+    /**
+     * Undefined.
+     *
+     * <p>This value is not valid and should not be intentionally created.
+     */
     Undefined(
             new UniversalLabel(
                     new byte[] {
@@ -14,36 +19,67 @@ public enum PredatorMetadataKey implements IKlvKey {
                         0x00, 0x00, 0x00, 0x00
                     }),
             99),
+    /** Frame Centre Latitude. */
     FrameCenterLatitude(PredatorMetadataConstants.FRAME_CENTRE_LATITUDE, 100),
+    /** Frame Centre Longitude. */
     FrameCenterLongitude(PredatorMetadataConstants.FRAME_CENTRE_LONGITUDE, 101),
+    /** Frame Centre Elevation. */
     FrameCenterElevation(PredatorMetadataConstants.FRAME_CENTRE_ELEVATION, 102),
+    /** Image Coordinate System. */
     ImageCoordinateSystem(PredatorMetadataConstants.IMAGE_COORDINATE_SYSTEM, 103),
+    /** Target Width. */
     TargetWidth(PredatorMetadataConstants.TARGET_WIDTH, 104),
+    /** Start date-time in UTC. */
     StartDateTimeUtc(PredatorMetadataConstants.START_DATE_TIME_UTC, 105),
+    /** Event start date-time in UTC. */
     EventStartDateTimeUtc(PredatorMetadataConstants.EVENT_START_DATE_TIME_UTC, 106),
+    /** User defined time stamp. */
     UserDefinedTimeStamp(PredatorMetadataConstants.USER_DEFINED_TIME_STAMP, 107),
+    /** Latitude of Corner Point 1. */
     CornerLatitudePoint1(PredatorMetadataConstants.CORNER_LATITUDE_POINT_1, 108),
+    /** Latitude of Corner Point 2. */
     CornerLatitudePoint2(PredatorMetadataConstants.CORNER_LATITUDE_POINT_2, 109),
+    /** Latitude of Corner Point 3. */
     CornerLatitudePoint3(PredatorMetadataConstants.CORNER_LATITUDE_POINT_3, 110),
+    /** Latitude of Corner Point 4. */
     CornerLatitudePoint4(PredatorMetadataConstants.CORNER_LATITUDE_POINT_4, 111),
+    /** Longitude of Corner Point 1. */
     CornerLongitudePoint1(PredatorMetadataConstants.CORNER_LONGITUDE_POINT_1, 112),
+    /** Longitude of Corner Point 2. */
     CornerLongitudePoint2(PredatorMetadataConstants.CORNER_LONGITUDE_POINT_2, 113),
+    /** Longitude of Corner Point 3. */
     CornerLongitudePoint3(PredatorMetadataConstants.CORNER_LONGITUDE_POINT_3, 114),
+    /** Longitude of Corner Point 4. */
     CornerLongitudePoint4(PredatorMetadataConstants.CORNER_LONGITUDE_POINT_4, 115),
+    /** Slant Range. */
     SlantRange(PredatorMetadataConstants.SLANT_RANGE, 116),
+    /** Sensor Roll Angle. */
     SensorRollAngle(PredatorMetadataConstants.SENSOR_ROLL_ANGLE, 117),
+    /** Angle to North. */
     AngleToNorth(PredatorMetadataConstants.ANGLE_TO_NORTH, 118),
+    /** Obliquity Angle. */
     ObliquityAngle(PredatorMetadataConstants.OBLIQUITY_ANGLE, 119),
+    /** Platform Roll Angle. */
     PlatformRollAngle(PredatorMetadataConstants.PLATFORM_ROLL_ANGLE, 120),
+    /** Platform Pitch Angle. */
     PlatformPitchAngle(PredatorMetadataConstants.PLATFORM_PITCH_ANGLE, 121),
+    /** Platform Heading Angle. */
     PlatformHeadingAngle(PredatorMetadataConstants.PLATFORM_HEADING_ANGLE, 122),
+    /** Horizontal Field of View. */
     FieldOfViewHorizontal(PredatorMetadataConstants.FIELD_OF_VIEW_HORIZONTAL, 123),
+    /** Vertical Field of View. */
     FieldOfViewVertical(PredatorMetadataConstants.FIELD_OF_VIEW_VERTICAL, 124),
+    /** Device Altitude. */
     DeviceAltitude(PredatorMetadataConstants.DEVICE_ALTITUDE, 125),
+    /** Device Latitude. */
     DeviceLatitude(PredatorMetadataConstants.DEVICE_LATITUDE, 126),
+    /** Device Longitude. */
     DeviceLongitude(PredatorMetadataConstants.DEVICE_LONGITUDE, 127),
+    /** Image Source Device. */
     ImageSourceDevice(PredatorMetadataConstants.IMAGE_SOURCE_DEVICE, 128),
+    /** Episode Number. */
     EpisodeNumber(PredatorMetadataConstants.EPISODE_NUMBER, 129),
+    /** Device Designation. */
     DeviceDesignation(PredatorMetadataConstants.DEVICE_DESIGATION, 130);
 
     private final UniversalLabel ul;
@@ -69,7 +105,7 @@ public enum PredatorMetadataKey implements IKlvKey {
      * @param ul The key's universal label
      * @param key an integer ident for this key.
      */
-    PredatorMetadataKey(UniversalLabel ul, int key) {
+    private PredatorMetadataKey(UniversalLabel ul, int key) {
         this.ul = ul;
         this.key = key;
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0102/CountryCodingMethod.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/CountryCodingMethod.java
@@ -23,6 +23,13 @@ public enum CountryCodingMethod implements IKlvValue {
      * <p>For example, Australia is "AUS".
      */
     ISO3166_THREE_LETTER,
+    /**
+     * Mixed ISO-3166 with CAPCO codes.
+     *
+     * <p>The Mixed Country Coding Method shall be used to support di- or tri-graphs (but not both)
+     * from GEC, ISO 3166, GENC and STANAG 1059, respectively, and approved tetragraphs in the same
+     * field.
+     */
     ISO3166_MIXED,
     /**
      * ISO-3166 Numeric codes.
@@ -31,14 +38,26 @@ public enum CountryCodingMethod implements IKlvValue {
      */
     ISO3166_NUMERIC,
     /**
-     * FIPS 10-4 codes.
+     * FIPS 10-4 / GEC codes.
      *
      * <p>For example, Australia is "AS".
      *
      * <p>This is a legacy coding method, only used in the US.
      */
     FIPS10_4_TWO_LETTER,
+    /**
+     * FIPS 10-4 / GEC four letter codes.
+     *
+     * <p>This is a legacy coding method, only used in the US.
+     */
     FIPS10_4_FOUR_LETTER,
+    /**
+     * Mixed FIPS 10-4 / GEC with CAPCO codes.
+     *
+     * <p>The Mixed Country Coding Method shall be used to support di- or tri-graphs (but not both)
+     * from GEC, ISO 3166, GENC and STANAG 1059, respectively, and approved tetragraphs in the same
+     * field.
+     */
     FIPS10_4_MIXED,
     /**
      * STANAG 1059 Two Letter codes.
@@ -60,6 +79,13 @@ public enum CountryCodingMethod implements IKlvValue {
      * <p>This is not valid, and should not be created.
      */
     OMITTED_VALUE,
+    /**
+     * Mixed STANAG 1059 with CAPCO codes.
+     *
+     * <p>The Mixed Country Coding Method shall be used to support di- or tri-graphs (but not both)
+     * from GEC, ISO 3166, GENC and STANAG 1059, respectively, and approved tetragraphs in the same
+     * field.
+     */
     STANAG_1059_MIXED,
     /**
      * GENC Two Letter codes.
@@ -82,7 +108,20 @@ public enum CountryCodingMethod implements IKlvValue {
      * US.
      */
     GENC_NUMERIC,
+    /**
+     * Mixed GENC with CAPCO codes.
+     *
+     * <p>The Mixed Country Coding Method shall be used to support di- or tri-graphs (but not both)
+     * from GEC, ISO 3166, GENC and STANAG 1059, respectively, and approved tetragraphs in the same
+     * field.
+     */
     GENC_MIXED,
+    /**
+     * GENC Administrative subdivision codes.
+     *
+     * <p>Similar to ISO-3166 Administrative subdivision codes. Motion Imagery consumers are
+     * required to understand at least the country code part of the overall code.
+     */
     GENC_ADMINSUB;
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataConstants.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataConstants.java
@@ -9,120 +9,140 @@ public class SecurityMetadataConstants {
 
     private SecurityMetadataConstants() {}
 
+    /** Security Classification Universal Label. */
     public static final UniversalLabel securityClassificationUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x02, 0x08, 0x02, 0x01,
                         0x00, 0x00, 0x00, 0x00
                     });
+    /** Country Code coding method Universal Label. */
     public static final UniversalLabel ccCodingMethodUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x07, 0x01, 0x20, 0x01,
                         0x02, 0x07, 0x00, 0x00
                     });
+    /** Classifying Country Universal Label. */
     public static final UniversalLabel classifyingCountryUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x07, 0x01, 0x20, 0x01,
                         0x02, 0x08, 0x00, 0x00
                     });
+    /** SCI / SHI Information Universal Label. */
     public static final UniversalLabel sciShiInfoUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x01, 0x0e, 0x01, 0x02, 0x03,
                         0x02, 0x00, 0x00, 0x00
                     });
+    /** Caveats Universal Label. */
     public static final UniversalLabel caveatsUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x02, 0x08, 0x02, 0x02,
                         0x00, 0x00, 0x00, 0x00
                     });
+    /** Releasing Instructions Universal Label. */
     public static final UniversalLabel releasingInstructionsUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x07, 0x01, 0x20, 0x01,
                         0x02, 0x09, 0x00, 0x00
                     });
+    /** Classified-by Universal Label. */
     public static final UniversalLabel classifiedByUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x02, 0x08, 0x02, 0x03,
                         0x00, 0x00, 0x00, 0x00
                     });
+    /** Derived From Universal Label. */
     public static final UniversalLabel derivedFromUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x02, 0x08, 0x02, 0x06,
                         0x00, 0x00, 0x00, 0x00
                     });
+    /** Security Classification Reason Universal Label. */
     public static final UniversalLabel classificationReasonUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x02, 0x08, 0x02, 0x04,
                         0x00, 0x00, 0x00, 0x00
                     });
+    /** Declassification Date Universal Label. */
     public static final UniversalLabel declassificationDateUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x02, 0x08, 0x02, 0x05,
                         0x00, 0x00, 0x00, 0x00
                     });
+    /** Marking System Universal Label. */
     public static final UniversalLabel markingSystemUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x02, 0x08, 0x02, 0x08,
                         0x00, 0x00, 0x00, 0x00
                     });
+    /** Object Country Coding Method Universal Label. */
     public static final UniversalLabel ocCodingMethodUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x07, 0x01, 0x20, 0x01,
                         0x02, 0x06, 0x00, 0x00
                     });
+    /** Object Country Code Universal Label. */
     public static final UniversalLabel objectCountryCodesUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x07, 0x01, 0x20, 0x01,
                         0x02, 0x01, 0x01, 0x00
                     });
+    /** Security Classification Comments Universal Label. */
     public static final UniversalLabel classificationCommentsUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x02, 0x08, 0x02, 0x07,
                         0x00, 0x00, 0x00, 0x00
                     });
+    /** Stream Identification Universal Label. */
     public static final UniversalLabel streamIdUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x01, 0x03, 0x04, 0x02,
                         0x00, 0x00, 0x00, 0x00
                     });
+    /** Transport Stream Identification Universal Label. */
     public static final UniversalLabel transportStreamIdUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x01, 0x03, 0x04, 0x03,
                         0x00, 0x00, 0x00, 0x0
                     });
+    /** Item Designator Universal Label. */
     public static final UniversalLabel itemDesignatorIdUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x03, 0x01, 0x03, 0x06, 0x01,
                         0x00, 0x00, 0x00, 0x00
                     });
+    /** Version Universal Label. */
     public static final UniversalLabel versionUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x01, 0x0e, 0x01, 0x02, 0x05,
                         0x04, 0x00, 0x00, 0x00
                     });
+    /** Country Coding Method version / date Universal Label. */
     public static final UniversalLabel ccCodingMethodVersionDateUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x01, 0x0e, 0x01, 0x04, 0x03,
                         0x03, 0x00, 0x00, 0x00
                     });
+    /** Object Country Coding Method version / date Universal Label. */
     public static final UniversalLabel ocCodingMethodVersionDateUl =
             new UniversalLabel(
                     new byte[] {

--- a/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataKey.java
@@ -15,6 +15,11 @@ import org.jmisb.api.klv.UniversalLabel;
  * the universal set.
  */
 public enum SecurityMetadataKey implements IKlvKey {
+    /**
+     * Unknown / Undefined metadata item.
+     *
+     * <p>This is not a valid value, and should not be intentionally created or used.
+     */
     Undefined(
             0,
             new UniversalLabel(

--- a/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0102/SecurityMetadataString.java
@@ -9,16 +9,27 @@ import java.nio.charset.StandardCharsets;
  * kinds of strings.
  */
 public class SecurityMetadataString implements ISecurityMetadataValue {
+    /** Caveats label. */
     public static final String CAVEATS = "Caveats";
+    /** Classification Comments label. */
     public static final String CLASSIFICATION_COMMENTS = "Classification Comments";
+    /** Classification Reason label. */
     public static final String CLASSIFICATION_REASON = "Classification Reason";
+    /** Classified By label. */
     public static final String CLASSIFIED_BY = "Classified By";
+    /** Classifying Country label. */
     public static final String CLASSIFYING_COUNTRY = "Classifying Country";
+    /** Derived From label. */
     public static final String DERIVED_FROM = "Derived From";
+    /** Marking System label. */
     public static final String MARKING_SYSTEM = "Marking System";
+    /** Object Country Coding Method label. */
     public static final String OBJECT_COUNTRY_CODING_METHOD = "Object Country Coding Method";
+    /** Releasing Instructions label. */
     public static final String RELEASING_INSTRUCTIONS = "Releasing Instructions";
+    /** SCI / SHI Information Label. */
     public static final String SCI_SHI_INFO = "Security-SCI/SHI Information";
+    /** Country Coding Method label. */
     public static final String COUNTRY_CODING_METHOD = "Country Coding Method";
 
     private final String stringValue;

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ActiveWavelengthList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ActiveWavelengthList.java
@@ -35,8 +35,6 @@ public class ActiveWavelengthList implements IUasDatalinkValue {
      * <p>This valid identifiers should be from the defined set (1-7), or 21 and higher as defined
      * by Item 128.
      *
-     * <p>
-     *
      * @param wavelengthIdentifiers the list of identifiers.
      */
     public ActiveWavelengthList(List<Integer> wavelengthIdentifiers) {
@@ -62,8 +60,6 @@ public class ActiveWavelengthList implements IUasDatalinkValue {
      * Get the list of wavelength identifiers.
      *
      * <p>This gets the live list, so it can also be used to add an entry, or to clear the list.
-     *
-     * <p>
      *
      * @return the wavelength identifiers, as a list.
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0601/AirbaseLocations.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/AirbaseLocations.java
@@ -216,8 +216,6 @@ public class AirbaseLocations implements IUasDatalinkValue {
     /**
      * Get the Takeoff Location.
      *
-     * <p>
-     *
      * @return the location, or null if it is not known.
      */
     public Location getTakeoffLocation() {
@@ -226,8 +224,6 @@ public class AirbaseLocations implements IUasDatalinkValue {
 
     /**
      * Get the Recovery Location.
-     *
-     * <p>
      *
      * @return the location, or null if it is not known.
      */
@@ -238,8 +234,6 @@ public class AirbaseLocations implements IUasDatalinkValue {
     /**
      * Whether the takeoff location is unknown.
      *
-     * <p>
-     *
      * @return true if its unknown, false if its known
      */
     public boolean isTakeoffLocationUnknown() {
@@ -248,8 +242,6 @@ public class AirbaseLocations implements IUasDatalinkValue {
 
     /**
      * Whether the recovery location is unknown.
-     *
-     * <p>
      *
      * @return true if its unknown, false if its known
      */

--- a/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommands.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/ControlCommands.java
@@ -18,7 +18,7 @@ import org.jmisb.api.klv.INestedKlvValue;
  */
 public class ControlCommands implements IUasDatalinkValue, INestedKlvValue, ISpecialFraming {
 
-    public List<ControlCommand> controlCommands = new ArrayList<>();
+    private List<ControlCommand> controlCommands = new ArrayList<>();
 
     /**
      * Create from a single command.

--- a/api/src/main/java/org/jmisb/api/klv/st0601/CountryCodeKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/CountryCodeKey.java
@@ -9,12 +9,16 @@ import org.jmisb.api.klv.IKlvKey;
  * have to be filled in.
  */
 public enum CountryCodeKey implements IKlvKey {
+    /** Coding Method. */
     CodingMethod(0),
+    /** Overflight Country. */
     OverflightCountry(1),
+    /** Operator Country. */
     OperatorCountry(2),
+    /** Country of Manufacture. */
     CountryOfManufacture(3);
 
-    CountryCodeKey(int key) {
+    private CountryCodeKey(int key) {
         this.tag = key;
     }
 

--- a/api/src/main/java/org/jmisb/api/klv/st0601/FlagDataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/FlagDataKey.java
@@ -5,15 +5,25 @@ import org.jmisb.api.klv.IKlvKey;
 /**
  * Enumeration of the various flags used in GenericFlagData01.
  *
- * <p>Each of these corresponds to a single bit in the GenericFlagData01 data. The tag value matches
- * the bit (where 0 is the least significant bit).
+ * <p>Each of these corresponds to a single bit in the {@link GenericFlagData01} data. The tag value
+ * matches the bit (where 0 is the least significant bit).
  */
 public enum FlagDataKey implements IKlvKey {
+    /** Laser Range. */
     LaserRange(0),
+    /** Auto Track. */
     AutoTrack(1),
+    /**
+     * IR Polarity.
+     *
+     * <p>This conveys whether an IR scene is "white hot" or "black hot".
+     */
     IR_Polarity(2),
+    /** Icing Status. */
     IcingStatus(3),
+    /** Slant Range. */
     SlantRange(4),
+    /** Image invalid. */
     ImageInvalid(5);
 
     FlagDataKey(int key) {

--- a/api/src/main/java/org/jmisb/api/klv/st0601/GenericFlagData01.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/GenericFlagData01.java
@@ -29,29 +29,29 @@ import org.jmisb.api.klv.INestedKlvValue;
  */
 public class GenericFlagData01 implements IUasDatalinkValue, INestedKlvValue {
 
-    protected static final String LASER_RANGE_STRING_KEY = "Laser Range";
-    protected static final String LASER_OFF = "Laser off";
-    protected static final String LASER_ON = "Laser on";
+    private static final String LASER_RANGE_STRING_KEY = "Laser Range";
+    private static final String LASER_OFF = "Laser off";
+    private static final String LASER_ON = "Laser on";
 
-    protected static final String AUTO_TRACK_STRING_KEY = "Auto-Track";
-    protected static final String AUTO_TRACK_OFF = "Auto-Track off";
-    protected static final String AUTO_TRACK_ON = "Auto-Track on";
+    private static final String AUTO_TRACK_STRING_KEY = "Auto-Track";
+    private static final String AUTO_TRACK_OFF = "Auto-Track off";
+    private static final String AUTO_TRACK_ON = "Auto-Track on";
 
-    protected static final String IR_POLARITY_STRING_KEY = "IR Polarity";
-    protected static final String WHITE_HOT = "White Hot";
-    protected static final String BLACK_HOT = "Black Hot";
+    private static final String IR_POLARITY_STRING_KEY = "IR Polarity";
+    private static final String WHITE_HOT = "White Hot";
+    private static final String BLACK_HOT = "Black Hot";
 
-    protected static final String ICING_STATUS_STRING_KEY = "Icing Status";
-    protected static final String NO_ICING_DETECTED = "No Icing Detected";
-    protected static final String ICING_DETECTED = "Icing Detected";
+    private static final String ICING_STATUS_STRING_KEY = "Icing Status";
+    private static final String NO_ICING_DETECTED = "No Icing Detected";
+    private static final String ICING_DETECTED = "Icing Detected";
 
-    protected static final String SLANT_RANGE_STRING_KEY = "Slant Range";
-    protected static final String CALCULATED = "Calculated";
-    protected static final String MEASURED = "Measured";
+    private static final String SLANT_RANGE_STRING_KEY = "Slant Range";
+    private static final String CALCULATED = "Calculated";
+    private static final String MEASURED = "Measured";
 
-    protected static final String IMAGE_INVALID_STRING_KEY = "Image Invalid";
-    protected static final String IMAGE_INVALID = "Image Invalid";
-    protected static final String IMAGE_VALID = "Image Valid";
+    private static final String IMAGE_INVALID_STRING_KEY = "Image Invalid";
+    private static final String IMAGE_INVALID = "Image Invalid";
+    private static final String IMAGE_VALID = "Image Valid";
 
     private final SortedMap<FlagDataKey, UasDatalinkString> map = new TreeMap<>();
 

--- a/api/src/main/java/org/jmisb/api/klv/st0601/OpaqueValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/OpaqueValue.java
@@ -3,6 +3,7 @@ package org.jmisb.api.klv.st0601;
 /** Represents a UAS Datalink value that is not interpreted by the library. */
 public class OpaqueValue implements IUasDatalinkValue {
     private final byte[] bytes;
+    /** The display name (label) used for Opaque Values. */
     public static final String DISPLAY_NAME = "Opaque Value";
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PayloadList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PayloadList.java
@@ -96,8 +96,6 @@ public class PayloadList implements IUasDatalinkValue, INestedKlvValue {
      *
      * <p>This gets the live list, so it can also be used to add an entry, or to clear the list.
      *
-     * <p>
-     *
      * @return the payloads, as a list.
      */
     public List<Payload> getPayloadList() {

--- a/api/src/main/java/org/jmisb/api/klv/st0601/PositioningMethodSource.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/PositioningMethodSource.java
@@ -45,13 +45,21 @@ public class PositioningMethodSource implements IUasDatalinkValue {
     private static final int MIN_VALUE = 1;
     private static final int MAX_VALUE = 255;
 
+    /** Inertial Navigation System (INS). */
     public static final int INS = 1;
+    /** US Global Positioning System (GPS). */
     public static final int GPS = 2;
+    /** Galileo. */
     public static final int GALILEO = 4;
+    /** QZSS. */
     public static final int QZSS = 8;
+    /** NAVIC. */
     public static final int NAVIC = 16;
+    /** GLONASS. */
     public static final int GLONASS = 32;
+    /** BeiDou Generation 1. */
     public static final int BEIDOU1 = 64;
+    /** BeiDou Generation 2. */
     public static final int BEIDOU2 = 128;
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/TargetWidth.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/TargetWidth.java
@@ -22,6 +22,12 @@ public class TargetWidth implements IUasDatalinkValue {
     private static final double MIN_VAL = 0.0;
     private static final double MAX_VAL = 10000.0;
     private static final double MAXINT = 65535.0; // 2^16 - 1
+    /**
+     * Approximate encoding error in this value.
+     *
+     * <p>This is based on the resolution / 2 and should be considered a precision. It is unlikely
+     * to represent actual accuracy.
+     */
     public static final double DELTA = 0.08; // +/- .08 meters
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitude.java
@@ -22,6 +22,12 @@ public abstract class UasDatalinkAltitude implements IUasDatalinkValue {
     private static final double MAX_VALUE = 19000;
     private static final double RANGE = 19900;
     private static final double MAX_INT = 65535.0; // 2^16 - 1
+    /**
+     * Approximate encoding error in this value.
+     *
+     * <p>This is based on the resolution / 2 and should be considered a precision. It is unlikely
+     * to represent actual accuracy.
+     */
     public static final double DELTA = 0.15; // +/- 0.15 meters
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitudeExtended.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAltitudeExtended.java
@@ -11,9 +11,9 @@ import org.jmisb.api.klv.st1201.OutOfRangeBehaviour;
  * Sensor Ellipsoid Height Extended (ST 0601 Item 104).
  */
 public abstract class UasDatalinkAltitudeExtended implements IUasDatalinkValue {
-    protected static final double MIN_VAL = -900.0;
-    protected static final double MAX_VAL = 40000.0;
-    protected static final int RECOMMENDED_BYTES = 3;
+    private static final double MIN_VAL = -900.0;
+    private static final double MAX_VAL = 40000.0;
+    private static final int RECOMMENDED_BYTES = 3;
     private final double meters;
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAngle.java
@@ -17,10 +17,10 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * </blockquote>
  */
 public abstract class UasDatalinkAngle implements IUasDatalinkValue {
-    static final byte[] invalidBytes = new byte[] {(byte) 0x80, (byte) 0x00};
-    protected static final double FLOAT_RANGE = 40.0;
-    protected static final double INT_RANGE = 65534.0; // 2^15-1
-    protected final double degrees;
+    private static final byte[] invalidBytes = new byte[] {(byte) 0x80, (byte) 0x00};
+    private static final double FLOAT_RANGE = 40.0;
+    private static final double INT_RANGE = 65534.0; // 2^15-1
+    private final double degrees;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAngle360.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkAngle360.java
@@ -19,9 +19,9 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * </blockquote>
  */
 public abstract class UasDatalinkAngle360 implements IUasDatalinkValue {
-    protected static final double RANGE = 360.0;
-    protected static final double MAXINT = 65535.0; // 2^16 - 1
-    protected final double degrees;
+    private static final double RANGE = 360.0;
+    private static final double MAXINT = 65535.0; // 2^16 - 1
+    private final double degrees;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLatitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLatitude.java
@@ -22,7 +22,14 @@ public abstract class UasDatalinkLatitude implements IUasDatalinkValue {
             new byte[] {(byte) 0x80, (byte) 0x00, (byte) 0x00, (byte) 0x00};
     private static final double FLOAT_RANGE = 90.0;
     private static final double MAX_INT = 2147483647.0;
+    /**
+     * Approximate encoding error in this value.
+     *
+     * <p>This is based on the resolution / 2 and should be considered a precision. It is unlikely
+     * to represent actual accuracy.
+     */
     public static final double DELTA = 21e-9; // +/- 21 nano degrees
+
     private final String displayName;
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLongitude.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkLongitude.java
@@ -22,7 +22,14 @@ public abstract class UasDatalinkLongitude implements IUasDatalinkValue {
             new byte[] {(byte) 0x80, (byte) 0x00, (byte) 0x00, (byte) 0x00};
     private static final double FLOAT_RANGE = 180.0;
     private static final double MAX_INT = 2147483647.0;
+    /**
+     * Approximate encoding error in this value.
+     *
+     * <p>This is based on the resolution / 2 and should be considered a precision. It is unlikely
+     * to represent actual accuracy.
+     */
     public static final double DELTA = 42e-9; // +/- 42 nano degrees
+
     private final String displayName;
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkString.java
@@ -4,17 +4,29 @@ import java.nio.charset.StandardCharsets;
 
 /** Represents a string value in ST 0601. */
 public class UasDatalinkString implements IUasDatalinkValue {
+    /** Alternate Platform Name. */
     public static final String ALTERNATE_PLATFORM_NAME = "Alternate Platform Name";
+    /** Broadcast Source. */
     public static final String BROADCAST_SOURCE = "Broadcast Source";
+    /** Communications Method. */
     public static final String COMMUNICATIONS_METHOD = "Communications Method";
+    /** Image Coordinate System. */
     public static final String IMAGE_COORDINATE_SYSTEM = "Image Coordinate System";
+    /** Image Source Sensor. */
     public static final String IMAGE_SOURCE_SENSOR = "Image Source Sensor";
+    /** Mission ID. */
     public static final String MISSION_ID = "Mission ID";
+    /** Operational Base. */
     public static final String OPERATIONAL_BASE = "Operational Base";
+    /** Platform Call Sign. */
     public static final String PLATFORM_CALL_SIGN = "Platform Call Sign";
+    /** Platform Designation. */
     public static final String PLATFORM_DESIGNATION = "Platform Designation";
+    /** Platform Tail Number. */
     public static final String PLATFORM_TAIL_NUMBER = "Platform Tail Number";
+    /** Stream Designator. */
     public static final String STREAM_DESIGNATOR = "Stream Designator";
+    /** Target ID. */
     public static final String TARGET_ID = "Target ID";
 
     private final String displayName;

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTag.java
@@ -6,6 +6,11 @@ import org.jmisb.api.klv.IKlvKey;
 
 /** ST 0601 tag. */
 public enum UasDatalinkTag implements IKlvKey {
+    /**
+     * Unknown / Undefined tag.
+     *
+     * <p>This is not a valid value, and should not be intentionally created or used.
+     */
     Undefined(0),
     /** Tag 1; Checksum used to detect errors within a UAS Datalink LS packet. */
     Checksum(1),

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTargetErrorEstimate.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasDatalinkTargetErrorEstimate.java
@@ -16,9 +16,9 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * </blockquote>
  */
 public abstract class UasDatalinkTargetErrorEstimate implements IUasDatalinkValue {
-    protected static final double FLOAT_RANGE = 4095;
-    protected static final double INT_RANGE = 65535.0; // (2^16) - 1
-    protected double meters;
+    private static final double FLOAT_RANGE = 4095;
+    private static final double INT_RANGE = 65535.0; // (2^16) - 1
+    private double meters;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasEnumeration.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasEnumeration.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 /** Abstract base class for single-byte enumeration values in ST 0601. */
 public abstract class UasEnumeration implements IUasDatalinkValue {
+    /** Implementing / backing value for the enumeration. */
     protected byte value;
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0601/UasRange.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/UasRange.java
@@ -17,11 +17,18 @@ import org.jmisb.core.klv.PrimitiveConverter;
  */
 public abstract class UasRange implements IUasDatalinkValue {
 
-    protected static final double MIN_VAL = 0.0;
-    protected static final double MAX_VAL = 5000000.0;
-    protected static final double MAX_INT = 4294967295.0; // 2^32-1
+    private static final double MIN_VAL = 0.0;
+    private static final double MAX_VAL = 5000000.0;
+    private static final double MAX_INT = 4294967295.0; // 2^32-1
+    /**
+     * Approximate encoding error in this value.
+     *
+     * <p>This is based on the resolution / 2 and should be considered a precision. It is unlikely
+     * to represent actual accuracy.
+     */
     public static final double DELTA = 0.6e-3; // +/- 0.6 mm
-    protected double meters;
+
+    private double meters;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0601/WavelengthsList.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/WavelengthsList.java
@@ -114,8 +114,6 @@ public class WavelengthsList implements IUasDatalinkValue {
      *
      * <p>This gets the live list, so it can also be used to add an entry, or to clear the list.
      *
-     * <p>
-     *
      * @return the known wavelengths, as a list.
      */
     public List<Wavelengths> getWavelengthsList() {

--- a/api/src/main/java/org/jmisb/api/klv/st0601/dto/PayloadKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0601/dto/PayloadKey.java
@@ -8,12 +8,20 @@ import org.jmisb.api.klv.IKlvKey;
  * <p>Each of these corresponds to part of the payload information.
  */
 public enum PayloadKey implements IKlvKey {
+    /**
+     * Unknown payload element.
+     *
+     * <p>This should not be intentionally created.
+     */
     unknown(0),
+    /** Identifier part of Payload. */
     Identifier(1),
+    /** Payload type part of Payload. */
     PayloadType(2),
+    /** Payload name part of Payload. */
     PayloadName(3);
 
-    PayloadKey(int key) {
+    private PayloadKey(int key) {
         this.tag = key;
     }
 

--- a/api/src/main/java/org/jmisb/api/klv/st0602/AnnotationMetadataConstants.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0602/AnnotationMetadataConstants.java
@@ -7,6 +7,7 @@ public class AnnotationMetadataConstants {
 
     private AnnotationMetadataConstants() {}
 
+    /** Locally Unique Identifier Universal Label. */
     public static final UniversalLabel locallyUniqueIdentifierUl =
             new UniversalLabel(
                     new byte[] {
@@ -14,6 +15,7 @@ public class AnnotationMetadataConstants {
                         0x00, 0x00, 0x00, 0x00
                     });
 
+    /** Event indication Universal Label. */
     public static final UniversalLabel eventIndicationUl =
             new UniversalLabel(
                     new byte[] {
@@ -21,6 +23,7 @@ public class AnnotationMetadataConstants {
                         0x00, 0x00, 0x00, 0x00
                     });
 
+    /** Media Description Universal Label. */
     public static final UniversalLabel mediaDescriptionUl =
             new UniversalLabel(
                     new byte[] {
@@ -28,6 +31,7 @@ public class AnnotationMetadataConstants {
                         0x03, 0x00, 0x00, 0x00
                     });
 
+    /** MIME Media Type Universal Label. */
     public static final UniversalLabel mimeMediaTypeUl =
             new UniversalLabel(
                     new byte[] {
@@ -35,6 +39,7 @@ public class AnnotationMetadataConstants {
                         0x00, 0x00, 0x00, 0x00
                     });
 
+    /** MIME data Universal Label. */
     public static final UniversalLabel mimeDataUl =
             new UniversalLabel(
                     new byte[] {
@@ -42,6 +47,7 @@ public class AnnotationMetadataConstants {
                         0x01, 0x00, 0x00, 0x00
                     });
 
+    /** Modification History Universal Label. */
     public static final UniversalLabel modificationHistoryUl =
             new UniversalLabel(
                     new byte[] {
@@ -49,13 +55,14 @@ public class AnnotationMetadataConstants {
                         0x02, 0x00, 0x00, 0x00
                     });
 
+    /** X view port position Universal Label. */
     public static final UniversalLabel xViewPortPositionInPixelsUl =
             new UniversalLabel(
                     new byte[] {
                         0x06, 0x0e, 0x2b, 0x34, 0x01, 0x01, 0x01, 0x01, 0x07, 0x01, 0x02, 0x03,
                         0x01, 0x00, 0x00, 0x00
                     });
-
+    /** Y view port position Universal Label. */
     public static final UniversalLabel yViewPortPositionInPixelsUl =
             new UniversalLabel(
                     new byte[] {
@@ -63,6 +70,7 @@ public class AnnotationMetadataConstants {
                         0x02, 0x00, 0x00, 0x00
                     });
 
+    /** Annotation Source Universal Label. */
     public static final UniversalLabel annotationSourceUl =
             new UniversalLabel(
                     new byte[] {
@@ -70,6 +78,7 @@ public class AnnotationMetadataConstants {
                         0x03, 0x00, 0x00, 0x00
                     });
 
+    /** Z-Order Universal Label. */
     public static final UniversalLabel zOrderUl =
             new UniversalLabel(
                     new byte[] {

--- a/api/src/main/java/org/jmisb/api/klv/st0602/AnnotationMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0602/AnnotationMetadataKey.java
@@ -13,6 +13,11 @@ import org.jmisb.api.klv.UniversalLabel;
  * enumeration, and a value represented by a instance implementing {@link IAnnotationMetadataValue}.
  */
 public enum AnnotationMetadataKey implements IKlvKey {
+    /**
+     * Unknown or undefined metadata key.
+     *
+     * <p>This key indicates an error, and should not be intentionally created or used.
+     */
     Undefined(
             new UniversalLabel(
                     new byte[] {

--- a/api/src/main/java/org/jmisb/api/klv/st0603/NanoPrecisionTimeStamp.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0603/NanoPrecisionTimeStamp.java
@@ -12,10 +12,12 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * are truncated to the nearest nanosecond.
  */
 public class NanoPrecisionTimeStamp implements IKlvValue {
+    /** Number of bytes for encoding. */
     public static final int BYTES = Long.BYTES;
 
     // this is conceptually unsigned, so be careful when manipulating it.
-    protected final long nanoseconds;
+    private final long nanoseconds;
+
     /**
      * Create from value.
      *

--- a/api/src/main/java/org/jmisb/api/klv/st0603/ST0603TimeStamp.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0603/ST0603TimeStamp.java
@@ -10,7 +10,7 @@ import org.jmisb.core.klv.PrimitiveConverter;
 /** ST0603 Timestamp. */
 public class ST0603TimeStamp {
     // this is conceptually unsigned, so be careful when manipulating it.
-    protected final long microseconds;
+    private final long microseconds;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0805/CotElement.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0805/CotElement.java
@@ -13,18 +13,37 @@ public abstract class CotElement {
      */
     abstract void writeAsXML(StringBuilder sb);
 
+    /**
+     * Write start element.
+     *
+     * @param sb the string builder to serialize to.
+     * @param elementName the element name to be started.
+     */
     protected void writeStartElement(StringBuilder sb, String elementName) {
         sb.append("<");
         sb.append(elementName);
         sb.append(">");
     }
 
+    /**
+     * Write end element.
+     *
+     * @param sb the string builder to serialize to.
+     * @param elementName the name of the element to be closed.
+     */
     protected void writeEndElement(StringBuilder sb, String elementName) {
         sb.append("</");
         sb.append(elementName);
         sb.append(">");
     }
 
+    /**
+     * Write an attribute key and value pair.
+     *
+     * @param sb the string builder to serialize to.
+     * @param key the attribute key
+     * @param value the attribute value as a String.
+     */
     protected void writeAttribute(StringBuilder sb, String key, String value) {
         sb.append(" ");
         sb.append(key);
@@ -33,6 +52,13 @@ public abstract class CotElement {
         sb.append("'");
     }
 
+    /**
+     * Write an attribute key and value pair.
+     *
+     * @param sb the string builder to serialize to.
+     * @param key the attribute key
+     * @param value the attribute value as a double.
+     */
     protected void writeAttribute(StringBuilder sb, String key, double value) {
         sb.append(" ");
         sb.append(key);

--- a/api/src/main/java/org/jmisb/api/klv/st0805/CotMessage.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0805/CotMessage.java
@@ -165,10 +165,20 @@ public abstract class CotMessage extends CotElement {
         return flowTags;
     }
 
+    /**
+     * Close the event start tag.
+     *
+     * @param sb the string builder to serialize to.
+     */
     protected void closeEventStartInXML(StringBuilder sb) {
         sb.append(">");
     }
 
+    /**
+     * Append event level attributes.
+     *
+     * @param sb the string builder to serialize to.
+     */
     protected void addEventLevelAttributesToXML(StringBuilder sb) {
         sb.append("<event");
         writeAttribute(sb, "version", COT_VERSION);
@@ -193,14 +203,29 @@ public abstract class CotMessage extends CotElement {
         writeAttribute(sb, "how", getHow());
     }
 
+    /**
+     * Add Event end element.
+     *
+     * @param sb the string builder to serialize to.
+     */
     protected void addEventEndToXML(StringBuilder sb) {
         writeEndElement(sb, "event");
     }
 
+    /**
+     * Add XML header.
+     *
+     * @param sb the string builder to serialize to.
+     */
     protected void addXmlHeader(StringBuilder sb) {
         sb.append("<?xml version='1.0' standalone='yes'?>");
     }
 
+    /**
+     * Write flow tags.
+     *
+     * @param sb the string builder to serialize to.
+     */
     protected void writeFlowTags(StringBuilder sb) {
         getFlowTags().writeAsXML(sb);
     }

--- a/api/src/main/java/org/jmisb/api/klv/st0805/CotSensor.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0805/CotSensor.java
@@ -6,11 +6,11 @@ package org.jmisb.api.klv.st0805;
  * <p>This represents the data in a Sensor detail element.
  */
 public class CotSensor extends CotElement {
-    public Double sensorAzimuth;
-    public Double sensorFov;
-    public Double sensorVfov;
-    public String sensorModel;
-    public Double sensorRange;
+    private Double sensorAzimuth;
+    private Double sensorFov;
+    private Double sensorVfov;
+    private String sensorModel;
+    private Double sensorRange;
 
     /**
      * Get sensor azimuth.

--- a/api/src/main/java/org/jmisb/api/klv/st0805/Link.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0805/Link.java
@@ -6,9 +6,9 @@ package org.jmisb.api.klv.st0805;
  * <p>This is one of the things that can be included in the {@code detail} part of an Event.
  */
 public class Link extends CotElement {
-    public String linkType;
-    public String linkUid;
-    public String linkRelation;
+    private String linkType;
+    private String linkUid;
+    private String linkRelation;
 
     /**
      * Get the link type (CoT type of the producing {@link PlatformPosition}).

--- a/api/src/main/java/org/jmisb/api/klv/st0805/PlatformPosition.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0805/PlatformPosition.java
@@ -5,7 +5,7 @@ import java.time.Clock;
 /** Represents a Platform Position CoT message. */
 public class PlatformPosition extends CotMessage {
 
-    public CotSensor sensor;
+    private CotSensor sensor;
 
     PlatformPosition(Clock clock) {
         super(clock);

--- a/api/src/main/java/org/jmisb/api/klv/st0805/SensorPointOfInterest.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0805/SensorPointOfInterest.java
@@ -12,6 +12,11 @@ public class SensorPointOfInterest extends CotMessage {
 
     private Link link;
 
+    /**
+     * Constructor.
+     *
+     * @param clock clock value to use for this message
+     */
     SensorPointOfInterest(Clock clock) {
         super(clock);
         setType("b-m-p-s-p-i");
@@ -61,7 +66,7 @@ public class SensorPointOfInterest extends CotMessage {
         addEventEndToXML(sb);
     }
 
-    protected void writeLink(StringBuilder sb) {
+    private void writeLink(StringBuilder sb) {
         if (getLink() != null) {
             getLink().writeAsXML(sb);
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0806/AbstractMGRSLatitudeBandAndGridSquare.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/AbstractMGRSLatitudeBandAndGridSquare.java
@@ -48,7 +48,7 @@ public abstract class AbstractMGRSLatitudeBandAndGridSquare extends RvtString
      * @return single character string.
      */
     public String getLatitudeBand() {
-        return this.stringValue.substring(0, 1);
+        return getDisplayableValue().substring(0, 1);
     }
 
     /**
@@ -57,6 +57,6 @@ public abstract class AbstractMGRSLatitudeBandAndGridSquare extends RvtString
      * @return two characters specifying the grid square in MGRS.
      */
     public String getGridSquare() {
-        return this.stringValue.substring(1);
+        return getDisplayableValue().substring(1);
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0806/AircraftMGRSEasting.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/AircraftMGRSEasting.java
@@ -10,7 +10,7 @@ package org.jmisb.api.klv.st0806;
  */
 public class AircraftMGRSEasting extends AbstractMGRSEastingOrNorthing
         implements IRvtMetadataValue {
-    public static final String AIRCRAFT_MGRS_EASTING = "Aircraft MGRS Easting";
+    private static final String AIRCRAFT_MGRS_EASTING = "Aircraft MGRS Easting";
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/AircraftMGRSLatitudeBandAndGridSquare.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/AircraftMGRSLatitudeBandAndGridSquare.java
@@ -9,7 +9,7 @@ package org.jmisb.api.klv.st0806;
  * B correspond to Antarctic UPS regions and Y &amp; Z correspond to Arctic UPS regions.
  */
 public class AircraftMGRSLatitudeBandAndGridSquare extends AbstractMGRSLatitudeBandAndGridSquare {
-    public static final String AIRCRAFT_MGRS_LATITUDE_BAND_AND_GRID_SQUARE =
+    private static final String AIRCRAFT_MGRS_LATITUDE_BAND_AND_GRID_SQUARE =
             "Aircraft MGRS Latitude Band and Grid Square";
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0806/AircraftMGRSNorthing.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/AircraftMGRSNorthing.java
@@ -10,7 +10,7 @@ package org.jmisb.api.klv.st0806;
  */
 public class AircraftMGRSNorthing extends AbstractMGRSEastingOrNorthing
         implements IRvtMetadataValue {
-    public static final String AIRCRAFT_MGRS_NORTHING = "Aircraft MGRS Northing";
+    private static final String AIRCRAFT_MGRS_NORTHING = "Aircraft MGRS Northing";
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/AircraftMGRSZone.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/AircraftMGRSZone.java
@@ -6,7 +6,7 @@ package org.jmisb.api.klv.st0806;
  * <p>First two characters of Aircraft MGRS coordinates, UTM zone 01 through 60.
  */
 public class AircraftMGRSZone extends AbstractMGRSZone implements IRvtMetadataValue {
-    public static final String AIRCRAFT_MGRS_ZONE = "Aircraft MGRS Zone";
+    private static final String AIRCRAFT_MGRS_ZONE = "Aircraft MGRS Zone";
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/DigitalVideoFileFormat.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/DigitalVideoFileFormat.java
@@ -9,7 +9,7 @@ package org.jmisb.api.klv.st0806;
  * other values or variants are also acceptable.
  */
 public class DigitalVideoFileFormat extends RvtString implements IRvtMetadataValue {
-    public static final String DIGITAL_VIDEO_FILE_FORMAT = "Digital Video File Format";
+    private static final String DIGITAL_VIDEO_FILE_FORMAT = "Digital Video File Format";
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/FragCircleRadius.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/FragCircleRadius.java
@@ -20,7 +20,7 @@ public class FragCircleRadius implements IRvtMetadataValue {
     /**
      * Create from value.
      *
-     * @param radius radius in meters/second. Legal values are in [0, 65535].
+     * @param radius radius in meters. Legal values are in [0, 65535].
      */
     public FragCircleRadius(int radius) {
         if (radius > MAX_VALUE || radius < MIN_VALUE) {

--- a/api/src/main/java/org/jmisb/api/klv/st0806/FrameCenterMGRSEasting.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/FrameCenterMGRSEasting.java
@@ -10,7 +10,7 @@ package org.jmisb.api.klv.st0806;
  */
 public class FrameCenterMGRSEasting extends AbstractMGRSEastingOrNorthing
         implements IRvtMetadataValue {
-    public static final String FRAME_CENTRE_MGRS_EASTING = "Frame Center MGRS Easting";
+    private static final String FRAME_CENTRE_MGRS_EASTING = "Frame Center MGRS Easting";
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/FrameCenterMGRSLatitudeBandAndGridSquare.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/FrameCenterMGRSLatitudeBandAndGridSquare.java
@@ -10,7 +10,7 @@ package org.jmisb.api.klv.st0806;
  */
 public class FrameCenterMGRSLatitudeBandAndGridSquare
         extends AbstractMGRSLatitudeBandAndGridSquare {
-    public static final String FRAME_CENTER_MGRS_LATITUDE_BAND_AND_GRID_SQUARE =
+    private static final String FRAME_CENTER_MGRS_LATITUDE_BAND_AND_GRID_SQUARE =
             "Frame Center MGRS Latitude Band and Grid Square";
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0806/FrameCenterMGRSNorthing.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/FrameCenterMGRSNorthing.java
@@ -10,7 +10,7 @@ package org.jmisb.api.klv.st0806;
  */
 public class FrameCenterMGRSNorthing extends AbstractMGRSEastingOrNorthing
         implements IRvtMetadataValue {
-    public static final String FRAME_CENTRE_MGRS_NORTHING = "Frame Center MGRS Northing";
+    private static final String FRAME_CENTRE_MGRS_NORTHING = "Frame Center MGRS Northing";
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/FrameCenterMGRSZone.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/FrameCenterMGRSZone.java
@@ -6,7 +6,7 @@ package org.jmisb.api.klv.st0806;
  * <p>First two characters of Frame Centre MGRS coordinates, UTM zone 01 through 60.
  */
 public class FrameCenterMGRSZone extends AbstractMGRSZone implements IRvtMetadataValue {
-    public static final String FRAME_CENTRE_MGRS_ZONE = "Frame Center MGRS Zone";
+    private static final String FRAME_CENTRE_MGRS_ZONE = "Frame Center MGRS Zone";
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/IRvtMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/IRvtMetadataValue.java
@@ -2,6 +2,11 @@ package org.jmisb.api.klv.st0806;
 
 import org.jmisb.api.klv.IKlvValue;
 
+/**
+ * ST 0806 metadata value.
+ *
+ * <p>All top level local set values implement this interface.
+ */
 public interface IRvtMetadataValue extends IKlvValue {
     /**
      * Get the encoded bytes.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/RvtLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/RvtLocalSet.java
@@ -29,6 +29,7 @@ import org.jmisb.core.klv.CRC32MPEG2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** Remote Video Terminal Local Set. */
 public class RvtLocalSet implements IMisbMessage {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RvtLocalSet.class);

--- a/api/src/main/java/org/jmisb/api/klv/st0806/RvtMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/RvtMetadataKey.java
@@ -8,26 +8,47 @@ import org.jmisb.api.klv.IKlvKey;
 public enum RvtMetadataKey implements IKlvKey {
     /** Unknown key. This should not be created. */
     Undefined(0),
+    /** Cyclic Redundancy Check value. */
     CRC32(1),
+    /** User defined timestamp - microseconds. */
     UserDefinedTimeStampMicroseconds(2),
+    /** Platform True Airspeed. */
     PlatformTrueAirspeed(3),
+    /** Platform Indicated Airspeed. */
     PlatformIndicatedAirspeed(4),
+    /** Telemetry Accuracy Indicator. */
     TelemetryAccuracyIndicator(5),
+    /** Frag Circle Radius. */
     FragCircleRadius(6),
+    /** Frame code. */
     FrameCode(7),
+    /** UAS Local Set Version Number. */
     UASLSVersionNumber(8),
+    /** Video Data Rate. */
     VideoDataRate(9),
+    /** Digital Video File Format. */
     DigitalVideoFileFormat(10),
+    /** User defined local set. */
     UserDefinedLS(11),
+    /** Point of interest (POI) local set. */
     PointOfInterestLS(12),
+    /** Area of interest (AOI) local set. */
     AreaOfInterestLS(13),
+    /** MGRS Zone. */
     MGRSZone(14),
+    /** MGRS Latitude Band and Grid Square. */
     MGRSLatitudeBandAndGridSquare(15),
+    /** MGRS Easting. */
     MGRSEasting(16),
+    /** MGRS Northing. */
     MGRSNorthing(17),
+    /** MGRS Zone Second Value. */
     MGRSZoneSecondValue(18),
+    /** MGRS Latitude Band and Grid Square Second Value. */
     MGRSLatitudeBandAndGridSquareSecondValue(19),
+    /** MGRS Easting Second Value. */
     MGRSEastingSecondValue(20),
+    /** MGRS Northing Second Value. */
     MGRSNorthingSecondValue(21);
 
     private final int tag;

--- a/api/src/main/java/org/jmisb/api/klv/st0806/RvtString.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/RvtString.java
@@ -4,8 +4,8 @@ import java.nio.charset.StandardCharsets;
 
 /** Base class for text string implementations. */
 public abstract class RvtString implements IRvtMetadataValue {
-    protected final String displayName;
-    protected final String stringValue;
+    private final String displayName;
+    private final String stringValue;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/IRvtPoiAoiMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/IRvtPoiAoiMetadataValue.java
@@ -2,6 +2,11 @@ package org.jmisb.api.klv.st0806.poiaoi;
 
 import org.jmisb.api.klv.IKlvValue;
 
+/**
+ * ST 0806 POI / AOI metadata value.
+ *
+ * <p>All POI and AOI local set values implement this interface.
+ */
 public interface IRvtPoiAoiMetadataValue extends IKlvValue {
     /**
      * Get the encoded bytes.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/PoiAoiType.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/PoiAoiType.java
@@ -37,7 +37,7 @@ public class PoiAoiType implements IRvtPoiAoiMetadataValue {
         UNKNOWN = new PoiAoiType((byte) 0x04);
     }
 
-    protected byte value;
+    private byte value;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtAoiMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtAoiMetadataKey.java
@@ -8,15 +8,25 @@ import org.jmisb.api.klv.IKlvKey;
 public enum RvtAoiMetadataKey implements IKlvKey {
     /** Unknown key. This should not be created. */
     Undefined(0),
+    /** POI / AOI Number. */
     PoiAoiNumber(1),
+    /** Corner Latitude Point 1. */
     CornerLatitudePoint1(2),
+    /** Corner Longitude Point 1. */
     CornerLongitudePoint1(3),
+    /** Corner Latitude Point 3. */
     CornerLatitudePoint3(4),
+    /** Corner Longitude Point 3. */
     CornerLongitudePoint3(5),
+    /** POI / AOI Type. */
     PoiAoiType(6),
+    /** POI / AOI Name. */
     PoiAoiText(7),
+    /** POI / AOI Source Identifier. */
     PoiAoiSourceId(8),
+    /** POI / AOI Label. */
     PoiAoiLabel(9),
+    /** Operation Identifier. */
     OperationId(10);
 
     private final int tag;
@@ -36,7 +46,7 @@ public enum RvtAoiMetadataKey implements IKlvKey {
      *
      * @param tag the tag value to initialise the enumeration value.
      */
-    RvtAoiMetadataKey(int tag) {
+    private RvtAoiMetadataKey(int tag) {
         this.tag = tag;
     }
 

--- a/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtPoiMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/poiaoi/RvtPoiMetadataKey.java
@@ -8,15 +8,25 @@ import org.jmisb.api.klv.IKlvKey;
 public enum RvtPoiMetadataKey implements IKlvKey {
     /** Unknown key. This should not be created. */
     Undefined(0),
+    /** POI / AOI Number. */
     PoiAoiNumber(1),
+    /** POI Latitude. */
     PoiLatitude(2),
+    /** POI Longitude. */
     PoiLongitude(3),
+    /** POI Altitude. */
     PoiAltitude(4),
+    /** POI / AOI Type. */
     PoiAoiType(5),
+    /** POI / AOI Text. */
     PoiAoiText(6),
+    /** POI Source Icon. */
     PoiSourceIcon(7),
+    /** POI / AOI Source Identifier. */
     PoiAoiSourceId(8),
+    /** POI / AOI Label. */
     PoiAoiLabel(9),
+    /** Operation Identifier. */
     OperationId(10);
 
     private final int tag;

--- a/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/IRvtUserDefinedMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/IRvtUserDefinedMetadataValue.java
@@ -2,6 +2,11 @@ package org.jmisb.api.klv.st0806.userdefined;
 
 import org.jmisb.api.klv.IKlvValue;
 
+/**
+ * ST 0806 RVT User Defined metadata value.
+ *
+ * <p>All RVT User Defined local set values implement this interface.
+ */
 public interface IRvtUserDefinedMetadataValue extends IKlvValue {
     /**
      * Get the encoded bytes.

--- a/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/RvtNumericId.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/RvtNumericId.java
@@ -8,7 +8,9 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * <p>Required when using User Defined Local Set.
  */
 public class RvtNumericId implements IRvtUserDefinedMetadataValue {
+    /** Implementing value. */
     protected short number;
+
     private static final int REQUIRED_BYTE_LENGTH = 1;
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/RvtUserDefinedMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0806/userdefined/RvtUserDefinedMetadataKey.java
@@ -6,9 +6,15 @@ import org.jmisb.api.klv.IKlvKey;
 
 /** ST 0806 User Defined local set keys - description and numbers. */
 public enum RvtUserDefinedMetadataKey implements IKlvKey {
-    /** Unknown key. This should not be created. */
+    /**
+     * Unknown key.
+     *
+     * <p>This should not be created.
+     */
     Undefined(0),
+    /** Numeric identifier. */
     NumericId(1),
+    /** User data. */
     UserData(2);
 
     private final int tag;

--- a/api/src/main/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0808/AncillaryTextLocalSet.java
@@ -19,6 +19,11 @@ import org.jmisb.api.klv.UniversalLabel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Ancillary Text Local Set.
+ *
+ * <p>This is the core ST 0808 Local Set.
+ */
 public class AncillaryTextLocalSet implements IMisbMessage {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AncillaryTextLocalSet.class);

--- a/api/src/main/java/org/jmisb/api/klv/st0808/AncillaryTextMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0808/AncillaryTextMetadataKey.java
@@ -8,10 +8,15 @@ import org.jmisb.api.klv.IKlvKey;
 public enum AncillaryTextMetadataKey implements IKlvKey {
     /** Unknown key. This should not be created. */
     Undefined(0),
+    /** Originator. */
     Originator(1),
+    /** Precision Time Stamp. */
     PrecisionTimeStamp(2),
+    /** Message Body. */
     MessageBody(3),
+    /** Source. */
     Source(4),
+    /** Message Creation Time. */
     MessageCreationTime(5);
 
     private final int tag;

--- a/api/src/main/java/org/jmisb/api/klv/st0808/IAncillaryTextMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0808/IAncillaryTextMetadataValue.java
@@ -2,6 +2,11 @@ package org.jmisb.api.klv.st0808;
 
 import org.jmisb.api.klv.IKlvValue;
 
+/**
+ * ST 0808 metadata value.
+ *
+ * <p>All ST 0808 Ancillary Text Local Set values implement this interface.
+ */
 public interface IAncillaryTextMetadataValue extends IKlvValue {
     /**
      * Get the encoded bytes.

--- a/api/src/main/java/org/jmisb/api/klv/st0808/MessageBody.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0808/MessageBody.java
@@ -10,7 +10,7 @@ package org.jmisb.api.klv.st0808;
  */
 public class MessageBody extends NaturalText implements IAncillaryTextMetadataValue {
 
-    public static final String MESSAGE_BODY = "Message Body";
+    private static final String MESSAGE_BODY = "Message Body";
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0808/NaturalText.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0808/NaturalText.java
@@ -4,8 +4,8 @@ import java.nio.charset.StandardCharsets;
 
 /** Base class for text string implementations. */
 public abstract class NaturalText implements IAncillaryTextMetadataValue {
-    protected final String displayName;
-    protected final String stringValue;
+    private final String displayName;
+    private final String stringValue;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0808/Originator.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0808/Originator.java
@@ -12,7 +12,7 @@ package org.jmisb.api.klv.st0808;
  */
 public class Originator extends NaturalText implements IAncillaryTextMetadataValue {
 
-    public static final String ORIGINATOR = "Originator";
+    private static final String ORIGINATOR = "Originator";
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0808/Source.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0808/Source.java
@@ -12,7 +12,7 @@ package org.jmisb.api.klv.st0808;
  */
 public class Source extends NaturalText implements IAncillaryTextMetadataValue {
 
-    public static final String SOURCE = "Source";
+    private static final String SOURCE = "Source";
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0809/AbstractIllumination.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0809/AbstractIllumination.java
@@ -1,12 +1,34 @@
 package org.jmisb.api.klv.st0809;
 
+import org.jmisb.api.common.KlvParseException;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 abstract class AbstractIllumination implements IMeteorologicalMetadataValue {
 
-    protected float value;
+    private float value;
 
-    public AbstractIllumination() {}
+    /**
+     * Create from value.
+     *
+     * @param illumination illumination value
+     */
+    protected AbstractIllumination(float illumination) {
+        this.value = illumination;
+    }
+
+    /**
+     * Create from encoded bytes.
+     *
+     * @param bytes Encoded byte array of length 4
+     * @throws KlvParseException if the byte array is not of the correct length
+     */
+    protected AbstractIllumination(byte[] bytes) throws KlvParseException {
+        if (bytes.length != 4) {
+            throw new KlvParseException(this.getDisplayName() + " encoding is a 4-byte float");
+        }
+
+        this.value = PrimitiveConverter.toFloat32(bytes);
+    }
 
     @Override
     public abstract String getDisplayName();

--- a/api/src/main/java/org/jmisb/api/klv/st0809/AbstractPercentage.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0809/AbstractPercentage.java
@@ -5,9 +5,9 @@ import org.jmisb.core.klv.PrimitiveConverter;
 
 abstract class AbstractPercentage implements IMeteorologicalMetadataValue {
 
-    protected static final float MIN_VALUE = 0.0f;
-    protected static final float MAX_VALUE = 100.0f;
-    protected final float value;
+    private static final float MIN_VALUE = 0.0f;
+    private static final float MAX_VALUE = 100.0f;
+    private final float value;
 
     AbstractPercentage(final float percentage) {
         if (percentage < MIN_VALUE || percentage > MAX_VALUE) {

--- a/api/src/main/java/org/jmisb/api/klv/st0809/SolarIlluminationDiffuse.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0809/SolarIlluminationDiffuse.java
@@ -1,7 +1,6 @@
 package org.jmisb.api.klv.st0809;
 
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
  * Solar Illumination Diffuse (ST 0809 Local Set Item 26).
@@ -16,7 +15,7 @@ public class SolarIlluminationDiffuse extends AbstractIllumination {
      * @param illumination illumination in lux
      */
     public SolarIlluminationDiffuse(float illumination) {
-        this.value = illumination;
+        super(illumination);
     }
 
     /**
@@ -26,10 +25,7 @@ public class SolarIlluminationDiffuse extends AbstractIllumination {
      * @throws KlvParseException if the byte array is not of the correct length
      */
     public SolarIlluminationDiffuse(byte[] bytes) throws KlvParseException {
-        if (bytes.length != 4) {
-            throw new KlvParseException(this.getDisplayName() + " encoding is a 4-byte float");
-        }
-        this.value = PrimitiveConverter.toFloat32(bytes);
+        super(bytes);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0809/SolarIlluminationDirect.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0809/SolarIlluminationDirect.java
@@ -1,7 +1,6 @@
 package org.jmisb.api.klv.st0809;
 
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
  * Solar Illumination Direct (ST 0809 Local Set Item 27).
@@ -16,7 +15,7 @@ public class SolarIlluminationDirect extends AbstractIllumination {
      * @param illumination illumination in lux
      */
     public SolarIlluminationDirect(float illumination) {
-        this.value = illumination;
+        super(illumination);
     }
 
     /**
@@ -26,10 +25,7 @@ public class SolarIlluminationDirect extends AbstractIllumination {
      * @throws KlvParseException if the byte array is not of the correct length
      */
     public SolarIlluminationDirect(byte[] bytes) throws KlvParseException {
-        if (bytes.length != 4) {
-            throw new KlvParseException(this.getDisplayName() + " encoding is a 4-byte float");
-        }
-        this.value = PrimitiveConverter.toFloat32(bytes);
+        super(bytes);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0809/TotalIlluminationDirect.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0809/TotalIlluminationDirect.java
@@ -1,7 +1,6 @@
 package org.jmisb.api.klv.st0809;
 
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
  * Total Illumination Direct (ST 0809 Local Set Item 27).
@@ -16,7 +15,7 @@ public class TotalIlluminationDirect extends AbstractIllumination {
      * @param illumination illumination in lux
      */
     public TotalIlluminationDirect(float illumination) {
-        this.value = illumination;
+        super(illumination);
     }
 
     /**
@@ -26,10 +25,7 @@ public class TotalIlluminationDirect extends AbstractIllumination {
      * @throws KlvParseException if the byte array is not of the correct length
      */
     public TotalIlluminationDirect(byte[] bytes) throws KlvParseException {
-        if (bytes.length != 4) {
-            throw new KlvParseException(this.getDisplayName() + " encoding is a 4-byte float");
-        }
-        this.value = PrimitiveConverter.toFloat32(bytes);
+        super(bytes);
     }
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st0903/FrameHeight.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/FrameHeight.java
@@ -47,6 +47,6 @@ public class FrameHeight extends VmtiV3Value
 
     @Override
     public String getDisplayableValue() {
-        return String.format("%dpx", value);
+        return String.format("%dpx", getValue());
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/FrameNumber.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/FrameNumber.java
@@ -39,9 +39,4 @@ public class FrameNumber extends VmtiV3Value
     public final String getDisplayName() {
         return "Frame Number";
     }
-
-    @Override
-    public String getDisplayableValue() {
-        return "" + value;
-    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/FrameWidth.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/FrameWidth.java
@@ -57,6 +57,6 @@ public class FrameWidth extends VmtiV3Value
 
     @Override
     public String getDisplayableValue() {
-        return String.format("%dpx", value);
+        return String.format("%dpx", getValue());
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/IVmtiMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/IVmtiMetadataValue.java
@@ -2,6 +2,11 @@ package org.jmisb.api.klv.st0903;
 
 import org.jmisb.api.klv.IKlvValue;
 
+/**
+ * ST 0903 VMTI metadata value.
+ *
+ * <p>All top level local set values implement this interface.
+ */
 public interface IVmtiMetadataValue extends IKlvValue {
     /**
      * Get the encoded bytes.

--- a/api/src/main/java/org/jmisb/api/klv/st0903/VmtiFieldOfView.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/VmtiFieldOfView.java
@@ -9,7 +9,7 @@ import org.jmisb.core.klv.PrimitiveConverter;
 public abstract class VmtiFieldOfView implements IVmtiMetadataValue {
     private static final double MIN_VAL = 0;
     private static final double MAX_VAL = 180;
-    protected static final double LEGACY_INT_RANGE = 65535.0; // 2^16-1
+    private static final double LEGACY_INT_RANGE = 65535.0; // 2^16-1
     private static final int NUM_BYTES = 2;
     private double value;
 

--- a/api/src/main/java/org/jmisb/api/klv/st0903/VmtiLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/VmtiLocalSet.java
@@ -25,6 +25,13 @@ import org.jmisb.core.klv.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * VMTI Local Set.
+ *
+ * <p>This is the top level ST 0903 Local Set.
+ *
+ * <p>Note that this local set can be nested in ST 0601.
+ */
 public class VmtiLocalSet implements IMisbMessage {
     private static final Logger LOGGER = LoggerFactory.getLogger(VmtiLocalSet.class);
 

--- a/api/src/main/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLS.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/algorithm/AlgorithmLS.java
@@ -134,7 +134,6 @@ public class AlgorithmLS implements IKlvValue, INestedKlvValue {
             byte[] lengthBytes = BerEncoder.encode(bytes.length);
             chunks.add(lengthBytes);
             len += lengthBytes.length;
-            ;
             chunks.add(bytes);
             len += bytes.length;
         }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/shared/Confidence.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/shared/Confidence.java
@@ -6,9 +6,9 @@ import org.jmisb.core.klv.PrimitiveConverter;
 /** Shared implementation of VTarget and VTracker confidence levels. */
 public abstract class Confidence implements IVmtiMetadataValue {
 
-    protected static final int MIN_VALUE = 0;
-    protected static final int MAX_VALUE = 100;
-    protected final short confidence;
+    private static final int MIN_VALUE = 0;
+    private static final int MAX_VALUE = 100;
+    private final short confidence;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0903/shared/IVTrackItemMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/shared/IVTrackItemMetadataValue.java
@@ -2,6 +2,7 @@ package org.jmisb.api.klv.st0903.shared;
 
 import org.jmisb.api.klv.IKlvValue;
 
+/** ST 0903 VTrackItem metadata value. */
 public interface IVTrackItemMetadataValue extends IKlvValue {
     /**
      * Get the encoded bytes.

--- a/api/src/main/java/org/jmisb/api/klv/st0903/shared/IVTrackMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/shared/IVTrackMetadataValue.java
@@ -2,6 +2,7 @@ package org.jmisb.api.klv.st0903.shared;
 
 import org.jmisb.api.klv.IKlvValue;
 
+/** ST 0903 VTrack metadata value. */
 public interface IVTrackMetadataValue extends IKlvValue {
     /**
      * Get the encoded bytes.

--- a/api/src/main/java/org/jmisb/api/klv/st0903/shared/LocVelAccPackKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/shared/LocVelAccPackKey.java
@@ -12,18 +12,32 @@ import org.jmisb.api.klv.st0903.vtracker.VelocityPack;
  * filled in.
  */
 public enum LocVelAccPackKey implements IKlvKey {
+    /**
+     * Unknown key.
+     *
+     * <p>This should not be created.
+     */
     unknown(0),
+    /** East component. */
     east(1),
+    /** North component. */
     north(2),
+    /** Up component. */
     up(3),
+    /** Standard deviation of East component. */
     sigEast(4),
+    /** Standard deviation of North component. */
     sigNorth(5),
+    /** Standard deviation of Up component. */
     sigUp(6),
+    /** Cross correlation of east and north components. */
     rhoEastNorth(7),
+    /** Cross correlation of east and up components. */
     rhoEastUp(8),
+    /** Cross correlation of north and up components. */
     rhoNorthUp(9);
 
-    LocVelAccPackKey(int key) {
+    private LocVelAccPackKey(int key) {
         this.tag = key;
     }
 

--- a/api/src/main/java/org/jmisb/api/klv/st0903/shared/VmtiEnumeration.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/shared/VmtiEnumeration.java
@@ -6,6 +6,7 @@ import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 
 /** Abstract base class for single-byte enumeration values in ST 0903. */
 public abstract class VmtiEnumeration implements IVmtiMetadataValue {
+    /** Implementing value. */
     protected byte value;
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st0903/shared/VmtiUtf8.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/shared/VmtiUtf8.java
@@ -5,8 +5,8 @@ import org.jmisb.api.klv.st0903.IVmtiMetadataValue;
 
 /** Base class for URI and plain text string implementations. */
 public abstract class VmtiUtf8 implements IVmtiMetadataValue {
-    protected final String displayName;
-    protected final String stringValue;
+    private final String displayName;
+    private final String stringValue;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0903/shared/VmtiV3Value.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/shared/VmtiV3Value.java
@@ -8,7 +8,7 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * values, three bytes maximum.
  */
 public abstract class VmtiV3Value implements IVmtiMetadataValue {
-    protected int value;
+    private int value;
     private static final int MIN_VALUE = 0;
     private static final int MAX_VALUE = 16777215;
 
@@ -39,7 +39,7 @@ public abstract class VmtiV3Value implements IVmtiMetadataValue {
         parse(bytes);
     }
 
-    protected final void parse(byte[] bytes) {
+    private void parse(byte[] bytes) {
         value = 0;
         for (byte aByte : bytes) {
             value = value << 8;
@@ -69,6 +69,6 @@ public abstract class VmtiV3Value implements IVmtiMetadataValue {
 
     @Override
     public String getDisplayableValue() {
-        return String.format("%d", value);
+        return String.format("%d", getValue());
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/AbstractPixelIndex.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/AbstractPixelIndex.java
@@ -9,9 +9,9 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * <p>Used by Tag 19 and Tag 20.
  */
 public abstract class AbstractPixelIndex implements IVmtiMetadataValue {
-    protected static final long MIN_VAL = 1;
-    protected static final long MAX_VAL = 4294967295L;
-    protected long value;
+    private static final long MIN_VAL = 1;
+    private static final long MAX_VAL = 4294967295L;
+    private long value;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/AbstractTargetLocationOffset.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/AbstractTargetLocationOffset.java
@@ -12,12 +12,13 @@ import org.jmisb.core.klv.PrimitiveConverter;
  */
 public abstract class AbstractTargetLocationOffset implements IVmtiMetadataValue {
 
-    protected static final double MIN_VAL = -19.2;
-    protected static final double MAX_VAL = 19.2;
-    protected static final int NUM_BYTES = 3;
+    private static final double MIN_VAL = -19.2;
+    private static final double MAX_VAL = 19.2;
+    private static final int NUM_BYTES = 3;
+
     private static final int LEGACY_ERROR_INDICATOR = -8388608;
     private static final int LEGACY_INT_RANGE = 8388607; // 2^23 - 1
-    protected double value;
+    private double value;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetHAE.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetHAE.java
@@ -19,11 +19,11 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * </blockquote>
  */
 public class TargetHAE implements IVmtiMetadataValue {
-    protected static final double MIN_VAL = -900;
-    protected static final double MAX_VAL = 19000;
-    protected static final int NUM_BYTES = 2;
+    private static final double MIN_VAL = -900;
+    private static final double MAX_VAL = 19000;
+    private static final int NUM_BYTES = 2;
     private static final double LEGACY_INT_RANGE = 65535.0; // 2^16-1
-    protected double value;
+    private double value;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetIntensity.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetIntensity.java
@@ -43,9 +43,4 @@ public class TargetIntensity extends VmtiV3Value
     public final String getDisplayName() {
         return "Target Intensity";
     }
-
-    @Override
-    public String getDisplayableValue() {
-        return String.format("%d", value);
-    }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetLocation.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/TargetLocation.java
@@ -51,8 +51,8 @@ public class TargetLocation
     private static final double MAX_LAT_VAL = 90.0;
     private static final double MIN_LON_VAL = -180.0;
     private static final double MAX_LON_VAL = 180.0;
-    protected static final double MIN_HAE_VAL = -900;
-    protected static final double MAX_HAE_VAL = 19000;
+    private static final double MIN_HAE_VAL = -900;
+    private static final double MAX_HAE_VAL = 19000;
     private static final int LEGACY_INT_RANGE = 65535;
     private static final long MAX_LAT_LON_INT_RANGE = 4294967295L;
     private static final int NUM_BYTES = 2;

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VTargetMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtarget/VTargetMetadataKey.java
@@ -4,6 +4,11 @@ import java.util.HashMap;
 import java.util.Map;
 import org.jmisb.api.klv.IKlvKey;
 
+/**
+ * VTarget metadata keys.
+ *
+ * <p>These keys are used to look up and identify metadata items.
+ */
 public enum VTargetMetadataKey implements IKlvKey {
     /** Unknown key. This should not be created. */
     Undefined(0),

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtrack/VTrackItemMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtrack/VTrackItemMetadataKey.java
@@ -12,35 +12,65 @@ import org.jmisb.api.klv.IKlvKey;
 public enum VTrackItemMetadataKey implements IKlvKey {
     /** Unknown key. This should not be created. */
     Undefined(0),
+    /** Target Time Stamp. */
     TargetTimeStamp(1),
+    /** Target Centroid Pixel Number. */
     TargetCentroidPixNum(2),
+    /** Target Centroid Pixel Row Number. */
     TargetCentroidPixRow(3),
+    /** Target Centroid Pixel Column Number. */
     TargetCentroidPixCol(4),
+    /** Boundary Top Left Pixel Number. */
     BoundaryTopLeftPixNum(5),
+    /** Boundary Bottom Right Pixel Number. */
     BoundaryBottomRightPixNum(6),
+    /** Target Priority. */
     TargetPriority(7),
+    /** Target Confidence Level. */
     TargetConfidenceLevel(8),
+    /** Target History. */
     TargetHistory(9),
+    /** Percentage Target Pixels. */
     PercentTargetPixels(10),
+    /** Target Color. */
     TargetColor(11),
+    /** Target Intensity. */
     TargetIntensity(12),
+    /** Target Location. */
     TargetLocation(13),
+    /** Target Boundary Series. */
     TargetBoundarySeries(14),
+    /** Velocity. */
     Velocity(15),
+    /** Acceleration. */
     Acceleration(16),
+    /** FPA Index. */
     FpaIndex(17),
+    /** Video Frame Number. */
     VideoFrameNumber(18),
+    /** Motion Imagery Identification System Identifier. */
     MiisId(19),
+    /** Frame Width. */
     FrameWidth(20),
+    /** Frame Height. */
     FrameHeight(21),
+    /** Sensor Horizontal Field of View. */
     SensorHorizontalFov(22),
+    /** Sensor Vertical Field of View. */
     SensorVerticalFov(23),
+    /** Motion Imagery URL. */
     MotionImageryUrl(24),
+    /** VMask Local Set. */
     VMask(101),
+    /** VObject Local Set. */
     VObject(102),
+    /** VFeature Local Set. */
     VFeature(103),
+    /** VChip Local Set. */
     VChip(105),
+    /** VChip Series Local Set. */
     VChipSeries(106),
+    /** VObject Series Local Set. */
     VObjectSeries(107);
 
     private final int tag;

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtrack/VTrackLocalSet.java
@@ -33,6 +33,7 @@ import org.jmisb.api.klv.st0903.vtracker.TrackId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** VTrack Local Set. */
 public class VTrackLocalSet implements IMisbMessage {
     private static final Logger LOGGER = LoggerFactory.getLogger(VTrackLocalSet.class);
 

--- a/api/src/main/java/org/jmisb/api/klv/st0903/vtrack/VTrackMetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st0903/vtrack/VTrackMetadataKey.java
@@ -29,17 +29,27 @@ public enum VTrackMetadataKey implements IKlvKey {
      * <p>Microsecond count from Epoch of 1970; See MISP Time System - MISB ST 0603.
      */
     TrackTimeStamp(2),
+    /** Track Id. */
     TrackId(3),
+    /** Track Status. */
     TrackStatus(4),
+    /** Track Start Time. */
     TrackStartTime(5),
+    /** Track End Time. */
     TrackEndTime(6),
+    /** Track Boundary Series. */
     TrackBoundarySeries(7),
+    /** Track Algorithm. */
     TrackAlgorithm(8),
+    /** Track Confidence. */
     TrackConfidence(9),
+    /** System Name. */
     SystemName(10),
+    /** Version Number. */
     VersionNumber(11),
     /** String of VMTI source sensor. E.g. 'EO Nose', 'EO Zoom (DLTV)'. */
     SourceSensor(12),
+    /** Number of Track Points. */
     NumTrackPoints(13),
     /**
      * VTrackItem Packs ordered as a Series.

--- a/api/src/main/java/org/jmisb/api/klv/st1108/IInterpretabilityQualityMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1108/IInterpretabilityQualityMetadataValue.java
@@ -3,6 +3,11 @@ package org.jmisb.api.klv.st1108;
 import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.IKlvValue;
 
+/**
+ * ST 1108 metadata value.
+ *
+ * <p>All ST 1108 Interpretability and Quality Local Set values implement this interface.
+ */
 public interface IInterpretabilityQualityMetadataValue extends IKlvValue {
     /**
      * Append the encoded bytes for this item to the byte array builder.

--- a/api/src/main/java/org/jmisb/api/klv/st1201/FpEncoder.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1201/FpEncoder.java
@@ -37,7 +37,13 @@ public class FpEncoder {
     private double a, b;
     private double sF, sR;
     private double zOffset;
+    /**
+     * The field length.
+     *
+     * <p>This mainly intended for unit testing.
+     */
     protected int fieldLength;
+
     private static final double logOf2 = Math.log(2.0);
     private final OutOfRangeBehaviour behaviour;
     private static final byte[] EIGHT_BYTE_HIGH_BIT =

--- a/api/src/main/java/org/jmisb/api/klv/st1206/AbstractAngle.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/AbstractAngle.java
@@ -3,7 +3,10 @@ package org.jmisb.api.klv.st1206;
 /** Shared ST1206 implementation of an angle value. */
 public abstract class AbstractAngle implements ISARMIMetadataValue {
 
+    /** Number of bytes used for encoding. */
     protected static final int NUM_BYTES = 2;
+
+    /** The angular value. */
     protected double value;
 
     @Override

--- a/api/src/main/java/org/jmisb/api/klv/st1206/AbstractDistance.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/AbstractDistance.java
@@ -10,9 +10,11 @@ import org.jmisb.api.klv.st1201.OutOfRangeBehaviour;
  */
 public abstract class AbstractDistance implements ISARMIMetadataValue {
 
-    protected static final double MIN_VAL = 0.0;
-    protected static final double MAX_VAL = 1.0e6;
-    protected static final int NUM_BYTES = 4;
+    private static final double MIN_VAL = 0.0;
+    private static final double MAX_VAL = 1.0e6;
+    private static final int NUM_BYTES = 4;
+
+    /** The implementing value. */
     protected double value;
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st1206/PulseRepetitionFrequencyScaleFactor.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/PulseRepetitionFrequencyScaleFactor.java
@@ -15,10 +15,10 @@ import org.jmisb.api.klv.st1201.OutOfRangeBehaviour;
  */
 public class PulseRepetitionFrequencyScaleFactor implements ISARMIMetadataValue {
 
-    protected static final double MIN_VAL = 0.0;
-    protected static final double MAX_VAL = 1.0;
-    protected static final int NUM_BYTES = 2;
-    protected double value;
+    private static final double MIN_VAL = 0.0;
+    private static final double MAX_VAL = 1.0;
+    private static final int NUM_BYTES = 2;
+    private double value;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st1206/SARMIEnumeration.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/SARMIEnumeration.java
@@ -6,6 +6,7 @@ import java.util.Map;
 /** Abstract base class for single-byte enumeration values in ST 1206. */
 public abstract class SARMIEnumeration implements ISARMIMetadataValue {
 
+    /** Implementing value for this enumeration. */
     protected byte value;
 
     /**

--- a/api/src/main/java/org/jmisb/api/klv/st1206/SARMILocalSet.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/SARMILocalSet.java
@@ -17,6 +17,11 @@ import org.jmisb.api.klv.UniversalLabel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * ST 1206 Synthetic Aperture Radar Motion Imagery Local Set.
+ *
+ * <p>This is the top level ST 1206 local set.
+ */
 public class SARMILocalSet implements IMisbMessage {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SARMILocalSet.class);

--- a/api/src/main/java/org/jmisb/api/klv/st1206/TransmitRFBandwidth.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/TransmitRFBandwidth.java
@@ -14,10 +14,10 @@ import org.jmisb.api.klv.st1201.OutOfRangeBehaviour;
  */
 public class TransmitRFBandwidth implements ISARMIMetadataValue {
 
-    protected static final double MIN_VAL = 0.0;
-    protected static final double MAX_VAL = 1.0e11;
-    protected static final int NUM_BYTES = 4;
-    protected double value;
+    private static final double MIN_VAL = 0.0;
+    private static final double MAX_VAL = 1.0e11;
+    private static final int NUM_BYTES = 4;
+    private double value;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st1206/TransmitRFCenterFrequency.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/TransmitRFCenterFrequency.java
@@ -15,10 +15,10 @@ import org.jmisb.api.klv.st1201.OutOfRangeBehaviour;
  */
 public class TransmitRFCenterFrequency implements ISARMIMetadataValue {
 
-    protected static final double MIN_VAL = 0.0;
-    protected static final double MAX_VAL = 1.0e12;
-    protected static final int NUM_BYTES = 4;
-    protected double value;
+    private static final double MIN_VAL = 0.0;
+    private static final double MAX_VAL = 1.0e12;
+    private static final int NUM_BYTES = 4;
+    private double value;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st1206/TruePulseRepetitionFrequency.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1206/TruePulseRepetitionFrequency.java
@@ -14,10 +14,10 @@ import org.jmisb.api.klv.st1201.OutOfRangeBehaviour;
  */
 public class TruePulseRepetitionFrequency implements ISARMIMetadataValue {
 
-    protected static final double MIN_VAL = 0.0;
-    protected static final double MAX_VAL = 1000000.0;
-    protected static final int NUM_BYTES = 4;
-    protected double value;
+    private static final double MIN_VAL = 0.0;
+    private static final double MAX_VAL = 1000000.0;
+    private static final int NUM_BYTES = 4;
+    private double value;
 
     /**
      * Create from value.

--- a/api/src/main/java/org/jmisb/api/klv/st1902/IMimdMetadataValue.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1902/IMimdMetadataValue.java
@@ -2,6 +2,7 @@ package org.jmisb.api.klv.st1902;
 
 import org.jmisb.api.klv.IKlvValue;
 
+/** ST 190x MIMD metadata value. */
 public interface IMimdMetadataValue extends IKlvValue {
     /**
      * Get the encoded bytes.

--- a/api/src/main/java/org/jmisb/api/klv/st1902/MimdIdReference.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1902/MimdIdReference.java
@@ -5,6 +5,12 @@ import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerField;
 
+/**
+ * MIMD Id Reference.
+ *
+ * <p>This models the MIMD "Ref" usage, where a value can cross-reference to another value by group
+ * identifier and serial number.
+ */
 public class MimdIdReference implements IMimdMetadataValue {
 
     private final int serialNumber;

--- a/api/src/main/java/org/jmisb/api/klv/st1909/MetadataKey.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1909/MetadataKey.java
@@ -6,26 +6,55 @@ package org.jmisb.api.klv.st1909;
  * <p>This is not intended to be a normal KLV key, but rather the key in a key:value Map sense.
  */
 public enum MetadataKey {
+    /** Platform name. */
     PlatformName("Platform Name"),
+    /** Platform Latitude. */
     PlatformLatitude("Platform Latitude"),
+    /** Platform Longitude. */
     PlatformLongitude("Platform Longitude"),
+    /** Platform Altitude. */
     PlatformAltitude("Platform Altitude"),
+    /** Target Latitude. */
     TargetLatitude("Target Latitude"),
+    /** Target Longitude. */
     TargetLongitude("Target Longitude"),
+    /** Target Elevation. */
     TargetElevation("Target Elevation"),
+    /** Vertical Field of View (FOV). */
     VerticalFOV("Vertical FOV"),
+    /** Horizontal Field of View (FOV). */
     HorizontalFOV("Horizontal FOV"),
+    /** Target Width. */
     TargetWidth("Target Width"),
+    /** Slant Range. */
     SlantRange("Slant Range"),
+    /** Metadata Timestamp. */
     MetadataTimestamp("Metadata Timestamp"),
+    /** Laser PRF Code. */
     LaserPrfCode("Laser PRF Code"),
+    /** Main Sensor Name. */
     MainSensorName("Main Sensor Name"),
+    /** Azimuth Angle. */
     AzAngle("Azimuth Angle"),
+    /** Elevation Angle. */
     ElAngle("Elevation Angle"),
+    /** Laser Sensor Name. */
     LaserSensorName("Laser Sensor Name"),
+    /** Laser Sensor Status. */
     LaserSensorStatus("Laser Sensor Status"),
+    /**
+     * Classification and Releasability Line 1.
+     *
+     * <p>This is the upper line.
+     */
     ClassificationAndReleasabilityLine1("Classification and Releasability Group Line 1"),
+    /**
+     * Classification and Releasability Line 2.
+     *
+     * <p>This is the lower line.
+     */
     ClassificationAndReleasabilityLine2("Classification and Releasability Group Line 2"),
+    /** True North Angle. */
     NorthAngle("True North Angle");
 
     private final String text;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,3 +1,9 @@
+/**
+ * jmisb utility methods.
+ *
+ * <p>This package provides shared implementation of methods that are commonly needed in KLV, video
+ * and other metadata processing, such as operations on byte arrays.
+ */
 module org.jmisb.core {
     requires org.slf4j;
 

--- a/core/src/main/java/org/jmisb/core/klv/CRC32MPEG2.java
+++ b/core/src/main/java/org/jmisb/core/klv/CRC32MPEG2.java
@@ -55,8 +55,18 @@ public class CRC32MPEG2 {
                 0xBCB4666D, 0xB8757BDA, 0xB5365D03, 0xB1F740B4
             };
 
+    /** Constructor. */
     public CRC32MPEG2() {}
 
+    /**
+     * Update the CRC results with an array of bytes.
+     *
+     * <p>This allows for the the CRC to be calculated on less than the full byte array, by
+     * specifying an upper limit.
+     *
+     * @param bytes the byte array to read from
+     * @param meaningfulLength the number of bytes to read from the array
+     */
     public void update(byte[] bytes, int meaningfulLength) {
         for (int byteIndex = 0; byteIndex < meaningfulLength; ++byteIndex) {
             int ub = ((int) bytes[byteIndex]) & 0xff;
@@ -66,6 +76,11 @@ public class CRC32MPEG2 {
         }
     }
 
+    /**
+     * Get the CRC32 value.
+     *
+     * @return the calculated CRC value.
+     */
     public byte[] getCRC32() {
         return PrimitiveConverter.uint32ToBytes(m_crcAccum);
     }
@@ -76,8 +91,6 @@ public class CRC32MPEG2 {
      * <p>This uses the CRC32 checksum specified by ISO/IEC-13818-1. This is used in ST0806.
      *
      * <p>This is not the same checksum as is used in ST0601.
-     *
-     * <p>
      *
      * @param fullMessage Byte array of the full message packet
      * @return 4-byte checksum
@@ -96,8 +109,6 @@ public class CRC32MPEG2 {
      * <p>This uses the CRC32 checksum specified by ISO/IEC-13818-1. This is used in ST0806.
      *
      * <p>This is not the same checksum as is used in ST0601.
-     *
-     * <p>
      *
      * @param fullMessage Byte array of the full message packet
      * @param expected expected checksum value

--- a/core/src/main/java/org/jmisb/core/klv/UuidUtils.java
+++ b/core/src/main/java/org/jmisb/core/klv/UuidUtils.java
@@ -95,6 +95,12 @@ public class UuidUtils {
                 + standardFormatUUID.substring(32);
     }
 
+    /**
+     * Convert a hash result to a version 5 UUID.
+     *
+     * @param uuidBytes the hash results
+     * @return the version 5 UUID equivalent of the hash result.
+     */
     public static UUID convertHashOutputToVersion5UUID(byte[] uuidBytes) {
         byte[] truncatedBytes = Arrays.copyOf(uuidBytes, 16);
         truncatedBytes[6] &= 15; // clear version

--- a/elevation/geoid/src/main/java/module-info.java
+++ b/elevation/geoid/src/main/java/module-info.java
@@ -1,1 +1,8 @@
-module org.jmisb.elevation.geoid {}
+/**
+ * Geoid calculations module for jmisb.
+ *
+ * <p>This module provides conversion between geoid and ellipsoid.
+ */
+module org.jmisb.elevation.geoid {
+    exports org.jmisb.elevation.geoid;
+}

--- a/examples/systemout/src/main/java/org/jmisb/examples/systemout/Main.java
+++ b/examples/systemout/src/main/java/org/jmisb/examples/systemout/Main.java
@@ -2,7 +2,16 @@ package org.jmisb.examples.systemout;
 
 import java.io.IOException;
 
+/** Main class. */
 public class Main {
+    /**
+     * Main entry point.
+     *
+     * <p>The file to open must be specified as a command line argument.
+     *
+     * @param args command line arguments
+     * @throws IOException if there was a problem parsing the specified file.
+     */
     public static void main(String[] args) throws IOException {
         if (args.length < 1) {
             System.out.println("Need to specify the file name on the command line");

--- a/miml-maven-plugin/src/main/resources/templates/metadataKey.ftl
+++ b/miml-maven-plugin/src/main/resources/templates/metadataKey.ftl
@@ -12,8 +12,22 @@ import org.jmisb.api.klv.IKlvKey;
  * See ${document} for more information on these values.
  */
 public enum ${name}MetadataKey implements IKlvKey {
+    /**
+     * Unknown / undefined value.
+     *
+     * This should not be intentionally created, and will not be serialised.
+     */
     Undefined(-1, true),
 <#list entries as entry>
+    /**
+     * ${entry.name}.
+     *
+     * <p>This value is encoded as ${entry.number}.
+<#if entry.deprecated>
+     *
+     * <p>This entry is deprecated.
+</#if>
+     */
     ${entry.name}(${entry.number}, ${entry.deprecated?c})<#sep>,</#sep><#if entry?is_last>;</#if>
 </#list>
 
@@ -52,6 +66,11 @@ public enum ${name}MetadataKey implements IKlvKey {
         return tagTable.containsKey(tag) ? tagTable.get(tag) : Undefined;
     }
 
+    /**
+     * Whether this item is deprecated.
+     *
+     * @return true if the item is deprecated, otherwise false.
+     */
     public boolean isDeprecated() {
         return deprecated;
     }

--- a/viewer/src/main/java/module-info.java
+++ b/viewer/src/main/java/module-info.java
@@ -1,3 +1,4 @@
+/** Demonstration Viewer application for jmisb. */
 module org.jmisb.viewer {
     requires org.jmisb.api.ffmpeg;
     requires org.jmisb.api.awt;

--- a/viewer/src/main/java/org/jmisb/viewer/Annotations.java
+++ b/viewer/src/main/java/org/jmisb/viewer/Annotations.java
@@ -20,6 +20,7 @@ import org.jmisb.api.klv.st0602.YViewportPosition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** Support for ST 0602 style annotations. */
 public class Annotations {
 
     private static Logger LOG = LoggerFactory.getLogger(Annotations.class);

--- a/viewer/src/main/java/org/jmisb/viewer/VideoPanel.java
+++ b/viewer/src/main/java/org/jmisb/viewer/VideoPanel.java
@@ -31,6 +31,7 @@ public class VideoPanel extends JPanel
     private boolean annotationOverlayEnabled = false;
     private final Annotations annotations = new Annotations();
 
+    /** Constructor. */
     VideoPanel() {
         if (logger.isDebugEnabled()) {
             logger.debug("Creating video panel");
@@ -107,6 +108,11 @@ public class VideoPanel extends JPanel
         }
     }
 
+    /**
+     * Clear previous display.
+     *
+     * <p>This will clear the image, metadata, and any annotations.
+     */
     public void clear() {
         bufferedImage = null;
         this.metadata.clear();


### PR DESCRIPTION
## Motivation and Context
I've switched to a newer java version, and it complains a lot more about missing javadoc when doing that stage of the build. (I hadn't actually noticed it before, because normally I don't watch the build, but there were a lot of warnings.)

## Description
This is a pretty big, but comparatively simple set of changes, mainly for the api and core modules. 
Mostly it just adds javadocs. 
There are a few places where things really should have been `private`. A couple of cases required a bit more.

## How Has This Been Tested?
Unit tests (full build) only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

