### PR TITLE
2.x: ensure UDS parsing gets all parts

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/UdsParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/UdsParser.java
@@ -23,7 +23,7 @@ public class UdsParser {
         List<UdsField> fields = new ArrayList<>();
 
         int offset = start;
-        while (offset < length) {
+        while (offset < start + length) {
             // Get the Key (UL)
             UniversalLabel key =
                     new UniversalLabel(

--- a/api/src/test/java/org/jmisb/api/klv/UdsParserTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/UdsParserTest.java
@@ -27,4 +27,57 @@ public class UdsParserTest {
                 });
         assertEquals(field.getValue(), new byte[] {0x04, 0x03, 0x02});
     }
+
+    @Test
+    public void checkParseWithOffset() throws KlvParseException {
+        byte[] bytes =
+                new byte[] {
+                    0x06,
+                    0x0E,
+                    0x2B,
+                    0x34,
+                    0x02,
+                    0x0B,
+                    0x01,
+                    0x01,
+                    0x0E,
+                    0x01,
+                    0x03,
+                    0x01,
+                    0x02,
+                    0x00,
+                    0x00,
+                    0x00,
+                    (byte) 0x81,
+                    0x12,
+                    0x06,
+                    0x0E,
+                    0x2B,
+                    0x34,
+                    0x02,
+                    0x0B,
+                    0x01,
+                    0x01,
+                    0x0E,
+                    0x01,
+                    0x03,
+                    0x01,
+                    0x02,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x01,
+                    0x02
+                };
+        List<UdsField> fields = UdsParser.parseFields(bytes, 18, 18);
+        assertEquals(fields.size(), 1);
+        UdsField field = fields.get(0);
+        assertEquals(
+                field.getKey().getBytes(),
+                new byte[] {
+                    0x06, 0x0E, 0x2B, 0x34, 0x02, 0x0B, 0x01, 0x01, 0x0E, 0x01, 0x03, 0x01, 0x02,
+                    0x00, 0x00, 0x00
+                });
+        assertEquals(field.getValue(), new byte[] {0x02});
+    }
 }

--- a/st0602/src/main/java/org/jmisb/st0602/AnnotationMetadataUniversalSet.java
+++ b/st0602/src/main/java/org/jmisb/st0602/AnnotationMetadataUniversalSet.java
@@ -54,10 +54,8 @@ public class AnnotationMetadataUniversalSet implements IMisbMessage {
     public AnnotationMetadataUniversalSet(byte[] bytes) throws KlvParseException {
         // Parse the length field
         BerField lengthField = BerDecoder.decode(bytes, UniversalLabel.LENGTH, false);
-        int lengthLength = lengthField.getLength();
-        int offset = UniversalLabel.LENGTH + lengthLength;
-        int valueLength = lengthField.getValue();
-        List<UdsField> fields = UdsParser.parseFields(bytes, offset, valueLength);
+        int offset = UniversalLabel.LENGTH + lengthField.getLength();
+        List<UdsField> fields = UdsParser.parseFields(bytes, offset, lengthField.getValue());
         for (UdsField field : fields) {
             try {
                 AnnotationMetadataKey key = AnnotationMetadataKey.getKey(field.getKey());

--- a/st0602/src/test/java/org/jmisb/st0602/AnnotationMetadataUniversalSetTest.java
+++ b/st0602/src/test/java/org/jmisb/st0602/AnnotationMetadataUniversalSetTest.java
@@ -177,6 +177,141 @@ public class AnnotationMetadataUniversalSetTest {
                 "3");
     }
 
+    @Test
+    public void parseBytesZOrder() throws KlvParseException {
+        byte[] bytes =
+                new byte[] {
+                    (byte) 0x06,
+                    (byte) 0x0e,
+                    (byte) 0x2b,
+                    (byte) 0x34,
+                    (byte) 0x02,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x0e,
+                    (byte) 0x01,
+                    (byte) 0x03,
+                    (byte) 0x03,
+                    (byte) 0x01,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    // This use of BER long form is test fix for broken parsing.
+                    (byte) 0x81,
+                    (byte) 0x39,
+                    (byte) 0x06,
+                    (byte) 0x0e,
+                    (byte) 0x2b,
+                    (byte) 0x34,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x03,
+                    (byte) 0x03,
+                    (byte) 0x01,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x04,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x03,
+                    (byte) 0x06,
+                    (byte) 0x0e,
+                    (byte) 0x2b,
+                    (byte) 0x34,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x05,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x02,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x01,
+                    (byte) 0x31,
+                    (byte) 0x06,
+                    (byte) 0x0E,
+                    (byte) 0x2B,
+                    (byte) 0x34,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x01,
+                    (byte) 0x0E,
+                    (byte) 0x01,
+                    (byte) 0x02,
+                    (byte) 0x05,
+                    (byte) 0x06,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x00,
+                    (byte) 0x01,
+                    (byte) 0x02
+                };
+        AnnotationMetadataUniversalSet universalSet = new AnnotationMetadataUniversalSet(bytes);
+        assertEquals(universalSet.displayHeader(), "ST 0602, ID: 3");
+        assertEquals(
+                universalSet.getUniversalLabel(),
+                AnnotationMetadataUniversalSet.AnnotationUniversalSetUl);
+        assertEquals(universalSet.getIdentifiers().size(), 3);
+        assertEquals(universalSet.getMetadataKeys().size(), 3);
+        assertTrue(universalSet.getIdentifiers().contains(AnnotationMetadataKey.EventIndication));
+        assertTrue(universalSet.getMetadataKeys().contains(AnnotationMetadataKey.EventIndication));
+        assertEquals(
+                universalSet.getField(AnnotationMetadataKey.EventIndication).getDisplayName(),
+                "Event Indication");
+        assertEquals(
+                universalSet
+                        .getField((IKlvKey) AnnotationMetadataKey.EventIndication)
+                        .getDisplayName(),
+                "Event Indication");
+        assertEquals(
+                universalSet.getField(AnnotationMetadataKey.EventIndication).getDisplayableValue(),
+                "NEW");
+        assertTrue(
+                universalSet
+                        .getIdentifiers()
+                        .contains(AnnotationMetadataKey.LocallyUniqueIdentifier));
+        assertTrue(
+                universalSet
+                        .getMetadataKeys()
+                        .contains(AnnotationMetadataKey.LocallyUniqueIdentifier));
+        assertEquals(
+                universalSet
+                        .getField(AnnotationMetadataKey.LocallyUniqueIdentifier)
+                        .getDisplayName(),
+                "Locally Unique Identifier");
+        assertEquals(
+                universalSet
+                        .getField((IKlvKey) AnnotationMetadataKey.LocallyUniqueIdentifier)
+                        .getDisplayName(),
+                "Locally Unique Identifier");
+        assertEquals(
+                universalSet
+                        .getField(AnnotationMetadataKey.LocallyUniqueIdentifier)
+                        .getDisplayableValue(),
+                "3");
+        assertTrue(universalSet.getIdentifiers().contains(AnnotationMetadataKey.ZOrder));
+        assertTrue(universalSet.getMetadataKeys().contains(AnnotationMetadataKey.ZOrder));
+        assertEquals(
+                universalSet.getField(AnnotationMetadataKey.ZOrder).getDisplayName(), "Z-Order");
+        assertEquals(
+                universalSet.getField((IKlvKey) AnnotationMetadataKey.ZOrder).getDisplayName(),
+                "Z-Order");
+        assertEquals(
+                universalSet.getField(AnnotationMetadataKey.ZOrder).getDisplayableValue(), "2");
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void frameMessageNested() throws KlvParseException {
         Map<AnnotationMetadataKey, IAnnotationMetadataValue> map = sampleDeleteMessageValues();


### PR DESCRIPTION
## Motivation and Context

This corrects a bug in Universal Set parsing, when the offset (usually the top level UL + the overall length) is at least as large the last key+length+value length. 

Relates to #396 (this is the 2.x part)

## Description
Update implementation to match API description.

## How Has This Been Tested?
Added unit tests at UDSParser and ST 0602 levels.

Verified in viewer with the annotation generator output.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

