### PR TITLE
ci: add main branch to workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ develop ]
+    branches: [ develop, main ]
   schedule:
     - cron: '25 13 * * 2'
 

--- a/.github/workflows/jdk11.yml
+++ b/.github/workflows/jdk11.yml
@@ -2,9 +2,9 @@ name: JDK11 Build (Ubuntu 20.04 default)
 
 on:
     push:
-      branches: [ develop ]
+      branches: [ develop, main ]
     pull_request:
-      branches: [ develop ]
+      branches: [ develop, main ]
 
 jobs:
   build:

--- a/.github/workflows/jdk14.yml
+++ b/.github/workflows/jdk14.yml
@@ -2,9 +2,9 @@ name: JDK14 Build (Ubuntu 20.04)
 
 on:
     push:
-      branches: [ develop ]
+      branches: [ develop, main ]
     pull_request:
-      branches: [ develop ]
+      branches: [ develop, main ]
 
 jobs:
   build:

--- a/.github/workflows/jdk8.yml
+++ b/.github/workflows/jdk8.yml
@@ -2,9 +2,9 @@ name: JDK8 Build (Ubuntu 18.04)
 
 on:
     push:
-      branches: [ develop ]
+      branches: [ develop, main ]
     pull_request:
-      branches: [ develop ]
+      branches: [ develop, main ]
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,9 +5,9 @@ name: macOS Build
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, main ]
   pull_request:
-    branches: [ develop ]
+    branches: [ develop, main ]
 
 jobs:
   build:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -2,9 +2,9 @@ name: Quality Assurance Checks
 
 on:
     push:
-      branches: [ develop ]
+      branches: [ develop, main ]
     pull_request:
-      branches: [ develop ]
+      branches: [ develop, main ]
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,9 +5,9 @@ name: Windows Build
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, main ]
   pull_request:
-    branches: [ develop ]
+    branches: [ develop, main ]
 
 jobs:
   build:


### PR DESCRIPTION
## Motivation and Context

The GitHub workflows for CI are not running on the main branch. I think it would be useful to do so.

## Description
Just adds `main` to existing `develop` entries.

## How Has This Been Tested?
Testing as part of this PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

