### PR TITLE
st1303: implement additional encode and decode

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/st1303/BooleanArrayEncoder.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1303/BooleanArrayEncoder.java
@@ -22,6 +22,39 @@ public class BooleanArrayEncoder {
     public BooleanArrayEncoder() {}
 
     /**
+     * Encode a one dimensional Boolean array to a Multi-Dimensional Array Pack using Binary Array
+     * Encoding.
+     *
+     * <p>This packs each value into a bit-encoded 1D array, and serialises the array to a byte
+     * array.
+     *
+     * @param data the array of ({@code boolean}) values.
+     * @return the encoded byte array including the MISB ST1303 header and array data.
+     * @throws KlvParseException if the encoding fails, such as for invalid array dimensions.
+     */
+    public byte[] encode(boolean[] data) throws KlvParseException {
+        if (data.length < 1) {
+            throw new KlvParseException("MDAP encoding requires at least one item.");
+        }
+        ArrayBuilder builder =
+                new ArrayBuilder()
+                        // Number of dimensions
+                        .appendAsOID(1)
+                        // dim
+                        .appendAsOID(data.length)
+                        // E_bytes value, see ST1303 Appendix D.2
+                        .appendAsOID(1)
+                        // array processing algorithm (APA)
+                        // note no array processing algorithm support (APAS) values
+                        .appendAsOID(ArrayProcessingAlgorithm.BooleanArray.getCode());
+        // Array Of Elements
+        for (boolean b : data) {
+            builder.appendAsBit(b);
+        }
+        return builder.toBytes();
+    }
+
+    /**
      * Encode a two dimensional Boolean array to a Multi-Dimensional Array Pack using Binary Array
      * Encoding.
      *

--- a/api/src/main/java/org/jmisb/api/klv/st1303/NaturalFormatEncoder.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1303/NaturalFormatEncoder.java
@@ -195,6 +195,38 @@ public class NaturalFormatEncoder {
     }
 
     /**
+     * Encode a one dimensional Boolean array to a Multi-Dimensional Array Pack using Natural Format
+     * Encoding.
+     *
+     * <p>This serialises each value into a byte array.
+     *
+     * @param data the array of ({@code boolean}) values.
+     * @return the encoded byte array including the MISB ST1303 header and array data.
+     * @throws KlvParseException if the encoding fails, such as for invalid array dimensions.
+     */
+    public byte[] encode(boolean[] data) throws KlvParseException {
+        if (data.length < 1) {
+            throw new KlvParseException("MDAP encoding requires at least one item");
+        }
+        ArrayBuilder builder =
+                new ArrayBuilder()
+                        // Number of dimensions
+                        .appendAsOID(1)
+                        // dim
+                        .appendAsOID(data.length)
+                        // E_bytes value - single byte
+                        .appendAsOID(1)
+                        // array processing algorithm (APA)
+                        // note no array processing algorithm support (APAS) values
+                        .appendAsOID(ArrayProcessingAlgorithm.NaturalFormat.getCode());
+        // Array Of Elements
+        for (int i = 0; i < data.length; ++i) {
+            builder.appendByte(data[i] == true ? (byte) 0x01 : (byte) 0x00);
+        }
+        return builder.toBytes();
+    }
+
+    /**
      * Encode a two dimensional Boolean array to a Multi-Dimensional Array Pack using Natural Format
      * Encoding.
      *

--- a/api/src/test/java/org/jmisb/api/klv/st1303/BooleanArrayEncoderTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1303/BooleanArrayEncoderTest.java
@@ -11,6 +11,47 @@ public class BooleanArrayEncoderTest {
     public BooleanArrayEncoderTest() {}
 
     @Test
+    public void checkSingleElement1D() throws KlvParseException {
+        BooleanArrayEncoder encoder = new BooleanArrayEncoder();
+        byte[] encoded = encoder.encode(new boolean[] {true});
+        assertEquals(
+                encoded,
+                new byte[] {(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x03, (byte) 0x80});
+    }
+
+    @Test
+    public void check1D() throws KlvParseException {
+        BooleanArrayEncoder encoder = new BooleanArrayEncoder();
+        byte[] encoded =
+                encoder.encode(
+                        new boolean[] {
+                            false, true, false, false,
+                            true, false, false, false,
+                            true, false, true, false,
+                            true, false, false, false,
+                            true, true, true, true
+                        });
+        assertEquals(
+                encoded,
+                new byte[] {
+                    (byte) 0x01,
+                    (byte) 0x14,
+                    (byte) 0x01,
+                    (byte) 0x03,
+                    (byte) 0x48,
+                    (byte) 0xA8,
+                    (byte) 0xF0
+                });
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void check1DBadCount() throws KlvParseException {
+        BooleanArrayEncoder encoder = new BooleanArrayEncoder();
+        assertNotNull(encoder);
+        encoder.encode(new boolean[0]);
+    }
+
+    @Test
     public void check2D() throws KlvParseException {
         BooleanArrayEncoder encoder = new BooleanArrayEncoder();
         byte[] encoded =
@@ -48,21 +89,21 @@ public class BooleanArrayEncoderTest {
     }
 
     @Test(expectedExceptions = KlvParseException.class)
-    public void check2DIntBadColumns() throws KlvParseException {
+    public void check2DBadColumns() throws KlvParseException {
         BooleanArrayEncoder encoder = new BooleanArrayEncoder();
         assertNotNull(encoder);
         encoder.encode(new boolean[1][0]);
     }
 
     @Test(expectedExceptions = KlvParseException.class)
-    public void check2DIntBadRows() throws KlvParseException {
+    public void check2DBadRows() throws KlvParseException {
         BooleanArrayEncoder encoder = new BooleanArrayEncoder();
         assertNotNull(encoder);
         encoder.encode(new boolean[0][1]);
     }
 
     @Test(expectedExceptions = KlvParseException.class)
-    public void check2DIntBadRowsAndColumns() throws KlvParseException {
+    public void check2DBadRowsAndColumns() throws KlvParseException {
         BooleanArrayEncoder encoder = new BooleanArrayEncoder();
         assertNotNull(encoder);
         encoder.encode(new boolean[0][0]);

--- a/api/src/test/java/org/jmisb/api/klv/st1303/MDAPDecoderTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1303/MDAPDecoderTest.java
@@ -186,39 +186,33 @@ public class MDAPDecoderTest {
                 0);
     }
 
-    @Test(expectedExceptions = KlvParseException.class)
-    public void checkBadAPA_RunLengthEncodedFloatingPoint1D() throws KlvParseException {
+    @Test
+    public void checkFloatingPoint1D_RunLengthEncoding() throws KlvParseException {
         MDAPDecoder decoder = new MDAPDecoder();
-        decoder.decodeFloatingPoint1D(
-                new byte[] {
-                    (byte) 0x01,
-                    (byte) 0x01,
-                    (byte) 0x04,
-                    (byte) 0x05, // APA
-                    (byte) 0x00,
-                    (byte) 0x00,
-                    (byte) 0x00,
-                    (byte) 0x00
-                },
-                0);
-    }
-
-    @Test(expectedExceptions = KlvParseException.class)
-    public void checkBadAPA_RunLengthEncodedFloatingPoint2D() throws KlvParseException {
-        MDAPDecoder decoder = new MDAPDecoder();
-        decoder.decodeFloatingPoint2D(
-                new byte[] {
-                    (byte) 0x02,
-                    (byte) 0x01,
-                    (byte) 0x01,
-                    (byte) 0x04,
-                    (byte) 0x05, // APA
-                    (byte) 0x00,
-                    (byte) 0x00,
-                    (byte) 0x00,
-                    (byte) 0x00
-                },
-                0);
+        double[] decoded =
+                decoder.decodeFloatingPoint1D(
+                        new byte[] {
+                            (byte) 0x01,
+                            (byte) 0x06,
+                            (byte) 0x04,
+                            // APA
+                            (byte) 0x05,
+                            // APAS
+                            (byte) 0x41,
+                            (byte) 0x20,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            // Run
+                            (byte) 0x41,
+                            (byte) 0xA0,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x01,
+                            (byte) 0x03
+                        },
+                        0);
+        double[] expected = new double[] {10.0, 20.0, 20.0, 20.0, 10.0, 10.0};
+        assertEquals(decoded, expected);
     }
 
     @Test(expectedExceptions = KlvParseException.class)
@@ -538,6 +532,42 @@ public class MDAPDecoderTest {
     }
 
     @Test
+    public void checkFloatingPoint2D_RunLengthEncoding() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        double[][] decoded =
+                decoder.decodeFloatingPoint2D(
+                        new byte[] {
+                            (byte) 0x02,
+                            (byte) 0x02,
+                            (byte) 0x06,
+                            (byte) 0x04,
+                            // APA
+                            (byte) 0x05,
+                            // APAS
+                            (byte) 0x41,
+                            (byte) 0x20,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            // Run
+                            (byte) 0x41,
+                            (byte) 0xA0,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x01,
+                            (byte) 0x02,
+                            (byte) 0x03
+                        },
+                        0);
+        double[][] expected =
+                new double[][] {
+                    {10.0, 20.0, 20.0, 20.0, 10.0, 10.0},
+                    {10.0, 20.0, 20.0, 20.0, 10.0, 10.0}
+                };
+        assertEquals(decoded, expected);
+    }
+
+    @Test
     public void decodeFloatAsDouble1D() throws KlvParseException {
         MDAPDecoder decoder = new MDAPDecoder();
         double[] decoded =
@@ -808,6 +838,167 @@ public class MDAPDecoderTest {
     }
 
     @Test
+    public void testBoolean1DimNaturalFormatEncodingSingleElement() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        boolean[] decoded =
+                decoder.decodeBoolean1D(
+                        new byte[] {
+                            (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x01
+                        },
+                        0);
+        assertEquals(decoded, new boolean[] {true});
+    }
+
+    @Test
+    public void testBoolean1DimNaturalFormatEncoding() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        boolean[] decoded =
+                decoder.decodeBoolean1D(
+                        new byte[] {
+                            (byte) 0x01,
+                            (byte) 0x14,
+                            (byte) 0x01,
+                            (byte) 0x01,
+                            (byte) 0x00,
+                            (byte) 0x01,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x01,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x01,
+                            (byte) 0x00,
+                            (byte) 0x01,
+                            (byte) 0x00,
+                            (byte) 0x01,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x01,
+                            (byte) 0x01,
+                            (byte) 0x01,
+                            (byte) 0x01
+                        },
+                        0);
+        assertEquals(
+                decoded,
+                new boolean[] {
+                    false, true, false, false, true, false, false, false,
+                    true, false, true, false, true, false, false, false,
+                    true, true, true, true
+                });
+    }
+
+    @Test
+    public void testBoolean1DimBooleanArrayEncodingSingleElement() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        boolean[] decoded =
+                decoder.decodeBoolean1D(
+                        new byte[] {
+                            (byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x03, (byte) 0x80
+                        },
+                        0);
+        assertEquals(decoded, new boolean[] {true});
+    }
+
+    @Test
+    public void testBoolean1DimBooleanArrayEncoding() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        boolean[] decoded =
+                decoder.decodeBoolean1D(
+                        new byte[] {
+                            (byte) 0x01,
+                            (byte) 0x14,
+                            (byte) 0x01,
+                            (byte) 0x03,
+                            (byte) 0x48,
+                            (byte) 0xA8,
+                            (byte) 0xF0
+                        },
+                        0);
+        assertEquals(
+                decoded,
+                new boolean[] {
+                    false, true, false, false, true, false, false, false,
+                    true, false, true, false, true, false, false, false,
+                    true, true, true, true
+                });
+    }
+
+    @Test
+    public void testBoolean1DimRunLengthEncodingDefaultFalse() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        boolean[] decoded =
+                decoder.decodeBoolean1D(
+                        new byte[] {
+                            (byte) 0x01,
+                            (byte) 0x14,
+                            (byte) 0x01,
+                            // APA
+                            (byte) 0x05,
+                            // APAS
+                            (byte) 0x00,
+                            // Patch 1
+                            (byte) 0x01,
+                            (byte) 0x01,
+                            (byte) 0x04,
+                            // Patch 2 - overlap
+                            (byte) 0x00,
+                            (byte) 0x02,
+                            (byte) 0x02,
+                            // Patch 3
+                            (byte) 0x01,
+                            (byte) 0x10,
+                            (byte) 0x04,
+                            // Patch 4
+                            (byte) 0x01,
+                            (byte) 0x0c,
+                            (byte) 0x01
+                        },
+                        0);
+        assertEquals(
+                decoded,
+                new boolean[] {
+                    false, true, false, false, true, false, false, false,
+                    false, false, false, false, true, false, false, false,
+                    true, true, true, true
+                });
+    }
+
+    @Test
+    public void testBoolean1DimRunLengthEncodingDefaultTrue() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        boolean[] decoded =
+                decoder.decodeBoolean1D(
+                        new byte[] {
+                            (byte) 0x01,
+                            (byte) 0x14,
+                            (byte) 0x01,
+                            // APA
+                            (byte) 0x05,
+                            // APAS
+                            (byte) 0x01,
+                            // Patch 1
+                            (byte) 0x00,
+                            (byte) 0x02,
+                            (byte) 0x08,
+                            // Patch 2 - overlap
+                            (byte) 0x01,
+                            (byte) 0x06,
+                            (byte) 0x02,
+                        },
+                        0);
+        assertEquals(
+                decoded,
+                new boolean[] {
+                    true, true, false, false, false, false, true, true,
+                    false, false, true, true, true, true, true, true,
+                    true, true, true, true
+                });
+    }
+
+    @Test
     public void testBoolean2DimNaturalFormatEncoding() throws KlvParseException {
         MDAPDecoder decoder = new MDAPDecoder();
         boolean[][] decoded =
@@ -852,6 +1043,20 @@ public class MDAPDecoderTest {
     }
 
     @Test(expectedExceptions = KlvParseException.class)
+    public void checkBadST1201APA_Boolean1D() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeBoolean1D(
+                new byte[] {
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x02, // APA
+                    (byte) 0x00
+                },
+                0);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
     public void checkBadST1201APA_Boolean2D() throws KlvParseException {
         MDAPDecoder decoder = new MDAPDecoder();
         decoder.decodeBoolean2D(
@@ -867,10 +1072,36 @@ public class MDAPDecoderTest {
     }
 
     @Test(expectedExceptions = KlvParseException.class)
+    public void checkBadDimensionsBoolean1D() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeBoolean1D(
+                new byte[] {
+                    (byte) 0x02, (byte) 0x05, (byte) 0x01, (byte) 0x01, (byte) 0x03, (byte) 0x00
+                },
+                0);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
     public void checkBadDimensionsBoolean2D() throws KlvParseException {
         MDAPDecoder decoder = new MDAPDecoder();
         decoder.decodeBoolean2D(
                 new byte[] {(byte) 0x01, (byte) 0x05, (byte) 0x01, (byte) 0x03, (byte) 0x00}, 0);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void testBadEbytesBoolean1D() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeBoolean1D(
+                new byte[] {
+                    (byte) 0x01,
+                    (byte) 0x14,
+                    (byte) 0x02,
+                    (byte) 0x03,
+                    (byte) 0x48,
+                    (byte) 0xA8,
+                    (byte) 0xF0
+                },
+                0);
     }
 
     @Test(expectedExceptions = KlvParseException.class)
@@ -963,6 +1194,20 @@ public class MDAPDecoderTest {
     }
 
     @Test(expectedExceptions = KlvParseException.class)
+    public void checkBadUnsignedIntegerAPA_Boolean1D() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeBoolean1D(
+                new byte[] {
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x04, // APA
+                    (byte) 0x00
+                },
+                0);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
     public void checkBadUnsignedIntegerAPA_Boolean2D() throws KlvParseException {
         MDAPDecoder decoder = new MDAPDecoder();
         decoder.decodeBoolean2D(
@@ -972,6 +1217,20 @@ public class MDAPDecoderTest {
                     (byte) 0x01,
                     (byte) 0x01,
                     (byte) 0x04, // APA
+                    (byte) 0x00
+                },
+                0);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
+    public void checkBadAPA_Boolean1D() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        decoder.decodeBoolean1D(
+                new byte[] {
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x55, // APA
                     (byte) 0x00
                 },
                 0);
@@ -1025,18 +1284,36 @@ public class MDAPDecoderTest {
                 new byte[] {(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x03, (byte) 0x02}, 0);
     }
 
+    @Test
+    public void testInt1Dim_RunLengthEncoding() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        long[] decoded =
+                decoder.decodeInt1D(
+                        new byte[] {
+                            (byte) 0x01,
+                            (byte) 0x0a,
+                            (byte) 0x02,
+                            (byte) 0x05,
+                            (byte) 0xfa,
+                            (byte) 0x70,
+                            (byte) 0x06,
+                            (byte) 0x78,
+                            (byte) 0x00,
+                            (byte) 0x03,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x05,
+                            (byte) 0x05
+                        },
+                        0);
+        assertEquals(decoded, new long[] {1656, 1656, 1656, -1424, -1424, 0, 0, 0, 0, 0});
+    }
+
     @Test(expectedExceptions = KlvParseException.class)
     public void testInt1Dim_BadAPA_UnsignedInteger() throws KlvParseException {
         MDAPDecoder decoder = new MDAPDecoder();
         decoder.decodeInt1D(
                 new byte[] {(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x04, (byte) 0x02}, 0);
-    }
-
-    @Test(expectedExceptions = KlvParseException.class)
-    public void testInt1Dim_BadAPA_RunLengthEncoding() throws KlvParseException {
-        MDAPDecoder decoder = new MDAPDecoder();
-        decoder.decodeInt1D(
-                new byte[] {(byte) 0x01, (byte) 0x01, (byte) 0x01, (byte) 0x05, (byte) 0x02}, 0);
     }
 
     @Test(expectedExceptions = KlvParseException.class)
@@ -1148,27 +1425,6 @@ public class MDAPDecoderTest {
                     (byte) 0x01,
                     (byte) 0x01,
                     (byte) 0x04,
-                    (byte) 0x81,
-                    (byte) 0x02,
-                    (byte) 0x00,
-                    (byte) 0x28,
-                    (byte) 0x19,
-                    (byte) 0x0D,
-                    (byte) 0x3C
-                },
-                0);
-    }
-
-    @Test(expectedExceptions = KlvParseException.class)
-    public void testInt2Dim_BadAPA_RunLengthEncoding() throws KlvParseException {
-        MDAPDecoder decoder = new MDAPDecoder();
-        decoder.decodeInt2D(
-                new byte[] {
-                    (byte) 0x02,
-                    (byte) 0x01,
-                    (byte) 0x05,
-                    (byte) 0x01,
-                    (byte) 0x05,
                     (byte) 0x81,
                     (byte) 0x02,
                     (byte) 0x00,
@@ -1500,24 +1756,36 @@ public class MDAPDecoderTest {
                 0);
     }
 
-    @Test(expectedExceptions = KlvParseException.class)
-    public void testUint1Dim_BadAPA_RunLengthEncoding() throws KlvParseException {
+    @Test
+    public void testUint1Dim_RunLengthEncoding() throws KlvParseException {
         MDAPDecoder decoder = new MDAPDecoder();
-        decoder.decodeUInt1D(
-                new byte[] {
-                    (byte) 0x01,
-                    (byte) 0x05,
-                    (byte) 0x01,
-                    (byte) 0x05,
-                    (byte) 0x81,
-                    (byte) 0x02,
-                    (byte) 0x00,
-                    (byte) 0x28,
-                    (byte) 0x19,
-                    (byte) 0x0D,
-                    (byte) 0x3C
-                },
-                0);
+        long[] decoded =
+                decoder.decodeUInt1D(
+                        new byte[] {
+                            // n_dims
+                            (byte) 0x01,
+                            // dim_1
+                            (byte) 0x05,
+                            // ebytes
+                            (byte) 0x02,
+                            // APA
+                            (byte) 0x05,
+                            // Two byte APAS
+                            (byte) 0x00,
+                            (byte) 0x82,
+                            // Patch 1
+                            (byte) 0x00,
+                            (byte) 0xaa,
+                            (byte) 0x01,
+                            (byte) 0x03,
+                            // Patch 2
+                            (byte) 0x01,
+                            (byte) 0x00,
+                            (byte) 0x02,
+                            (byte) 0x01
+                        },
+                        0);
+        assertEquals(decoded, new long[] {130, 170, 256, 170, 130});
     }
 
     @Test(expectedExceptions = KlvParseException.class)
@@ -1624,25 +1892,116 @@ public class MDAPDecoderTest {
                 0);
     }
 
-    @Test(expectedExceptions = KlvParseException.class)
-    public void testUint2Dim_BadAPA_RunLengthEncoding() throws KlvParseException {
+    // ST 1303.2 Figure 10 test case
+    @Test
+    public void testInt2Dim_RunLengthEncoding() throws KlvParseException {
         MDAPDecoder decoder = new MDAPDecoder();
-        decoder.decodeUInt2D(
-                new byte[] {
-                    (byte) 0x02,
-                    (byte) 0x01,
-                    (byte) 0x05,
-                    (byte) 0x01,
-                    (byte) 0x05,
-                    (byte) 0x81,
-                    (byte) 0x02,
-                    (byte) 0x00,
-                    (byte) 0x28,
-                    (byte) 0x19,
-                    (byte) 0x0D,
-                    (byte) 0x3C
-                },
-                0);
+        long[][] decoded =
+                decoder.decodeInt2D(
+                        new byte[] {
+                            (byte) 0x02,
+                            (byte) 0x0a,
+                            (byte) 0x0a,
+                            (byte) 0x02,
+                            (byte) 0x05,
+                            (byte) 0xfa,
+                            (byte) 0x70,
+                            (byte) 0x06,
+                            (byte) 0x78,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x04,
+                            (byte) 0x03,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x05,
+                            (byte) 0x04,
+                            (byte) 0x05,
+                            (byte) 0xfc,
+                            (byte) 0x09,
+                            (byte) 0x04,
+                            (byte) 0x00,
+                            (byte) 0x06,
+                            (byte) 0x03,
+                            (byte) 0x03,
+                            (byte) 0xd2,
+                            (byte) 0x04,
+                            (byte) 0x05,
+                            (byte) 0x03,
+                            (byte) 0x05,
+                            (byte) 0x04,
+                            (byte) 0xec,
+                            (byte) 0x07,
+                            (byte) 0x05,
+                            (byte) 0x03,
+                            (byte) 0x05
+                        },
+                        0);
+        assertEquals(
+                decoded,
+                new long[][] {
+                    {1656, 1656, 1656, -1424, -1424, 0, 0, 0, 0, 0},
+                    {1656, 1656, 1656, -1424, -1424, 0, 0, 0, 0, 0},
+                    {1656, 1656, 1656, -1424, -1424, 0, 0, 0, 0, 0},
+                    {1656, 1656, 1656, -1424, -1424, 0, 0, 0, 0, 0},
+                    {-1015, -1015, -1015, -1424, -1424, 978, 978, 978, 978, 978},
+                    {-1015, -1015, -1015, -1424, -1424, 978, 978, 978, 978, 978},
+                    {-1015, -1015, -1015, -1424, -1424, 978, 978, 978, 978, 978},
+                    {-1015, -1015, -1015, -1424, -1424, 1260, 1260, 1260, 1260, 1260},
+                    {-1015, -1015, -1015, -1424, -1424, 1260, 1260, 1260, 1260, 1260},
+                    {-1015, -1015, -1015, -1424, -1424, 1260, 1260, 1260, 1260, 1260}
+                });
+    }
+
+    // ST 1303.2 Figure 13 test case
+    @Test
+    public void testUint2Dim_RunLengthEncoding_Overlap() throws KlvParseException {
+        MDAPDecoder decoder = new MDAPDecoder();
+        long[][] decoded =
+                decoder.decodeUInt2D(
+                        new byte[] {
+                            (byte) 0x02,
+                            (byte) 0x0a,
+                            (byte) 0x0a,
+                            (byte) 0x02,
+                            (byte) 0x05,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x1B,
+                            (byte) 0x00,
+                            (byte) 0x00,
+                            (byte) 0x0A,
+                            (byte) 0x03,
+                            (byte) 0x00,
+                            (byte) 0x0D,
+                            (byte) 0x04,
+                            (byte) 0x00,
+                            (byte) 0x03,
+                            (byte) 0x0a,
+                            (byte) 0x01,
+                            (byte) 0x13,
+                            (byte) 0x00,
+                            (byte) 0x03,
+                            (byte) 0x0A,
+                            (byte) 0x02
+                        },
+                        0);
+        assertEquals(
+                decoded,
+                new long[][] {
+                    {27, 27, 27, 275, 275, 0, 0, 0, 0, 0},
+                    {27, 27, 27, 275, 275, 0, 0, 0, 0, 0},
+                    {27, 27, 27, 275, 275, 0, 0, 0, 0, 0},
+                    {27, 27, 27, 275, 275, 0, 0, 0, 0, 0},
+                    {13, 13, 13, 275, 275, 13, 13, 13, 13, 13},
+                    {13, 13, 13, 275, 275, 13, 13, 13, 13, 13},
+                    {13, 13, 13, 275, 275, 13, 13, 13, 13, 13},
+                    {27, 27, 27, 275, 275, 0, 0, 0, 0, 0},
+                    {27, 27, 27, 275, 275, 0, 0, 0, 0, 0},
+                    {27, 27, 27, 275, 275, 0, 0, 0, 0, 0}
+                });
     }
 
     @Test(expectedExceptions = KlvParseException.class)

--- a/api/src/test/java/org/jmisb/api/klv/st1303/NaturalFormatEncoderTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1303/NaturalFormatEncoderTest.java
@@ -211,6 +211,13 @@ public class NaturalFormatEncoderTest {
     }
 
     @Test(expectedExceptions = KlvParseException.class)
+    public void check1DBooleanBadCount() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        encoder.encode(new boolean[0]);
+    }
+
+    @Test(expectedExceptions = KlvParseException.class)
     public void check2DBooleanBadColumns() throws KlvParseException {
         NaturalFormatEncoder encoder = new NaturalFormatEncoder();
         assertNotNull(encoder);
@@ -229,6 +236,15 @@ public class NaturalFormatEncoderTest {
         NaturalFormatEncoder encoder = new NaturalFormatEncoder();
         assertNotNull(encoder);
         encoder.encode(new boolean[0][0]);
+    }
+
+    @Test
+    public void check1DBoolean() throws KlvParseException {
+        NaturalFormatEncoder encoder = new NaturalFormatEncoder();
+        assertNotNull(encoder);
+        byte[] encoded = encoder.encode(new boolean[] {true, false, true, false, false, true});
+        assertEquals(
+                encoded, new byte[] {0x01, 0x06, 0x01, 0x1, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01});
     }
 
     @Test

--- a/api/src/test/java/org/jmisb/api/klv/st1303/RunLengthEncodingEncoderTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1303/RunLengthEncodingEncoderTest.java
@@ -11,7 +11,7 @@ public class RunLengthEncodingEncoderTest {
     public RunLengthEncodingEncoderTest() {}
 
     @Test
-    public void check2D() throws KlvParseException {
+    public void check2Dboolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         boolean[][] input =
                 new boolean[][] {
@@ -58,7 +58,7 @@ public class RunLengthEncodingEncoderTest {
     }
 
     @Test
-    public void check2DAlternate() throws KlvParseException {
+    public void check2DAlternateBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         boolean[][] input =
                 new boolean[][] {
@@ -110,7 +110,7 @@ public class RunLengthEncodingEncoderTest {
     }
 
     @Test
-    public void check2DRectangularVertical() throws KlvParseException {
+    public void check2DRectangularVerticalBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         boolean[][] input =
                 new boolean[][] {
@@ -142,7 +142,7 @@ public class RunLengthEncodingEncoderTest {
     }
 
     @Test
-    public void check2DRectangularHorizontal() throws KlvParseException {
+    public void check2DRectangularHorizontalBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         boolean[][] input =
                 new boolean[][] {
@@ -174,7 +174,7 @@ public class RunLengthEncodingEncoderTest {
     }
 
     @Test
-    public void checkSingleElement2DTrue() throws KlvParseException {
+    public void checkSingleElement2DTrueBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         byte[] encoded = encoder.encode(new boolean[][] {{true}});
         assertEquals(
@@ -188,7 +188,7 @@ public class RunLengthEncodingEncoderTest {
     }
 
     @Test
-    public void checkSingleElement2DFalse() throws KlvParseException {
+    public void checkSingleElement2DFalseBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         byte[] encoded = encoder.encode(new boolean[][] {{false}});
         assertEquals(
@@ -202,7 +202,7 @@ public class RunLengthEncodingEncoderTest {
     }
 
     @Test
-    public void checkSingleRow2DTrue() throws KlvParseException {
+    public void checkSingleRow2DTrueBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         byte[] encoded = encoder.encode(new boolean[][] {{true, true, true, true}});
         assertEquals(
@@ -216,7 +216,7 @@ public class RunLengthEncodingEncoderTest {
     }
 
     @Test
-    public void checkSingleRow2DMixed() throws KlvParseException {
+    public void checkSingleRow2DMixedBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         byte[] encoded = encoder.encode(new boolean[][] {{false, true, true, true}});
         assertEquals(
@@ -240,7 +240,7 @@ public class RunLengthEncodingEncoderTest {
     }
 
     @Test
-    public void checkNonRectangular() throws KlvParseException {
+    public void checkNonRectangularBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         boolean[][] input =
                 new boolean[][] {
@@ -275,19 +275,19 @@ public class RunLengthEncodingEncoderTest {
     }
 
     @Test(expectedExceptions = KlvParseException.class)
-    public void checkBadRowDimension() throws KlvParseException {
+    public void checkBadRowDimensionBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         encoder.encode(new boolean[0][1]);
     }
 
     @Test(expectedExceptions = KlvParseException.class)
-    public void checkBadColumnDimension() throws KlvParseException {
+    public void checkBadColumnDimensionBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         encoder.encode(new boolean[1][0]);
     }
 
     @Test(expectedExceptions = KlvParseException.class)
-    public void checkBadBothDimensions() throws KlvParseException {
+    public void checkBadBothDimensionsBoolean() throws KlvParseException {
         RunLengthEncodingEncoder encoder = new RunLengthEncodingEncoder();
         encoder.encode(new boolean[0][0]);
     }


### PR DESCRIPTION
## Motivation and Context

Adds implementations for ST 1303 Multi Dimensional Array Pack that we don't yet support.

 - Boolean 1D decoding (Natural Format, Boolean Array, Run length encoding)
 - Boolean 1D encoding (Natural Format, Boolean Array)
 - Floating Point 1D decoding (Run length encoding)
 - Floating Point 2D decoding (Run length encoding)
 - Signed 1D integer decoding (Run length encoding)
 - Signed 2D integer decoding (Run length encoding)
 - Unsigned 1D integer decoding (Run length encoding)
 - Unsigned 2D integer decoding (Run length encoding)

The decoding is important for interoperability in case someone decides to use that. The Boolean 1D stuff is just for completeness (and is probably not useful).

Resolves #198 (which I've dropped RLE encoding - as opposed to decoding -  support out of - its difficult to do in general, and probably requires domain-specific knowledge of the nature of the data being encoded to be really efficient).

## Description

Adds implementations consistent with existing code. Updated documentation and tests.

## How Has This Been Tested?

Unit tests only. The test cases from ST 1303.2 are now used.

## Screenshots (if appropriate):

N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

