### PR TITLE
ci: add JDK 17 and Ubuntu 22.04 support

### DIFF
--- a/.github/workflows/jdk17.yml
+++ b/.github/workflows/jdk17.yml
@@ -1,0 +1,25 @@
+name: JDK17 Build (Ubuntu 22.04)
+
+on:
+    push:
+      branches: [ develop, 2.x ]
+    pull_request:
+      branches: [ develop, 2.x ]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.3
+        with:
+          maven-version: 3.8.5
+      - name: Build and install
+        run: mvn -B install -Pdebug || mvn -B install -Pdebug || mvn -B install -Pdebug
+


### PR DESCRIPTION
## Motivation and Context

JDK 14 is out-of-life, and JDK 17 is the current LTS. 

Also, #403 reports a problem with JDK 14. That might be a broader issue, but can be investigated better if we have a more recent JDK in the CI mix.

## Description

Add JDK 17 CI workflow. JDK 14 remains for the purposes of debugging, so this is considered to relate to #403, but not resolve it yet.

## How Has This Been Tested?

Only testing as part of the CI for this PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

