### PR TITLE
st0102: add validator

### DIFF
--- a/st0102/src/main/java/org/jmisb/st0102/validity/SecurityMetadataLocalSetValidator.java
+++ b/st0102/src/main/java/org/jmisb/st0102/validity/SecurityMetadataLocalSetValidator.java
@@ -1,0 +1,406 @@
+package org.jmisb.st0102.validity;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jmisb.st0102.CountryCodingMethod;
+import org.jmisb.st0102.ISecurityMetadataValue;
+import org.jmisb.st0102.ObjectCountryCodeString;
+import org.jmisb.st0102.ST0102Version;
+import org.jmisb.st0102.SecurityMetadataConstants;
+import org.jmisb.st0102.SecurityMetadataKey;
+import org.jmisb.st0102.SecurityMetadataString;
+import org.jmisb.st0102.localset.CcMethod;
+import org.jmisb.st0102.localset.ClassificationLocal;
+import org.jmisb.st0102.localset.OcMethod;
+import org.jmisb.st0102.localset.SecurityMetadataLocalSet;
+
+/**
+ * Validator for ST 0102 local sets.
+ *
+ * <p>This provides facility to check the content of the Security Metadata local set. Not all
+ * requirements can be validated (e.g. it is possible to check that a required marking is present,
+ * but not possible to say that the marking corresponds to the required classification for the
+ * content).
+ *
+ * <p>The intent of this is to help identify potential problems when generating (or amending) ST
+ * 0102 Security Metadata. It has limited applicability to testing metadata on video received from
+ * other sources. The outputs are not intended to be shown to typical users - it would usually be
+ * more appropriate to log rather than put into a user interface.
+ */
+public class SecurityMetadataLocalSetValidator {
+
+    private SecurityMetadataLocalSetValidator() {};
+
+    /**
+     * Check the validity of a local set.
+     *
+     * @param localSet the local set to validate
+     * @return the validation results
+     */
+    public static ValidationResults checkValidity(SecurityMetadataLocalSet localSet) {
+        ValidationResults result = new ValidationResults();
+        result.addResults(validateSecurityClassification(localSet));
+        result.addResults(
+                validateClassifyingCountryAndReleasingInstructionsCountryCodingMethod(localSet));
+        result.addResults(validateClassifyingCountry(localSet));
+        // There are potentially SCI-related requirements from ST 0102 Section 6.1.4 that could be
+        // added in here.
+        result.addResults(validateCaveats(localSet));
+        result.addResults(validateReleasingInstructions(localSet));
+        result.addResults(validateClassifiedBy(localSet));
+        result.addResults(validateDerivedFrom(localSet));
+        result.addResults(validateClassificationReason(localSet));
+        result.addResults(validateClassificationAndMarkingSystem(localSet));
+        result.addResults(validateObjectCountryCodingMethod(localSet));
+        result.addResults(validateObjectCountryCodes(localSet));
+        result.addResults(validateClassificationComments(localSet));
+        result.addResults(validateVersion(localSet));
+        return result;
+    }
+
+    private static List<ValidationResult> validateSecurityClassification(
+            SecurityMetadataLocalSet localSet) {
+        List<ValidationResult> results = new ArrayList<>();
+        if (localSet.getIdentifiers().contains(SecurityMetadataKey.SecurityClassification)) {
+            ValidationResult result = new ValidationResult(Validity.Conforms);
+            result.setTraceability("ST 0102.10-03");
+            result.setDescription(
+                    "Motion Imagery Data contained the Security Classification metadata element.");
+            results.add(result);
+            ISecurityMetadataValue v =
+                    localSet.getField(SecurityMetadataKey.SecurityClassification);
+            if (!(v instanceof ClassificationLocal)) {
+                ValidationResult typeCheckResult = new ValidationResult(Validity.DoesNotConform);
+                typeCheckResult.setDescription(
+                        "The value assigned to the SecurityClassification is not of the correct type (expecting ClassificationLocal).");
+                results.add(typeCheckResult);
+            }
+        } else {
+            ValidationResult result = new ValidationResult(Validity.DoesNotConform);
+            result.setTraceability("ST 0102.10-03");
+            result.setDescription(
+                    "Motion Imagery Data did not contain the Security Classification metadata element.");
+            results.add(result);
+        }
+        return results;
+    }
+
+    private static List<ValidationResult>
+            validateClassifyingCountryAndReleasingInstructionsCountryCodingMethod(
+                    SecurityMetadataLocalSet localSet) {
+        List<ValidationResult> results = new ArrayList<>();
+        if (localSet.getIdentifiers().contains(SecurityMetadataKey.CcCodingMethod)) {
+            ValidationResult result = new ValidationResult(Validity.Conforms);
+            result.setTraceability("ST 0102.10-04");
+            result.setDescription(
+                    "Motion Imagery Data contained the Classifying Country and Releasing Instructions Country Coding Method metadata element.");
+            results.add(result);
+            ISecurityMetadataValue v = localSet.getField(SecurityMetadataKey.CcCodingMethod);
+            if (!(v instanceof CcMethod)) {
+                ValidationResult typeCheckResult = new ValidationResult(Validity.DoesNotConform);
+                typeCheckResult.setDescription(
+                        "The value assigned to the CcCodingMethod is not of the correct type (expecting CcMethod).");
+                results.add(typeCheckResult);
+            } else {
+                CcMethod ccMethod = (CcMethod) v;
+                if (ccMethod.getMethod().equals(CountryCodingMethod.OMITTED_VALUE)) {
+                    ValidationResult valueCheckResult =
+                            new ValidationResult(Validity.DoesNotConform);
+                    valueCheckResult.setDescription(
+                            "The value assigned to the CcCodingMethod is not one of the allowed values.");
+                    results.add(valueCheckResult);
+                } else {
+                    ValidationResult valueCheckResult = new ValidationResult(Validity.Conforms);
+                    valueCheckResult.setDescription(
+                            "The value assigned to the CcCodingMethod is one of the allowed values.");
+                    results.add(valueCheckResult);
+                }
+            }
+        } else {
+            ValidationResult result = new ValidationResult(Validity.DoesNotConform);
+            result.setTraceability("ST 0102.10-04");
+            result.setDescription(
+                    "Motion Imagery Data did not contain the Classifying Country and Releasing Instructions Country Coding Method metadata element.");
+            results.add(result);
+        }
+        return results;
+    }
+
+    private static List<ValidationResult> validateClassifyingCountry(
+            SecurityMetadataLocalSet localSet) {
+        List<ValidationResult> results = new ArrayList<>();
+        if (localSet.getIdentifiers().contains(SecurityMetadataKey.ClassifyingCountry)) {
+            ValidationResult result = new ValidationResult(Validity.Conforms);
+            result.setTraceability("ST 0102.10-05");
+            result.setDescription(
+                    "Motion Imagery Data contained the Classifying Country metadata element.");
+            results.add(result);
+            ISecurityMetadataValue v = localSet.getField(SecurityMetadataKey.ClassifyingCountry);
+            if (!(v instanceof SecurityMetadataString)) {
+                ValidationResult typeCheckResult = new ValidationResult(Validity.DoesNotConform);
+                typeCheckResult.setDescription(
+                        "The value assigned to the ClassifyingCountry is not of the correct type (expecting SecurityMetadataString).");
+                results.add(typeCheckResult);
+            } else {
+                SecurityMetadataString securityMetadataString = (SecurityMetadataString) v;
+                results.add(checkPrefixOnCountryCode(securityMetadataString));
+                if (!securityMetadataString
+                        .getDisplayName()
+                        .equals(SecurityMetadataString.CLASSIFYING_COUNTRY)) {
+                    ValidationResult typeCheckResult =
+                            new ValidationResult(Validity.DoesNotConform);
+                    typeCheckResult.setDescription(
+                            "The SecurityMetadataString assigned to the ClassifyingCountry has the wrong label (expecting CLASSIFYING_COUNTRY).");
+                    results.add(typeCheckResult);
+                }
+            }
+        } else {
+            ValidationResult result = new ValidationResult(Validity.DoesNotConform);
+            result.setTraceability("ST 0102.10-05");
+            result.setDescription(
+                    "Motion Imagery Data did not contain the Classifying Country metadata element.");
+            results.add(result);
+        }
+        return results;
+    }
+
+    private static ValidationResult checkPrefixOnCountryCode(
+            SecurityMetadataString securityMetadataString) {
+        if (securityMetadataString.getValue().startsWith("//")) {
+            ValidationResult prefixResult = new ValidationResult(Validity.Conforms);
+            prefixResult.setTraceability("ST 0102.12 Para 6.1.3");
+            prefixResult.setDescription("Classifying country value starts with //");
+            return prefixResult;
+        } else {
+            ValidationResult prefixResult = new ValidationResult(Validity.DoesNotConform);
+            prefixResult.setTraceability("ST 0102.12 Para 6.1.3");
+            prefixResult.setDescription("Classifying country value did not start with //.");
+            return prefixResult;
+        }
+    }
+
+    private static List<ValidationResult> validateClassifiedBy(SecurityMetadataLocalSet localSet) {
+        return validateSecurityMetadataString(
+                localSet, SecurityMetadataKey.ClassifiedBy, SecurityMetadataString.CLASSIFIED_BY);
+    }
+
+    private static List<ValidationResult> validateCaveats(SecurityMetadataLocalSet localSet) {
+        return validateSecurityMetadataString(
+                localSet, SecurityMetadataKey.Caveats, SecurityMetadataString.CAVEATS);
+    }
+
+    private static List<ValidationResult> validateReleasingInstructions(
+            SecurityMetadataLocalSet localSet) {
+        List<ValidationResult> results = new ArrayList<>();
+        if (localSet.getIdentifiers().contains(SecurityMetadataKey.ReleasingInstructions)) {
+            ISecurityMetadataValue v = localSet.getField(SecurityMetadataKey.ReleasingInstructions);
+            if (!(v instanceof SecurityMetadataString)) {
+                ValidationResult typeCheckResult = new ValidationResult(Validity.DoesNotConform);
+                typeCheckResult.setDescription(
+                        "The value assigned to "
+                                + SecurityMetadataKey.ReleasingInstructions.toString()
+                                + " is not of the correct type (expecting SecurityMetadataString).");
+                results.add(typeCheckResult);
+            } else {
+                SecurityMetadataString securityMetadataString = (SecurityMetadataString) v;
+                if (!securityMetadataString
+                        .getDisplayName()
+                        .equals(SecurityMetadataString.RELEASING_INSTRUCTIONS)) {
+                    ValidationResult typeCheckResult =
+                            new ValidationResult(Validity.DoesNotConform);
+                    typeCheckResult.setDescription(
+                            "The SecurityMetadataString assigned to "
+                                    + SecurityMetadataKey.ReleasingInstructions.toString()
+                                    + " has the wrong label (expecting "
+                                    + SecurityMetadataString.RELEASING_INSTRUCTIONS
+                                    + ").");
+                    results.add(typeCheckResult);
+                }
+                String releaseInstructionsText = securityMetadataString.getDisplayableValue();
+                if (releaseInstructionsText.contains("_")
+                        || releaseInstructionsText.contains(";")) {
+                    ValidationResult valueCheckResult =
+                            new ValidationResult(Validity.DoesNotConform);
+                    valueCheckResult.setTraceability("ST 0102.10-16");
+                    valueCheckResult.setDescription(
+                            "The SecurityMetadataString assigned to "
+                                    + SecurityMetadataKey.ReleasingInstructions.toString()
+                                    + " has invalid separators.");
+                    results.add(valueCheckResult);
+                }
+            }
+        }
+        return results;
+    }
+
+    private static List<ValidationResult> validateDerivedFrom(SecurityMetadataLocalSet localSet) {
+        return validateSecurityMetadataString(
+                localSet, SecurityMetadataKey.DerivedFrom, SecurityMetadataString.DERIVED_FROM);
+    }
+
+    private static List<ValidationResult> validateClassificationAndMarkingSystem(
+            SecurityMetadataLocalSet localSet) {
+        return validateSecurityMetadataString(
+                localSet, SecurityMetadataKey.MarkingSystem, SecurityMetadataString.MARKING_SYSTEM);
+    }
+
+    private static List<ValidationResult> validateClassificationReason(
+            SecurityMetadataLocalSet localSet) {
+        return validateSecurityMetadataString(
+                localSet,
+                SecurityMetadataKey.ClassificationReason,
+                SecurityMetadataString.CLASSIFICATION_REASON);
+    }
+
+    private static List<ValidationResult> validateClassificationComments(
+            SecurityMetadataLocalSet localSet) {
+        return validateSecurityMetadataString(
+                localSet,
+                SecurityMetadataKey.ClassificationComments,
+                SecurityMetadataString.CLASSIFICATION_COMMENTS);
+    }
+
+    private static List<ValidationResult> validateSecurityMetadataString(
+            SecurityMetadataLocalSet localSet, SecurityMetadataKey key, String label) {
+        List<ValidationResult> results = new ArrayList<>();
+        if (localSet.getIdentifiers().contains(key)) {
+            ISecurityMetadataValue v = localSet.getField(key);
+            if (!(v instanceof SecurityMetadataString)) {
+                ValidationResult typeCheckResult = new ValidationResult(Validity.DoesNotConform);
+                typeCheckResult.setDescription(
+                        "The value assigned to "
+                                + key.toString()
+                                + " is not of the correct type (expecting SecurityMetadataString).");
+                results.add(typeCheckResult);
+            } else {
+                SecurityMetadataString securityMetadataString = (SecurityMetadataString) v;
+                if (!securityMetadataString.getDisplayName().equals(label)) {
+                    ValidationResult typeCheckResult =
+                            new ValidationResult(Validity.DoesNotConform);
+                    typeCheckResult.setDescription(
+                            "The SecurityMetadataString assigned to "
+                                    + key.toString()
+                                    + " has the wrong label (expecting "
+                                    + label
+                                    + ").");
+                    results.add(typeCheckResult);
+                }
+            }
+        }
+        return results;
+    }
+
+    private static List<ValidationResult> validateObjectCountryCodingMethod(
+            SecurityMetadataLocalSet localSet) {
+        List<ValidationResult> results = new ArrayList<>();
+        if (localSet.getIdentifiers().contains(SecurityMetadataKey.OcCodingMethod)) {
+            ISecurityMetadataValue v = localSet.getField(SecurityMetadataKey.OcCodingMethod);
+            if (!(v instanceof OcMethod)) {
+                ValidationResult typeCheckResult = new ValidationResult(Validity.DoesNotConform);
+                typeCheckResult.setDescription(
+                        "The value assigned to the OcCodingMethod is not of the correct type (expecting OcMethod).");
+                results.add(typeCheckResult);
+            } else {
+                OcMethod ocMethod = (OcMethod) v;
+                if (ocMethod.getMethod().equals(CountryCodingMethod.OMITTED_VALUE)) {
+                    ValidationResult valueCheckResult =
+                            new ValidationResult(Validity.DoesNotConform);
+                    valueCheckResult.setDescription(
+                            "The value assigned to the OcCodingMethod is not one of the allowed values.");
+                    results.add(valueCheckResult);
+                } else {
+                    ValidationResult valueCheckResult = new ValidationResult(Validity.Conforms);
+                    valueCheckResult.setDescription(
+                            "The value assigned to the OcCodingMethod is one of the allowed values.");
+                    results.add(valueCheckResult);
+                }
+            }
+        } else {
+            ValidationResult result = new ValidationResult(Validity.DoesNotConform);
+            result.setTraceability("ST 0102 6.1.12");
+            result.setDescription(
+                    "Motion Imagery Data did not contain the expected Object Country Coding Method (required from Version 5 onwards).");
+            results.add(result);
+        }
+        return results;
+    }
+
+    private static List<ValidationResult> validateVersion(SecurityMetadataLocalSet localSet) {
+        List<ValidationResult> results = new ArrayList<>();
+        if (localSet.getIdentifiers().contains(SecurityMetadataKey.Version)) {
+            ValidationResult result = new ValidationResult(Validity.Conforms);
+            result.setTraceability("ST 0102.10-56");
+            result.setDescription(
+                    "Motion Imagery Data contained the Security Metadata Version metadata element.");
+            results.add(result);
+            ISecurityMetadataValue v = localSet.getField(SecurityMetadataKey.Version);
+            if (!(v instanceof ST0102Version)) {
+                ValidationResult typeCheckResult = new ValidationResult(Validity.DoesNotConform);
+                typeCheckResult.setDescription(
+                        "The value assigned to the Version is not of the correct type (expecting ST0102Version).");
+                results.add(typeCheckResult);
+            } else {
+                ST0102Version version = (ST0102Version) v;
+                if ((version.getVersion() < 4)
+                        || (version.getVersion() > SecurityMetadataConstants.ST_VERSION_NUMBER)) {
+                    ValidationResult valueCheckResult =
+                            new ValidationResult(Validity.DoesNotConform);
+                    valueCheckResult.setDescription(
+                            String.format(
+                                    "The value assigned to the ST0102Version is not one of the expected values [4-%d].",
+                                    SecurityMetadataConstants.ST_VERSION_NUMBER));
+                    results.add(valueCheckResult);
+                } else {
+                    ValidationResult valueCheckResult = new ValidationResult(Validity.Conforms);
+                    valueCheckResult.setDescription(
+                            "The value assigned to the ST0102Version is one of the expected values.");
+                    results.add(valueCheckResult);
+                }
+            }
+        } else {
+            ValidationResult result = new ValidationResult(Validity.DoesNotConform);
+            result.setTraceability("ST 0102.10-56");
+            result.setDescription(
+                    "Motion Imagery Data did not contain the Security Metadata Version metadata element (required on Version 4 and later).");
+            results.add(result);
+        }
+        return results;
+    }
+
+    private static List<ValidationResult> validateObjectCountryCodes(
+            SecurityMetadataLocalSet localSet) {
+        List<ValidationResult> results = new ArrayList<>();
+        if (localSet.getIdentifiers().contains(SecurityMetadataKey.ObjectCountryCodes)) {
+            ValidationResult result = new ValidationResult(Validity.Conforms);
+            result.setTraceability("ST 0102.10-23");
+            result.setDescription(
+                    "Motion Imagery Data contained the Object Country Code metadata element.");
+            results.add(result);
+            ISecurityMetadataValue v = localSet.getField(SecurityMetadataKey.ObjectCountryCodes);
+            if (!(v instanceof ObjectCountryCodeString)) {
+                ValidationResult typeCheckResult = new ValidationResult(Validity.DoesNotConform);
+                typeCheckResult.setDescription(
+                        "The value assigned to the ObjectCountryCodes is not of the correct type (expecting ObjectCountryCodeString).");
+                results.add(typeCheckResult);
+            } else {
+                ObjectCountryCodeString objectCountryCodeString = (ObjectCountryCodeString) v;
+                String countryCodes = objectCountryCodeString.getValue();
+                if (countryCodes.contains(",") || countryCodes.contains(" ")) {
+                    ValidationResult valueCheckResult =
+                            new ValidationResult(Validity.DoesNotConform);
+                    valueCheckResult.setTraceability("ST 0102.10-24");
+                    valueCheckResult.setDescription(
+                            "Object Country Codes contained space or comma separators (should be semi-colon).");
+                    results.add(valueCheckResult);
+                }
+            }
+        } else {
+            ValidationResult result = new ValidationResult(Validity.DoesNotConform);
+            result.setTraceability("ST 0102.10-23");
+            result.setDescription(
+                    "Motion Imagery Data did not contain the Object Country Code metadata element.");
+            results.add(result);
+        }
+        return results;
+    }
+}

--- a/st0102/src/main/java/org/jmisb/st0102/validity/ValidationResult.java
+++ b/st0102/src/main/java/org/jmisb/st0102/validity/ValidationResult.java
@@ -1,0 +1,68 @@
+package org.jmisb.st0102.validity;
+
+/** Results of validation of one part (or sub-part) of a requirement. */
+public class ValidationResult {
+    private final Validity validity;
+    private String traceability;
+    private String description;
+
+    /**
+     * Constructor.
+     *
+     * @param validity whether the item is considered to have complied or not.
+     */
+    public ValidationResult(Validity validity) {
+        this.validity = validity;
+    }
+
+    /**
+     * Get the validity status for this result.
+     *
+     * @return whether the item is considered to have complied or not.
+     */
+    public Validity getValidity() {
+        return validity;
+    }
+
+    /**
+     * Get the traceability reference.
+     *
+     * <p>This is the EARS reference, or something else that represents where the requirement came
+     * from.
+     *
+     * @return short text describing the source of the requirement.
+     */
+    public String getTraceability() {
+        return traceability;
+    }
+
+    /**
+     * Set the traceability reference.
+     *
+     * <p>This is the EARS reference, or something else that represents where the requirement came
+     * from.
+     *
+     * @param traceability short text describing the source of the requirement.
+     */
+    public void setTraceability(String traceability) {
+        this.traceability = traceability;
+    }
+
+    /**
+     * Get the description of the result.
+     *
+     * @return the text description for result.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Set the description of the result.
+     *
+     * @param description human readable description for result.
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/st0102/src/main/java/org/jmisb/st0102/validity/ValidationResults.java
+++ b/st0102/src/main/java/org/jmisb/st0102/validity/ValidationResults.java
@@ -1,0 +1,52 @@
+package org.jmisb.st0102.validity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The results of validation process.
+ *
+ * <p>This is primarily a container class.
+ */
+public class ValidationResults {
+
+    private final List<ValidationResult> validationResults = new ArrayList<>();
+
+    /**
+     * Add multiple results to this result.
+     *
+     * @param results the results to add.
+     */
+    public void addResults(List<ValidationResult> results) {
+        validationResults.addAll(results);
+    }
+
+    /**
+     * Check if the results show conformance.
+     *
+     * @return true if every requirement was met, otherwise false (one or more non-conformances).
+     */
+    public boolean isConformant() {
+        boolean isConformant = true;
+        for (ValidationResult result : validationResults) {
+            if (result.getValidity().equals(Validity.DoesNotConform)) {
+                isConformant = false;
+                break;
+            }
+        }
+        return isConformant;
+    }
+
+    /**
+     * Get the non-conformance parts of the result.
+     *
+     * @return list containing only the failed (Does not conform) items.
+     */
+    public List<ValidationResult> getNonConformances() {
+        List<ValidationResult> nonConformances = new ArrayList<>();
+        validationResults.stream()
+                .filter(result -> result.getValidity().equals(Validity.DoesNotConform))
+                .forEach(nonConformances::add);
+        return nonConformances;
+    }
+}

--- a/st0102/src/main/java/org/jmisb/st0102/validity/Validity.java
+++ b/st0102/src/main/java/org/jmisb/st0102/validity/Validity.java
@@ -1,0 +1,9 @@
+package org.jmisb.st0102.validity;
+
+/** Validity Status for conformance results. */
+public enum Validity {
+    /** The requirement is considered to conform. */
+    Conforms,
+    /** The requirement is considered to not conform. */
+    DoesNotConform
+}

--- a/st0102/src/main/java/org/jmisb/st0102/validity/package-info.java
+++ b/st0102/src/main/java/org/jmisb/st0102/validity/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * ST 0102 Validation.
+ *
+ * <p>ST 0102 has required elements. This package allows checking that a set is valid against
+ * reasonably checkable rules.
+ *
+ * <p>It does not validate that the classification and other security metadata values are
+ * appropriate or reasonable, only that they are present.
+ */
+package org.jmisb.st0102.validity;

--- a/st0102/src/test/java/org/jmisb/st0102/localset/SecurityMetadataLocalSetTest.java
+++ b/st0102/src/test/java/org/jmisb/st0102/localset/SecurityMetadataLocalSetTest.java
@@ -15,6 +15,8 @@ import org.jmisb.st0102.ObjectCountryCodeString;
 import org.jmisb.st0102.ST0102Version;
 import org.jmisb.st0102.SecurityMetadataKey;
 import org.jmisb.st0102.SecurityMetadataString;
+import org.jmisb.st0102.validity.SecurityMetadataLocalSetValidator;
+import org.jmisb.st0102.validity.ValidationResults;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -61,7 +63,7 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks {
 
         values.put(
                 SecurityMetadataKey.OcCodingMethod,
-                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
         values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("US;CA"));
 
         values.put(SecurityMetadataKey.Version, new ST0102Version(12));
@@ -224,6 +226,13 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks {
     }
 
     @Test
+    public void testValidity() {
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        Assert.assertTrue(results.isConformant());
+        Assert.assertEquals(results.getNonConformances().size(), 0);
+    }
+
+    @Test
     public void testMinimumFromBuilder() {
         // Create a message equivalent to localSet
         SecurityMetadataLocalSet builderSet =
@@ -239,6 +248,11 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks {
         bytes1 = localSet.frameMessage(true);
         bytes2 = builderSet.frameMessage(true);
         Assert.assertEquals(bytes1, bytes2);
+
+        ValidationResults validationResults =
+                SecurityMetadataLocalSetValidator.checkValidity(builderSet);
+        Assert.assertTrue(validationResults.isConformant());
+        Assert.assertEquals(validationResults.getNonConformances().size(), 0);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -299,6 +313,11 @@ public class SecurityMetadataLocalSetTest extends LoggerChecks {
         // System.out.println(ArrayUtils.toHexString(bytes));
 
         Assert.assertEquals(bytes[20], Classification.TOP_SECRET.getCode());
+
+        ValidationResults validationResults =
+                SecurityMetadataLocalSetValidator.checkValidity(fullMessage);
+        Assert.assertTrue(validationResults.isConformant());
+        Assert.assertEquals(validationResults.getNonConformances().size(), 0);
     }
 
     @Test

--- a/st0102/src/test/java/org/jmisb/st0102/validity/SecurityMetadataLocalSetValidatorTest.java
+++ b/st0102/src/test/java/org/jmisb/st0102/validity/SecurityMetadataLocalSetValidatorTest.java
@@ -1,0 +1,869 @@
+package org.jmisb.st0102.validity;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.jmisb.st0102.Classification;
+import org.jmisb.st0102.CountryCodingMethod;
+import org.jmisb.st0102.ISecurityMetadataValue;
+import org.jmisb.st0102.ObjectCountryCodeString;
+import org.jmisb.st0102.ST0102Version;
+import org.jmisb.st0102.SecurityMetadataConstants;
+import org.jmisb.st0102.SecurityMetadataKey;
+import org.jmisb.st0102.SecurityMetadataString;
+import org.jmisb.st0102.localset.CcMethod;
+import org.jmisb.st0102.localset.ClassificationLocal;
+import org.jmisb.st0102.localset.OcMethod;
+import org.jmisb.st0102.localset.SecurityMetadataLocalSet;
+import org.jmisb.st0102.universalset.ClassificationUniversal;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for SecurityMetadataLocalSetValidator.
+ *
+ * <p>Note that some of testing is in the main LocalSet tests. This covers more of the edge cases.
+ */
+public class SecurityMetadataLocalSetValidatorTest {
+
+    @Test
+    public void testNoSecurityClassification() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AS"));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "Motion Imagery Data did not contain the Security Classification metadata element.");
+        assertEquals(validationResult.getTraceability(), "ST 0102.10-03");
+    }
+
+    @Test
+    public void testSecurityClassificationWrongType() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationUniversal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AS"));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to the SecurityClassification is not of the correct type (expecting ClassificationLocal).");
+    }
+
+    @Test
+    public void testNoClassifyingCountry() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "Motion Imagery Data did not contain the Classifying Country metadata element.");
+        assertEquals(validationResult.getTraceability(), "ST 0102.10-05");
+    }
+
+    @Test
+    public void testClassifyingCountryWrongType() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ClassifyingCountry, new ObjectCountryCodeString("AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to the ClassifyingCountry is not of the correct type (expecting SecurityMetadataString).");
+    }
+
+    @Test
+    public void testClassifyingCountryWrongStringLabel() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CAVEATS, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The SecurityMetadataString assigned to the ClassifyingCountry has the wrong label (expecting CLASSIFYING_COUNTRY).");
+    }
+
+    @Test
+    public void testClassifyingCountryBadPrefix() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "AU"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "Classifying country value did not start with //.");
+        assertEquals(validationResult.getTraceability(), "ST 0102.12 Para 6.1.3");
+    }
+
+    @Test
+    public void testNoClassifyingCountryCodingMethod() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AS"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "Motion Imagery Data did not contain the Classifying Country and Releasing Instructions Country Coding Method metadata element.");
+        assertEquals(validationResult.getTraceability(), "ST 0102.10-04");
+    }
+
+    @Test
+    public void testClassifyingCountryCodingMethodWrongType() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AS"));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to the CcCodingMethod is not of the correct type (expecting CcMethod).");
+    }
+
+    @Test
+    public void testClassifyingCountryCodingMethodInvalidValue() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AS"));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.OMITTED_VALUE));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to the CcCodingMethod is not one of the allowed values.");
+    }
+
+    @Test
+    public void testNoVersion() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AS"));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "Motion Imagery Data did not contain the Security Metadata Version metadata element (required on Version 4 and later).");
+        assertEquals(validationResult.getTraceability(), "ST 0102.10-56");
+    }
+
+    @Test
+    public void testInvalidVersionHigh() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AS"));
+        values.put(SecurityMetadataKey.Version, new ST0102Version(99));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to the ST0102Version is not one of the expected values [4-12].");
+    }
+
+    @Test
+    public void testInvalidVersionLow() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AS"));
+        values.put(SecurityMetadataKey.Version, new ST0102Version(1));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to the ST0102Version is not one of the expected values [4-12].");
+    }
+
+    @Test
+    public void testInvalidVersionType() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AS"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new SecurityMetadataString(SecurityMetadataString.CAVEATS, "ABC"));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to the Version is not of the correct type (expecting ST0102Version).");
+    }
+
+    @Test
+    public void testCaveatsBadType() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Caveats, new OcMethod(CountryCodingMethod.C1059_THREE_LETTER));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to Caveats is not of the correct type (expecting SecurityMetadataString).");
+    }
+
+    @Test
+    public void testCaveatsBadValueLabel() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.Caveats,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFICATION_COMMENTS, "ABC"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The SecurityMetadataString assigned to Caveats has the wrong label (expecting Caveats).");
+    }
+
+    @Test
+    public void testCaveatsGood() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Caveats,
+                new SecurityMetadataString(SecurityMetadataString.CAVEATS, "ABC"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertTrue(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 0);
+    }
+
+    @Test
+    public void testReleaseInstructionsGood() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.ReleasingInstructions,
+                new SecurityMetadataString(SecurityMetadataString.RELEASING_INSTRUCTIONS, "UK US"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertTrue(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 0);
+    }
+
+    @Test
+    public void testReleaseInstructionsWrongType() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.ReleasingInstructions,
+                new OcMethod(CountryCodingMethod.C1059_THREE_LETTER));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to ReleasingInstructions is not of the correct type (expecting SecurityMetadataString).");
+    }
+
+    @Test
+    public void testReleaseInstructionsWrongValueLabel() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.ReleasingInstructions,
+                new SecurityMetadataString(SecurityMetadataString.CAVEATS, "UK US"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The SecurityMetadataString assigned to ReleasingInstructions has the wrong label (expecting Releasing Instructions).");
+    }
+
+    @Test
+    public void testReleaseInstructionsUnderscoreSeparator() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.ReleasingInstructions,
+                new SecurityMetadataString(SecurityMetadataString.RELEASING_INSTRUCTIONS, "UK_US"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The SecurityMetadataString assigned to ReleasingInstructions has invalid separators.");
+    }
+
+    @Test
+    public void testReleaseInstructionsSemicolonSeparator() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.ReleasingInstructions,
+                new SecurityMetadataString(SecurityMetadataString.RELEASING_INSTRUCTIONS, "UK;US"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The SecurityMetadataString assigned to ReleasingInstructions has invalid separators.");
+    }
+
+    @Test
+    public void testObjectCountryCodingMethod() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.C1059_THREE_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertTrue(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 0);
+    }
+
+    @Test
+    public void testNoObjectCountryCodingMethod() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(validationResult.getTraceability(), "ST 0102 6.1.12");
+        assertEquals(
+                validationResult.getDescription(),
+                "Motion Imagery Data did not contain the expected Object Country Coding Method (required from Version 5 onwards).");
+    }
+
+    @Test
+    public void testObjectCountryCodingMethodWrongType() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new CcMethod(CountryCodingMethod.C1059_THREE_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to the OcCodingMethod is not of the correct type (expecting OcMethod).");
+    }
+
+    @Test
+    public void testObjectCountryCodingMethodBadValue() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.OMITTED_VALUE));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to the OcCodingMethod is not one of the allowed values.");
+    }
+
+    @Test
+    public void testNoObjectCountryCodes() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(validationResult.getTraceability(), "ST 0102.10-23");
+        assertEquals(
+                validationResult.getDescription(),
+                "Motion Imagery Data did not contain the Object Country Code metadata element.");
+    }
+
+    @Test
+    public void testObjectCountryCodesWrongType() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ObjectCountryCodes,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "AU;NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "The value assigned to the ObjectCountryCodes is not of the correct type (expecting ObjectCountryCodeString).");
+    }
+
+    @Test
+    public void testObjectCountryCodesBadValueSpace() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "Object Country Codes contained space or comma separators (should be semi-colon).");
+    }
+
+    @Test
+    public void testObjectCountryCodesBadValueComma() {
+        SortedMap<SecurityMetadataKey, ISecurityMetadataValue> values = new TreeMap<>();
+        values.put(
+                SecurityMetadataKey.SecurityClassification,
+                new ClassificationLocal(Classification.UNCLASSIFIED));
+        values.put(
+                SecurityMetadataKey.CcCodingMethod,
+                new CcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(
+                SecurityMetadataKey.ClassifyingCountry,
+                new SecurityMetadataString(SecurityMetadataString.CLASSIFYING_COUNTRY, "//AU"));
+        values.put(
+                SecurityMetadataKey.OcCodingMethod,
+                new OcMethod(CountryCodingMethod.GENC_TWO_LETTER));
+        values.put(SecurityMetadataKey.ObjectCountryCodes, new ObjectCountryCodeString("AU,NZ"));
+        values.put(
+                SecurityMetadataKey.Version,
+                new ST0102Version(SecurityMetadataConstants.ST_VERSION_NUMBER));
+        SecurityMetadataLocalSet localSet = new SecurityMetadataLocalSet(values);
+        ValidationResults results = SecurityMetadataLocalSetValidator.checkValidity(localSet);
+        assertFalse(results.isConformant());
+        assertEquals(results.getNonConformances().size(), 1);
+        ValidationResult validationResult = results.getNonConformances().get(0);
+        assertEquals(
+                validationResult.getDescription(),
+                "Object Country Codes contained space or comma separators (should be semi-colon).");
+    }
+}


### PR DESCRIPTION
## Motivation and Context
ST 0102 has a lot of mandatory requirements, which are eased by use of the Builder, but are still complex.

#183 tracks the idea of a validator that checks the local set meets the minimum requirements.

## Description
Implement validator. The design is based on the existing ST 1403 validator.

## How Has This Been Tested?
Unit tests. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

