### PR TITLE
klv: fix Universal Set parsing with offsets

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/UdsParser.java
+++ b/api/src/main/java/org/jmisb/api/klv/UdsParser.java
@@ -23,7 +23,7 @@ public class UdsParser {
         List<UdsField> fields = new ArrayList<>();
 
         int offset = start;
-        while (offset < length) {
+        while (offset < start + length) {
             // Get the Key (UL)
             UniversalLabel key =
                     new UniversalLabel(

--- a/api/src/test/java/org/jmisb/api/klv/UdsParserTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/UdsParserTest.java
@@ -1,0 +1,64 @@
+package org.jmisb.api.klv;
+
+import static org.testng.Assert.*;
+
+import java.util.List;
+import org.jmisb.api.common.KlvParseException;
+import org.testng.annotations.Test;
+
+/** Unit tests for UdsParser. */
+public class UdsParserTest {
+
+    @Test
+    public void checkParseWithOffset() throws KlvParseException {
+        byte[] bytes =
+                new byte[] {
+                    0x06,
+                    0x0E,
+                    0x2B,
+                    0x34,
+                    0x02,
+                    0x0B,
+                    0x01,
+                    0x01,
+                    0x0E,
+                    0x01,
+                    0x03,
+                    0x01,
+                    0x02,
+                    0x00,
+                    0x00,
+                    0x00,
+                    (byte) 0x81,
+                    0x12,
+                    0x06,
+                    0x0E,
+                    0x2B,
+                    0x34,
+                    0x02,
+                    0x0B,
+                    0x01,
+                    0x01,
+                    0x0E,
+                    0x01,
+                    0x03,
+                    0x01,
+                    0x02,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x01,
+                    0x02
+                };
+        List<UdsField> fields = UdsParser.parseFields(bytes, 18, 18);
+        assertEquals(fields.size(), 1);
+        UdsField field = fields.get(0);
+        assertEquals(
+                field.getKey().getBytes(),
+                new byte[] {
+                    0x06, 0x0E, 0x2B, 0x34, 0x02, 0x0B, 0x01, 0x01, 0x0E, 0x01, 0x03, 0x01, 0x02,
+                    0x00, 0x00, 0x00
+                });
+        assertEquals(field.getValue(), new byte[] {0x02});
+    }
+}


### PR DESCRIPTION
## Motivation and Context
This corrects a bug in Universal Set parsing, when the offset (usually the top level UL + the overall length) is at least as large the last key+length+value length.

Resolves #396

## Description
Update implementation to match API description.

## How Has This Been Tested?

Added unit test for `UdsParser`.

Most of the testing was against the 2.x branch (see #397)

## Screenshots (if appropriate):

N/A.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

