### PR TITLE
deps: upgrade FFmpeg to 5.0 (2.x)

### DIFF
--- a/api-ffmpeg/src/main/java/module-info.java
+++ b/api-ffmpeg/src/main/java/module-info.java
@@ -1,3 +1,8 @@
+/**
+ * FFmpeg integration for jmisb.
+ *
+ * <p>This module provides FFmpeg-specific support, including parsing.
+ */
 module org.jmisb.api.ffmpeg {
     requires org.jmisb.api;
     requires org.jmisb.core;

--- a/api-ffmpeg/src/main/java/org/jmisb/api/video/PesType.java
+++ b/api-ffmpeg/src/main/java/org/jmisb/api/video/PesType.java
@@ -10,11 +10,21 @@ import java.util.Map;
  * provides the known PES types.
  */
 public enum PesType {
+    /**
+     * Unknown PES type.
+     *
+     * <p>This is not valid and should not be intentionally created.
+     */
     UNKNOWN(-1),
+    /** Video elementary stream. */
     VIDEO(0),
+    /** Audio elementary stream. */
     AUDIO(1),
+    /** Data elementary stream. */
     DATA(2),
+    /** Subtitle elementary stream. */
     SUBTITLE(3),
+    /** Attachment elementary stream. */
     ATTACHMENT(4);
 
     private final int code;
@@ -27,7 +37,7 @@ public enum PesType {
         }
     }
 
-    PesType(int c) {
+    private PesType(int c) {
         code = c;
     }
 

--- a/api-ffmpeg/src/main/java/org/jmisb/api/video/VideoDecodeThread.java
+++ b/api-ffmpeg/src/main/java/org/jmisb/api/video/VideoDecodeThread.java
@@ -189,7 +189,7 @@ class VideoDecodeThread extends ProcessingThread {
                         AVFrameSideData sideData =
                                 av_frame_get_side_data(avFrame, AV_FRAME_DATA_SEI_UNREGISTERED);
                         if (sideData != null) {
-                            int numBytesInSideData = sideData.size();
+                            int numBytesInSideData = (int) sideData.size();
                             if (numBytesInSideData >= 16) {
                                 byte[] sideDataBytes = new byte[numBytesInSideData];
                                 sideData.data().get(sideDataBytes);

--- a/api-ffmpeg/src/main/java/org/jmisb/api/video/VideoFileOutput.java
+++ b/api-ffmpeg/src/main/java/org/jmisb/api/video/VideoFileOutput.java
@@ -32,8 +32,8 @@ public class VideoFileOutput extends VideoOutput implements IVideoFileOutput {
     private static final Logger logger = LoggerFactory.getLogger(VideoFileOutput.class);
     private String filename;
 
-    protected static final byte ASYNC_STREAM_ID = (byte) 0xBD;
-    protected static final byte SYNC_STREAM_ID = (byte) 0xFC;
+    private static final byte ASYNC_STREAM_ID = (byte) 0xBD;
+    private static final byte SYNC_STREAM_ID = (byte) 0xFC;
 
     /**
      * Constructor.

--- a/api-ffmpeg/src/main/java/org/jmisb/api/video/VideoOutput.java
+++ b/api-ffmpeg/src/main/java/org/jmisb/api/video/VideoOutput.java
@@ -64,8 +64,14 @@ public abstract class VideoOutput extends VideoIO {
 
     private static final Logger logger = LoggerFactory.getLogger(VideoOutput.class);
 
-    protected static final int METADATA_AU_HEADER_LEN = 5;
+    private static final int METADATA_AU_HEADER_LEN = 5;
 
+    /**
+     * Configuration options for the video output.
+     *
+     * <p>This is holds the configuration settings that change the output (e.g. rates, data
+     * included, and frame size).
+     */
     protected VideoOutputOptions options;
 
     // Format

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <cyclonedx.schema.version>1.3</cyclonedx.schema.version>
         <cyclonedx.version>2.5.3</cyclonedx.version>
         <failsafe.version>3.0.0-M5</failsafe.version>
-        <ffmpeg.platform.version>4.4-1.5.6</ffmpeg.platform.version>
+        <ffmpeg.platform.version>5.0-1.5.7</ffmpeg.platform.version>
         <freemarker.version>2.3.31</freemarker.version>
         <googleformatter.maven.plugin.version>1.7.5</googleformatter.maven.plugin.version>
         <gstreamer.version>1.4.0</gstreamer.version>


### PR DESCRIPTION
## Motivation and Context
FFmpeg 5.0 is released, and that is supported by a recent release from bytedeco for the presets. There is a range of fixes in 5.0, and while none of them are critical, this seems like a useful step. I plan to make use of some of the new features (like encoding SEI) in the future.

## Description
Bumps the ffmpeg dependency. There is also a change in the data type (int to long, although the size can't reasonably exceed int) in one place. 

I've also added some javadoc that is arguably a different change, but still seems like a useful add. A few `protected` methods in our code don't need to be exposed, made those `private`. That is definitely a different change, but this was a good opportunity to check that didn't cause any problems given the testing required for FFmpeg 5.0.

## How Has This Been Tested?
Full build, all unit tests.
Used viewer application on a fair sample of input files - no problems noted.
Used systemout example on a couple of test files - no problems noted.
Used generator example to make file. Verified it shows up OK with VLC.

## Screenshots (if appropriate):
N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

