### PR TITLE
2.x: migrate use of ArrayUtils to ArrayBuilder

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/ArrayBuilder.java
+++ b/api/src/main/java/org/jmisb/api/klv/ArrayBuilder.java
@@ -1,9 +1,11 @@
 package org.jmisb.api.klv;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import org.jmisb.core.klv.ArrayUtils;
+import java.util.UUID;
 import org.jmisb.core.klv.PrimitiveConverter;
+import org.jmisb.core.klv.UuidUtils;
 
 /**
  * Builder for linear byte arrays.
@@ -14,6 +16,7 @@ import org.jmisb.core.klv.PrimitiveConverter;
  * <p>It supports method chaining to make the code more fluent.
  */
 public class ArrayBuilder {
+
     private final List<byte[]> chunks;
     private int numBytesInChunks = 0;
     private byte bitBuffer = 0;
@@ -87,6 +90,7 @@ public class ArrayBuilder {
         bitBuffer = 0x00;
         bitPosition = 0;
     }
+
     /**
      * Append an unsigned integer encoded as a BER-OID value.
      *
@@ -176,6 +180,16 @@ public class ArrayBuilder {
     }
 
     /**
+     * Append a UUID.
+     *
+     * @param uuid the value to append
+     * @return this instance, to support method chaining.
+     */
+    public ArrayBuilder append(final UUID uuid) {
+        return append(UuidUtils.uuidToArray(uuid));
+    }
+
+    /**
      * Append a Universal Label.
      *
      * @param universalLabel the value to append
@@ -235,6 +249,7 @@ public class ArrayBuilder {
         chunks.add(0, encodedBytes);
         return this;
     }
+
     /**
      * Build the byte array from the appended parts.
      *
@@ -242,6 +257,23 @@ public class ArrayBuilder {
      */
     public byte[] toBytes() {
         flushBitBuffer();
-        return ArrayUtils.arrayFromChunks(chunks, numBytesInChunks);
+        return arrayFromChunks(this.chunks, this.numBytesInChunks);
+    }
+
+    /**
+     * Concatenate a collection of byte arrays (chunks) sequentially into one big array
+     *
+     * @param chunks The collection of chunks
+     * @param totalLength The total number of bytes in all chunks
+     * @return New array concatenating all chunks
+     */
+    public static byte[] arrayFromChunks(Collection<byte[]> chunks, int totalLength) {
+        byte[] array = new byte[totalLength];
+        int i = 0;
+        for (byte[] chunk : chunks) {
+            System.arraycopy(chunk, 0, array, i, chunk.length);
+            i += chunk.length;
+        }
+        return array;
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/st1204/CoreIdentifier.java
+++ b/api/src/main/java/org/jmisb/api/klv/st1204/CoreIdentifier.java
@@ -2,12 +2,11 @@ package org.jmisb.api.klv.st1204;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
 import org.jmisb.api.klv.BerField;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.core.klv.UuidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -463,28 +462,21 @@ public class CoreIdentifier {
      * @return byte array representation of this identifier.
      */
     public byte[] getRawBytesRepresentation() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
-        chunks.add(new byte[] {(byte) version});
-        len += 1;
-        chunks.add(new byte[] {(byte) buildUsage()});
-        len += 1;
+        ArrayBuilder builder = new ArrayBuilder();
+        builder.appendByte((byte) version);
+        builder.appendByte((byte) buildUsage());
         if (sensorUUID != null) {
-            chunks.add(UuidUtils.uuidToArray(sensorUUID));
-            len += 16;
+            builder.append(sensorUUID);
         }
         if (platformUUID != null) {
-            chunks.add(UuidUtils.uuidToArray(platformUUID));
-            len += 16;
+            builder.append(platformUUID);
         }
         if (windowUUID != null) {
-            chunks.add(UuidUtils.uuidToArray(windowUUID));
-            len += 16;
+            builder.append(windowUUID);
         }
         if (minorUUID != null) {
-            chunks.add(UuidUtils.uuidToArray(minorUUID));
-            len += 16;
+            builder.append(minorUUID);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return builder.toBytes();
     }
 }

--- a/api/src/test/java/org/jmisb/api/klv/ArrayBuilderTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/ArrayBuilderTest.java
@@ -2,6 +2,8 @@ package org.jmisb.api.klv;
 
 import static org.testng.Assert.*;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import org.testng.annotations.Test;
 
 /** Unit tests for the ArrayBuilder class. */
@@ -188,5 +190,21 @@ public class ArrayBuilderTest {
         assertNotNull(bytes);
         assertEquals(bytes.length, 1);
         assertEquals(bytes, new byte[] {(byte) 0xFF});
+    }
+
+    @Test
+    public void checkBytesToArray() {
+        Collection<byte[]> chunks = new ArrayList<>();
+        byte[] chunk0 = new byte[] {0x0a, 0x0b};
+        int len = chunk0.length;
+        chunks.add(chunk0);
+        byte[] chunk1 = new byte[] {0x01, 0x02};
+        len += chunk1.length;
+        chunks.add(chunk1);
+        byte[] chunk2 = new byte[] {0x09, 0x08, 0x07};
+        len += chunk2.length;
+        chunks.add(chunk2);
+        byte[] a = ArrayBuilder.arrayFromChunks(chunks, len);
+        assertEquals(a, new byte[] {0x0a, 0x0b, 0x01, 0x02, 0x09, 0x08, 0x07});
     }
 }

--- a/core/src/main/java/org/jmisb/core/klv/ArrayUtils.java
+++ b/core/src/main/java/org/jmisb/core/klv/ArrayUtils.java
@@ -1,6 +1,5 @@
 package org.jmisb.core.klv;
 
-import java.util.Collection;
 import java.util.Formatter;
 
 /** Utility methods for arrays */
@@ -53,22 +52,5 @@ public class ArrayUtils {
             }
         }
         return formatter.toString();
-    }
-
-    /**
-     * Concatenate a collection of byte arrays (chunks) sequentially into one big array
-     *
-     * @param chunks The collection of chunks
-     * @param totalLength The total number of bytes in all chunks
-     * @return New array concatenating all chunks
-     */
-    public static byte[] arrayFromChunks(Collection<byte[]> chunks, int totalLength) {
-        byte[] array = new byte[totalLength];
-        int i = 0;
-        for (byte[] chunk : chunks) {
-            System.arraycopy(chunk, 0, array, i, chunk.length);
-            i += chunk.length;
-        }
-        return array;
     }
 }

--- a/core/src/test/java/org/jmisb/core/klv/ArrayUtilsTest.java
+++ b/core/src/test/java/org/jmisb/core/klv/ArrayUtilsTest.java
@@ -2,8 +2,6 @@ package org.jmisb.core.klv;
 
 import static org.testng.Assert.*;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import org.testng.annotations.Test;
 
 /** Tests for the ArrayUtils. */
@@ -144,21 +142,5 @@ public class ArrayUtilsTest {
                         + "0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, "
                         + System.lineSeparator()
                         + "0x10, 0xff, ");
-    }
-
-    @Test
-    public void checkBytesToArray() {
-        Collection<byte[]> chunks = new ArrayList<>();
-        byte[] chunk0 = new byte[] {0x0a, 0x0b};
-        int len = chunk0.length;
-        chunks.add(chunk0);
-        byte[] chunk1 = new byte[] {0x01, 0x02};
-        len += chunk1.length;
-        chunks.add(chunk1);
-        byte[] chunk2 = new byte[] {0x09, 0x08, 0x07};
-        len += chunk2.length;
-        chunks.add(chunk2);
-        byte[] a = ArrayUtils.arrayFromChunks(chunks, len);
-        assertEquals(a, new byte[] {0x0a, 0x0b, 0x01, 0x02, 0x09, 0x08, 0x07});
     }
 }

--- a/st0102/src/main/java/org/jmisb/st0102/localset/SecurityMetadataLocalSet.java
+++ b/st0102/src/main/java/org/jmisb/st0102/localset/SecurityMetadataLocalSet.java
@@ -1,7 +1,5 @@
 package org.jmisb.st0102.localset;
 
-import static org.jmisb.core.klv.ArrayUtils.arrayFromChunks;
-
 import java.time.LocalDate;
 import java.util.*;
 import org.jmisb.api.common.InvalidDataHandler;
@@ -96,9 +94,7 @@ public class SecurityMetadataLocalSet extends SecurityMetadataMessage {
 
     @Override
     public byte[] frameMessage(boolean isNested) {
-        // List representing all tags and values as primitive byte arrays. Avoids boxing/unboxing
-        // individual bytes for efficiency.
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder builder = new ArrayBuilder();
 
         // Add all values from map
         for (Map.Entry<SecurityMetadataKey, ISecurityMetadataValue> entry : map.entrySet()) {
@@ -106,36 +102,16 @@ public class SecurityMetadataLocalSet extends SecurityMetadataMessage {
             ISecurityMetadataValue value = entry.getValue();
             byte[] bytes = value.getBytes();
             if (bytes != null && bytes.length > 0) {
-                chunks.add(new byte[] {(byte) key.getIdentifier()});
-                chunks.add(BerEncoder.encode(bytes.length));
-                chunks.add(bytes.clone());
+                builder.appendByte((byte) key.getIdentifier());
+                builder.appendAsBerLength(bytes.length);
+                builder.append(bytes.clone());
             }
         }
-
-        // Figure out value length
-        int valueLength = 0;
-        for (byte[] chunk : chunks) {
-            valueLength += chunk.length;
+        if (!isNested) {
+            builder.prependLength();
+            builder.prepend(SecurityMetadataLocalSetUl);
         }
-
-        // Determine total length
-        int totalLength;
-        if (isNested) {
-            totalLength = valueLength;
-        } else {
-            // Prepend length field into front of the list
-            byte[] lengthField = BerEncoder.encode(valueLength);
-            chunks.add(0, lengthField);
-
-            // Prepend key field (UL) into front of the list
-            chunks.add(0, SecurityMetadataLocalSetUl.getBytes());
-
-            // Compute full message length
-            totalLength = UniversalLabel.LENGTH + lengthField.length + valueLength;
-        }
-
-        // Allocate array and write all chunks
-        return arrayFromChunks(chunks, totalLength);
+        return builder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0601/ControlCommand.java
+++ b/st0601/src/main/java/org/jmisb/st0601/ControlCommand.java
@@ -1,14 +1,10 @@
 package org.jmisb.st0601;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.Ber;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
@@ -109,23 +105,16 @@ public class ControlCommand implements IUasDatalinkValue {
 
     @Override
     public byte[] getBytes() {
-        List<byte[]> chunks = new ArrayList<>();
-        int totalLength = 0;
-        byte[] idBytes = BerEncoder.encode(id, Ber.OID);
-        chunks.add(idBytes);
-        totalLength += idBytes.length;
+        ArrayBuilder builder = new ArrayBuilder();
+        builder.appendAsOID(id);
         byte[] commandBytes = commandText.getBytes(StandardCharsets.UTF_8);
-        byte[] commandLengthBytes = BerEncoder.encode(commandBytes.length);
-        chunks.add(commandLengthBytes);
-        totalLength += commandLengthBytes.length;
-        chunks.add(commandBytes);
-        totalLength += commandBytes.length;
+        builder.appendAsBerLength(commandBytes.length);
+        builder.append(commandBytes);
         if (timestampIsValid) {
             byte[] timestampBytes = PrimitiveConverter.int64ToBytes(timestamp);
-            chunks.add(timestampBytes);
-            totalLength += timestampBytes.length;
+            builder.append(timestampBytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, totalLength);
+        return builder.toBytes();
     }
 
     /**

--- a/st0601/src/main/java/org/jmisb/st0601/ControlCommandVerification.java
+++ b/st0601/src/main/java/org/jmisb/st0601/ControlCommandVerification.java
@@ -2,11 +2,9 @@ package org.jmisb.st0601;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.jmisb.api.klv.Ber;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
-import org.jmisb.core.klv.ArrayUtils;
 
 /**
  * Control Command Verification List (ST 0601 Item 116).
@@ -60,14 +58,12 @@ public class ControlCommandVerification implements IUasDatalinkValue {
 
     @Override
     public byte[] getBytes() {
-        List<byte[]> chunks = new ArrayList<>();
-        int totalLength = 0;
-        for (int id : commands) {
-            byte[] idBytes = BerEncoder.encode(id, Ber.OID);
-            totalLength += idBytes.length;
-            chunks.add(idBytes);
-        }
-        return ArrayUtils.arrayFromChunks(chunks, totalLength);
+        ArrayBuilder builder = new ArrayBuilder();
+        commands.forEach(
+                id -> {
+                    builder.appendAsOID(id);
+                });
+        return builder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0601/CountryCodes.java
+++ b/st0601/src/main/java/org/jmisb/st0601/CountryCodes.java
@@ -1,18 +1,15 @@
 package org.jmisb.st0601;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0102.CountryCodingMethod;
 import org.jmisb.st0102.CountryCodingMethodUtilities;
 
@@ -155,48 +152,30 @@ public class CountryCodes implements IUasDatalinkValue, INestedKlvValue {
 
     @Override
     public byte[] getBytes() {
-        List<byte[]> chunks = new ArrayList<>();
-        int totalLength = 0;
+        ArrayBuilder builder = new ArrayBuilder();
         byte[] codingMethodBytes =
                 new byte[] {CountryCodingMethodUtilities.getValueForCodingMethod(codingMethod)};
-        byte[] codingMethodLengthBytes = BerEncoder.encode(codingMethodBytes.length);
-        chunks.add(codingMethodLengthBytes);
-        totalLength += codingMethodLengthBytes.length;
-        chunks.add(codingMethodBytes);
-        totalLength += codingMethodBytes.length;
+        builder.appendAsBerLength(codingMethodBytes.length);
+        builder.append(codingMethodBytes);
 
         byte[] overflightCountryBytes = overflightCountry.getBytes(StandardCharsets.UTF_8);
-        byte[] overflightCountryLengthBytes = BerEncoder.encode(overflightCountryBytes.length);
-        chunks.add(overflightCountryLengthBytes);
-        totalLength += overflightCountryLengthBytes.length;
-        chunks.add(overflightCountryBytes);
-        totalLength += overflightCountryBytes.length;
-
+        builder.appendAsBerLength(overflightCountryBytes.length);
+        builder.append(overflightCountryBytes);
         byte[] operatorCountryBytes = operatorCountry.getBytes(StandardCharsets.UTF_8);
         byte[] countryOfManufactureBytes = countryOfManufacture.getBytes(StandardCharsets.UTF_8);
-
         if ((operatorCountryBytes.length == 0) && (countryOfManufactureBytes.length == 0)) {
             // truncate here
-            return ArrayUtils.arrayFromChunks(chunks, totalLength);
+            return builder.toBytes();
         }
-        byte[] operatorCountryLengthBytes = BerEncoder.encode(operatorCountryBytes.length);
-        chunks.add(operatorCountryLengthBytes);
-        totalLength += operatorCountryLengthBytes.length;
-        chunks.add(operatorCountryBytes);
-        totalLength += operatorCountryBytes.length;
-
+        builder.appendAsBerLength(operatorCountryBytes.length);
+        builder.append(operatorCountryBytes);
         if (countryOfManufactureBytes.length == 0) {
             // truncate here
-            return ArrayUtils.arrayFromChunks(chunks, totalLength);
+            return builder.toBytes();
         }
-        byte[] countryOfManufactureLengthBytes =
-                BerEncoder.encode(countryOfManufactureBytes.length);
-        chunks.add(countryOfManufactureLengthBytes);
-        totalLength += countryOfManufactureLengthBytes.length;
-        chunks.add(countryOfManufactureBytes);
-        totalLength += countryOfManufactureBytes.length;
-
-        return ArrayUtils.arrayFromChunks(chunks, totalLength);
+        builder.appendAsBerLength(countryOfManufactureBytes.length);
+        builder.append(countryOfManufactureBytes);
+        return builder.toBytes();
     }
 
     /**

--- a/st0601/src/main/java/org/jmisb/st0601/ImageHorizonPixelPack.java
+++ b/st0601/src/main/java/org/jmisb/st0601/ImageHorizonPixelPack.java
@@ -1,9 +1,7 @@
 package org.jmisb.st0601;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import org.jmisb.core.klv.ArrayUtils;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.core.klv.PrimitiveConverter;
 
 /**
@@ -121,13 +119,13 @@ public class ImageHorizonPixelPack implements IUasDatalinkValue {
                 || Double.isFinite(this.longitude0)
                 || Double.isFinite(this.latitude1)
                 || Double.isFinite(this.longitude1)) {
-            List<byte[]> chunks = new ArrayList<>();
-            chunks.add(getMandatoryBytes());
-            chunks.add(getLatitudeBytes(latitude0));
-            chunks.add(getLongitudeBytes(longitude0));
-            chunks.add(getLatitudeBytes(latitude1));
-            chunks.add(getLongitudeBytes(longitude1));
-            return ArrayUtils.arrayFromChunks(chunks, 20);
+            ArrayBuilder builder = new ArrayBuilder();
+            builder.append(getMandatoryBytes());
+            builder.append(getLatitudeBytes(latitude0));
+            builder.append(getLongitudeBytes(longitude0));
+            builder.append(getLatitudeBytes(latitude1));
+            builder.append(getLongitudeBytes(longitude1));
+            return builder.toBytes();
         } else {
             return getMandatoryBytes();
         }

--- a/st0601/src/main/java/org/jmisb/st0601/SensorFrameRate.java
+++ b/st0601/src/main/java/org/jmisb/st0601/SensorFrameRate.java
@@ -1,12 +1,8 @@
 package org.jmisb.st0601;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.jmisb.api.klv.Ber;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
-import org.jmisb.core.klv.ArrayUtils;
 
 /**
  * Sensor Frame Rate (ST 0601 Item 127).
@@ -69,17 +65,12 @@ public class SensorFrameRate implements IUasDatalinkValue {
 
     @Override
     public byte[] getBytes() {
-        List<byte[]> chunks = new ArrayList<>();
-        int totalLength = 0;
-        byte[] numeratorBytes = BerEncoder.encode(numerator, Ber.OID);
-        chunks.add(numeratorBytes);
-        totalLength += numeratorBytes.length;
+        ArrayBuilder builder = new ArrayBuilder();
+        builder.appendAsOID(numerator);
         if (denominator != 1) {
-            byte[] denominatorBytes = BerEncoder.encode(denominator, Ber.OID);
-            chunks.add(denominatorBytes);
-            totalLength += denominatorBytes.length;
+            builder.appendAsOID(denominator);
         }
-        return ArrayUtils.arrayFromChunks(chunks, totalLength);
+        return builder.toBytes();
     }
 
     /**

--- a/st0601/src/main/java/org/jmisb/st0806/poiaoi/RvtAoiLocalSet.java
+++ b/st0601/src/main/java/org/jmisb/st0806/poiaoi/RvtAoiLocalSet.java
@@ -1,19 +1,17 @@
 package org.jmisb.st0806.poiaoi;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0806.IRvtMetadataValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,20 +122,15 @@ public class RvtAoiLocalSet implements IRvtMetadataValue, INestedKlvValue {
      */
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder builder = new ArrayBuilder();
         for (RvtAoiMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getIdentifier()});
-            len += 1;
+            builder.appendByte((byte) tag.getIdentifier());
             IRvtPoiAoiMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            builder.appendAsBerLength(bytes.length);
+            builder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return builder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0806/poiaoi/RvtPoiLocalSet.java
+++ b/st0601/src/main/java/org/jmisb/st0806/poiaoi/RvtPoiLocalSet.java
@@ -1,19 +1,17 @@
 package org.jmisb.st0806.poiaoi;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0806.IRvtMetadataValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,20 +122,15 @@ public class RvtPoiLocalSet implements IRvtMetadataValue, INestedKlvValue {
      */
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder builder = new ArrayBuilder();
         for (RvtPoiMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getIdentifier()});
-            len += 1;
+            builder.appendByte((byte) tag.getIdentifier());
             IRvtPoiAoiMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            builder.appendAsBerLength(bytes.length);
+            builder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return builder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0806/userdefined/RvtUserDefinedLocalSet.java
+++ b/st0601/src/main/java/org/jmisb/st0806/userdefined/RvtUserDefinedLocalSet.java
@@ -1,19 +1,17 @@
 package org.jmisb.st0806.userdefined;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0806.IRvtMetadataValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,20 +108,15 @@ public class RvtUserDefinedLocalSet implements IRvtMetadataValue, INestedKlvValu
      */
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder builder = new ArrayBuilder();
         for (RvtUserDefinedMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getIdentifier()});
-            len += 1;
+            builder.appendByte((byte) tag.getIdentifier());
             IRvtUserDefinedMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            builder.appendAsBerLength(bytes.length);
+            builder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return builder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/AlgorithmSeries.java
+++ b/st0601/src/main/java/org/jmisb/st0903/AlgorithmSeries.java
@@ -5,13 +5,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.algorithm.AlgorithmLS;
 import org.jmisb.st0903.algorithm.AlgorithmMetadataKey;
 import org.jmisb.st0903.shared.AlgorithmId;
@@ -68,17 +67,13 @@ public class AlgorithmSeries implements IVmtiMetadataValue, INestedKlvValue {
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder builder = new ArrayBuilder();
         for (AlgorithmLS localSet : localSets) {
             byte[] localSetBytes = localSet.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(localSetBytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(localSetBytes);
-            len += localSetBytes.length;
+            builder.appendAsBerLength(localSetBytes.length);
+            builder.append(localSetBytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return builder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/OntologySeries.java
+++ b/st0601/src/main/java/org/jmisb/st0903/OntologySeries.java
@@ -5,13 +5,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.ontology.OntologyId;
 import org.jmisb.st0903.ontology.OntologyLS;
 import org.jmisb.st0903.ontology.OntologyMetadataKey;
@@ -69,17 +68,13 @@ public class OntologySeries implements IVmtiMetadataValue, IVTrackMetadataValue,
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder builder = new ArrayBuilder();
         for (OntologyLS localSet : localSets) {
             byte[] bytes = localSet.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            builder.appendAsBerLength(bytes.length);
+            builder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return builder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/VTargetSeries.java
+++ b/st0601/src/main/java/org/jmisb/st0903/VTargetSeries.java
@@ -7,13 +7,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.shared.EncodingMode;
 import org.jmisb.st0903.vtarget.TargetIdentifierKey;
 import org.jmisb.st0903.vtarget.VTargetPack;
@@ -82,17 +81,13 @@ public class VTargetSeries implements IVmtiMetadataValue, INestedKlvValue {
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder builder = new ArrayBuilder();
         for (VTargetPack vtargetPack : targetPacks.values()) {
             byte[] localSetBytes = vtargetPack.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(localSetBytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(localSetBytes);
-            len += localSetBytes.length;
+            builder.appendAsBerLength(localSetBytes.length);
+            builder.append(localSetBytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return builder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/algorithm/AlgorithmLS.java
+++ b/st0601/src/main/java/org/jmisb/st0903/algorithm/AlgorithmLS.java
@@ -1,6 +1,5 @@
 package org.jmisb.st0903.algorithm;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -8,13 +7,12 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.AlgorithmId;
 import org.jmisb.st0903.shared.VmtiTextString;
@@ -124,20 +122,15 @@ public class AlgorithmLS implements IKlvValue, INestedKlvValue {
      * @return byte array with the encoded local set.
      */
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (AlgorithmMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getTag()});
-            len += 1;
+            arrayBuilder.appendByte((byte) tag.getTag());
             IVmtiMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            arrayBuilder.appendAsBerLength(bytes.length);
+            arrayBuilder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/ontology/OntologyLS.java
+++ b/st0601/src/main/java/org/jmisb/st0903/ontology/OntologyLS.java
@@ -1,6 +1,5 @@
 package org.jmisb.st0903.ontology;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -8,13 +7,12 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.VmtiTextString;
 import org.jmisb.st0903.shared.VmtiUri;
@@ -130,20 +128,15 @@ public class OntologyLS implements IKlvValue, INestedKlvValue {
      * @return byte array with the encoded local set.
      */
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (OntologyMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getTag()});
-            len += 1;
+            arrayBuilder.appendByte((byte) tag.getTag());
             IVmtiMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            arrayBuilder.appendAsBerLength(bytes.length);
+            arrayBuilder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/vchip/VChipLS.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vchip/VChipLS.java
@@ -1,6 +1,5 @@
 package org.jmisb.st0903.vchip;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -8,10 +7,9 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.VmtiTextString;
 import org.jmisb.st0903.shared.VmtiUri;
@@ -111,19 +109,14 @@ public class VChipLS {
      * @return byte array with the encoded local set.
      */
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (VChipMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getTag()});
-            len += 1;
+            arrayBuilder.appendByte((byte) tag.getTag());
             IVmtiMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            arrayBuilder.appendAsBerLength(bytes.length);
+            arrayBuilder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 }

--- a/st0601/src/main/java/org/jmisb/st0903/vfeature/VFeatureLS.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vfeature/VFeatureLS.java
@@ -1,6 +1,5 @@
 package org.jmisb.st0903.vfeature;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -8,10 +7,9 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.VmtiTextString;
 import org.jmisb.st0903.shared.VmtiUri;
@@ -107,19 +105,14 @@ public class VFeatureLS {
      * @return byte array with the encoded local set.
      */
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (VFeatureMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getTag()});
-            len += 1;
+            arrayBuilder.appendByte((byte) tag.getTag());
             IVmtiMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            arrayBuilder.appendAsBerLength(bytes.length);
+            arrayBuilder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 }

--- a/st0601/src/main/java/org/jmisb/st0903/vmask/PixelPolygon.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vmask/PixelPolygon.java
@@ -3,10 +3,9 @@ package org.jmisb.st0903.vmask;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.core.klv.PrimitiveConverter;
 import org.jmisb.st0903.IVmtiMetadataValue;
 
@@ -67,17 +66,13 @@ public class PixelPolygon implements IVmtiMetadataValue {
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (Long point : getPolygon()) {
             byte[] pointBytes = PrimitiveConverter.uintToVariableBytesV6(point);
-            byte[] lengthBytes = BerEncoder.encode(pointBytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(pointBytes);
-            len += pointBytes.length;
+            arrayBuilder.appendAsBerLength(pointBytes.length);
+            arrayBuilder.append(pointBytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/vmask/VMaskLS.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vmask/VMaskLS.java
@@ -1,6 +1,5 @@
 package org.jmisb.st0903.vmask;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -8,10 +7,9 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,19 +101,14 @@ public class VMaskLS {
      * @return byte array with the encoded local set.
      */
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (VMaskMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getTag()});
-            len += 1;
+            arrayBuilder.appendByte((byte) tag.getTag());
             IVmtiMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            arrayBuilder.appendAsBerLength(bytes.length);
+            arrayBuilder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 }

--- a/st0601/src/main/java/org/jmisb/st0903/vobject/VObjectLS.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vobject/VObjectLS.java
@@ -1,6 +1,5 @@
 package org.jmisb.st0903.vobject;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -8,10 +7,9 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.VmtiTextString;
 import org.jmisb.st0903.shared.VmtiUri;
@@ -113,19 +111,14 @@ public class VObjectLS {
      * @return byte array with the encoded local set.
      */
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (VObjectMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getTag()});
-            len += 1;
+            arrayBuilder.appendByte((byte) tag.getTag());
             IVmtiMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            arrayBuilder.appendAsBerLength(bytes.length);
+            arrayBuilder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 }

--- a/st0601/src/main/java/org/jmisb/st0903/vtarget/TargetBoundarySeries.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vtarget/TargetBoundarySeries.java
@@ -3,10 +3,9 @@ package org.jmisb.st0903.vtarget;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.EncodingMode;
 import org.jmisb.st0903.shared.IVTrackItemMetadataValue;
@@ -73,17 +72,13 @@ public class TargetBoundarySeries implements IVmtiMetadataValue, IVTrackItemMeta
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (LocationPack location : getLocations()) {
-            byte[] localSetBytes = TargetLocation.serialiseLocationPack(location);
-            byte[] lengthBytes = BerEncoder.encode(localSetBytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(localSetBytes);
-            len += localSetBytes.length;
+            byte[] locationPackBytes = TargetLocation.serialiseLocationPack(location);
+            arrayBuilder.appendAsBerLength(locationPackBytes.length);
+            arrayBuilder.append(locationPackBytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/vtarget/TargetLocation.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vtarget/TargetLocation.java
@@ -1,15 +1,13 @@
 package org.jmisb.st0903.vtarget;
 
-import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
 import org.jmisb.api.klv.st1201.FpEncoder;
 import org.jmisb.api.klv.st1201.OutOfRangeBehaviour;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.core.klv.PrimitiveConverter;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.EncodingMode;
@@ -289,27 +287,23 @@ public class TargetLocation
      * @return the byte array containing the serialised LocationPack.
      */
     public static byte[] serialiseLocationPack(LocationPack targetLocationPack) {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         if (hasRequiredValues(targetLocationPack)) {
-            chunks.add(LatEncoder.encode(targetLocationPack.getLat()));
-            chunks.add(LonEncoder.encode(targetLocationPack.getLon()));
-            chunks.add(HaeEncoder.encode(targetLocationPack.getHae()));
-            len += COORDINATES_GROUP_LEN;
+            arrayBuilder.append(LatEncoder.encode(targetLocationPack.getLat()));
+            arrayBuilder.append(LonEncoder.encode(targetLocationPack.getLon()));
+            arrayBuilder.append(HaeEncoder.encode(targetLocationPack.getHae()));
             if (hasStandardDeviations(targetLocationPack)) {
-                chunks.add(SigmaEncoder.encode(targetLocationPack.getSigEast()));
-                chunks.add(SigmaEncoder.encode(targetLocationPack.getSigNorth()));
-                chunks.add(SigmaEncoder.encode(targetLocationPack.getSigUp()));
-                len += STANDARD_DEVIATIONS_GROUP_LEN;
+                arrayBuilder.append(SigmaEncoder.encode(targetLocationPack.getSigEast()));
+                arrayBuilder.append(SigmaEncoder.encode(targetLocationPack.getSigNorth()));
+                arrayBuilder.append(SigmaEncoder.encode(targetLocationPack.getSigUp()));
                 if (hasCorrelations(targetLocationPack)) {
-                    chunks.add(RhoEncoder.encode(targetLocationPack.getRhoEastNorth()));
-                    chunks.add(RhoEncoder.encode(targetLocationPack.getRhoEastUp()));
-                    chunks.add(RhoEncoder.encode(targetLocationPack.getRhoNorthUp()));
-                    len += CORRELATION_GROUP_LEN;
+                    arrayBuilder.append(RhoEncoder.encode(targetLocationPack.getRhoEastNorth()));
+                    arrayBuilder.append(RhoEncoder.encode(targetLocationPack.getRhoEastUp()));
+                    arrayBuilder.append(RhoEncoder.encode(targetLocationPack.getRhoNorthUp()));
                 }
             }
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/vtarget/VChipSeries.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vtarget/VChipSeries.java
@@ -3,10 +3,9 @@ package org.jmisb.st0903.vtarget;
 import java.util.ArrayList;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.IVTrackItemMetadataValue;
 import org.jmisb.st0903.vchip.VChipLS;
@@ -58,17 +57,13 @@ public class VChipSeries implements IVmtiMetadataValue, IVTrackItemMetadataValue
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (VChipLS chip : getChips()) {
-            byte[] localSetBytes = chip.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(localSetBytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(localSetBytes);
-            len += localSetBytes.length;
+            byte[] chipBytes = chip.getBytes();
+            arrayBuilder.appendAsBerLength(chipBytes.length);
+            arrayBuilder.append(chipBytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/vtarget/VObjectSeries.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vtarget/VObjectSeries.java
@@ -3,10 +3,9 @@ package org.jmisb.st0903.vtarget;
 import java.util.ArrayList;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.IVTrackItemMetadataValue;
 import org.jmisb.st0903.vobject.VObjectLS;
@@ -56,17 +55,13 @@ public class VObjectSeries implements IVmtiMetadataValue, IVTrackItemMetadataVal
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (VObjectLS vobject : getVObjects()) {
-            byte[] localSetBytes = vobject.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(localSetBytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(localSetBytes);
-            len += localSetBytes.length;
+            byte[] bytes = vobject.getBytes();
+            arrayBuilder.appendAsBerLength(bytes.length);
+            arrayBuilder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/vtarget/VTargetPack.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vtarget/VTargetPack.java
@@ -1,6 +1,5 @@
 package org.jmisb.st0903.vtarget;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -8,16 +7,14 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.Ber;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.AlgorithmId;
 import org.jmisb.st0903.shared.EncodingMode;
@@ -238,25 +235,16 @@ public class VTargetPack implements IKlvValue, INestedKlvValue {
      * @return byte array with the encoded local set.
      */
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
-
-        byte[] targetIdBytes = BerEncoder.encode(targetId, Ber.OID);
-        chunks.add(targetIdBytes);
-        len += targetIdBytes.length;
-
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
+        arrayBuilder.appendAsOID(targetId);
         for (VTargetMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getTag()});
-            len += 1;
+            arrayBuilder.appendByte((byte) tag.getTag());
             IVmtiMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            arrayBuilder.appendAsBerLength(bytes.length);
+            arrayBuilder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/vtracker/Acceleration.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vtracker/Acceleration.java
@@ -1,15 +1,13 @@
 package org.jmisb.st0903.vtracker;
 
-import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
 import org.jmisb.api.klv.st1201.FpEncoder;
 import org.jmisb.api.klv.st1201.OutOfRangeBehaviour;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.core.klv.PrimitiveConverter;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.EncodingMode;
@@ -221,27 +219,23 @@ public class Acceleration implements IVmtiMetadataValue, IVTrackItemMetadataValu
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         if (hasRequiredValues()) {
-            chunks.add(AccelerationEncoder.encode(value.getEast()));
-            chunks.add(AccelerationEncoder.encode(value.getNorth()));
-            chunks.add(AccelerationEncoder.encode(value.getUp()));
-            len += ACCELERATION_GROUP_LEN;
+            arrayBuilder.append(AccelerationEncoder.encode(value.getEast()));
+            arrayBuilder.append(AccelerationEncoder.encode(value.getNorth()));
+            arrayBuilder.append(AccelerationEncoder.encode(value.getUp()));
             if (hasStandardDeviations()) {
-                chunks.add(SigmaEncoder.encode(value.getSigEast()));
-                chunks.add(SigmaEncoder.encode(value.getSigNorth()));
-                chunks.add(SigmaEncoder.encode(value.getSigUp()));
-                len += STANDARD_DEVIATIONS_GROUP_LEN;
+                arrayBuilder.append(SigmaEncoder.encode(value.getSigEast()));
+                arrayBuilder.append(SigmaEncoder.encode(value.getSigNorth()));
+                arrayBuilder.append(SigmaEncoder.encode(value.getSigUp()));
                 if (hasCorrelations()) {
-                    chunks.add(RhoEncoder.encode(value.getRhoEastNorth()));
-                    chunks.add(RhoEncoder.encode(value.getRhoEastUp()));
-                    chunks.add(RhoEncoder.encode(value.getRhoNorthUp()));
-                    len += CORRELATION_GROUP_LEN;
+                    arrayBuilder.append(RhoEncoder.encode(value.getRhoEastNorth()));
+                    arrayBuilder.append(RhoEncoder.encode(value.getRhoEastUp()));
+                    arrayBuilder.append(RhoEncoder.encode(value.getRhoNorthUp()));
                 }
             }
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     private boolean hasRequiredValues() {

--- a/st0601/src/main/java/org/jmisb/st0903/vtracker/BoundarySeries.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vtracker/BoundarySeries.java
@@ -3,10 +3,9 @@ package org.jmisb.st0903.vtracker;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.EncodingMode;
 import org.jmisb.st0903.shared.IVTrackMetadataValue;
@@ -70,17 +69,13 @@ public class BoundarySeries implements IVmtiMetadataValue, IVTrackMetadataValue 
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (LocationPack location : getLocations()) {
-            byte[] localSetBytes = TargetLocation.serialiseLocationPack(location);
-            byte[] lengthBytes = BerEncoder.encode(localSetBytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(localSetBytes);
-            len += localSetBytes.length;
+            byte[] locationPackBytes = TargetLocation.serialiseLocationPack(location);
+            arrayBuilder.appendAsBerLength(locationPackBytes.length);
+            arrayBuilder.append(locationPackBytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/vtracker/TrackHistorySeries.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vtracker/TrackHistorySeries.java
@@ -3,10 +3,9 @@ package org.jmisb.st0903.vtracker;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.BerDecoder;
-import org.jmisb.api.klv.BerEncoder;
 import org.jmisb.api.klv.BerField;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.EncodingMode;
 import org.jmisb.st0903.shared.LocationPack;
@@ -69,17 +68,13 @@ public class TrackHistorySeries implements IVmtiMetadataValue {
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (LocationPack location : getTrackHistory()) {
-            byte[] localSetBytes = TargetLocation.serialiseLocationPack(location);
-            byte[] lengthBytes = BerEncoder.encode(localSetBytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(localSetBytes);
-            len += localSetBytes.length;
+            byte[] locationPackBytes = TargetLocation.serialiseLocationPack(location);
+            arrayBuilder.appendAsBerLength(locationPackBytes.length);
+            arrayBuilder.append(locationPackBytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     @Override

--- a/st0601/src/main/java/org/jmisb/st0903/vtracker/VTrackerLS.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vtracker/VTrackerLS.java
@@ -1,6 +1,5 @@
 package org.jmisb.st0903.vtracker;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -8,10 +7,9 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
-import org.jmisb.api.klv.BerEncoder;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.LdsField;
 import org.jmisb.api.klv.LdsParser;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.AlgorithmId;
 import org.jmisb.st0903.shared.EncodingMode;
@@ -144,20 +142,15 @@ public class VTrackerLS {
      * @return byte array with the encoded local set.
      */
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         for (VTrackerMetadataKey tag : getTags()) {
-            chunks.add(new byte[] {(byte) tag.getTag()});
-            len += 1;
+            arrayBuilder.appendByte((byte) tag.getTag());
             IVmtiMetadataValue value = getField(tag);
             byte[] bytes = value.getBytes();
-            byte[] lengthBytes = BerEncoder.encode(bytes.length);
-            chunks.add(lengthBytes);
-            len += lengthBytes.length;
-            chunks.add(bytes);
-            len += bytes.length;
+            arrayBuilder.appendAsBerLength(bytes.length);
+            arrayBuilder.append(bytes);
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     /**

--- a/st0601/src/main/java/org/jmisb/st0903/vtracker/Velocity.java
+++ b/st0601/src/main/java/org/jmisb/st0903/vtracker/Velocity.java
@@ -1,15 +1,13 @@
 package org.jmisb.st0903.vtracker;
 
-import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
+import org.jmisb.api.klv.ArrayBuilder;
 import org.jmisb.api.klv.IKlvKey;
 import org.jmisb.api.klv.IKlvValue;
 import org.jmisb.api.klv.INestedKlvValue;
 import org.jmisb.api.klv.st1201.FpEncoder;
 import org.jmisb.api.klv.st1201.OutOfRangeBehaviour;
-import org.jmisb.core.klv.ArrayUtils;
 import org.jmisb.core.klv.PrimitiveConverter;
 import org.jmisb.st0903.IVmtiMetadataValue;
 import org.jmisb.st0903.shared.EncodingMode;
@@ -235,27 +233,23 @@ public class Velocity implements IVmtiMetadataValue, IVTrackItemMetadataValue, I
 
     @Override
     public byte[] getBytes() {
-        int len = 0;
-        List<byte[]> chunks = new ArrayList<>();
+        ArrayBuilder arrayBuilder = new ArrayBuilder();
         if (hasRequiredValues()) {
-            chunks.add(VelocityEncoder.encode(value.getEast()));
-            chunks.add(VelocityEncoder.encode(value.getNorth()));
-            chunks.add(VelocityEncoder.encode(value.getUp()));
-            len += VELOCITY_GROUP_LEN;
+            arrayBuilder.append(VelocityEncoder.encode(value.getEast()));
+            arrayBuilder.append(VelocityEncoder.encode(value.getNorth()));
+            arrayBuilder.append(VelocityEncoder.encode(value.getUp()));
             if (hasStandardDeviations()) {
-                chunks.add(SigmaEncoder.encode(value.getSigEast()));
-                chunks.add(SigmaEncoder.encode(value.getSigNorth()));
-                chunks.add(SigmaEncoder.encode(value.getSigUp()));
-                len += STANDARD_DEVIATIONS_GROUP_LEN;
+                arrayBuilder.append(SigmaEncoder.encode(value.getSigEast()));
+                arrayBuilder.append(SigmaEncoder.encode(value.getSigNorth()));
+                arrayBuilder.append(SigmaEncoder.encode(value.getSigUp()));
                 if (hasCorrelations()) {
-                    chunks.add(RhoEncoder.encode(value.getRhoEastNorth()));
-                    chunks.add(RhoEncoder.encode(value.getRhoEastUp()));
-                    chunks.add(RhoEncoder.encode(value.getRhoNorthUp()));
-                    len += CORRELATION_GROUP_LEN;
+                    arrayBuilder.append(RhoEncoder.encode(value.getRhoEastNorth()));
+                    arrayBuilder.append(RhoEncoder.encode(value.getRhoEastUp()));
+                    arrayBuilder.append(RhoEncoder.encode(value.getRhoNorthUp()));
                 }
             }
         }
-        return ArrayUtils.arrayFromChunks(chunks, len);
+        return arrayBuilder.toBytes();
     }
 
     private boolean hasRequiredValues() {


### PR DESCRIPTION
## Motivation and Context
The is a utility for concatenating byte arrays that we use a bit (especially in ST 0903). That is a bit too easy to get wrong (if you miss updating the lengths), and I added a wrapper (`ArrayBuilder`) that handles the housekeeping. Before doing some bigger refactoring on ST 0601/ ST 0903 to support the possibly repeating entries, and SDCC structures, I'd like to migrate the current uses of `ArrayUtils.arrayFromChunks` to `ArrayBuilder`.

This doesn't touch the ArrayUtils hex display utilities.

## Description
Reworks existing code (mostly the KLV serialisation) to ArrayBuilder, then moves the `arrayFromChunks` to be a member of ArrayBuilder. I did consider making `arrayFromChunks` `private`, and may yet do that in a follow-on commit.

## How Has This Been Tested?

Unit tests only. I think there is reasonable coverage for most of the changed code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

