### PR TITLE
ffmpeg: pre-load required files in integration tests

### DIFF
--- a/api-ffmpeg/src/test/java/org/jmisb/api/video/VideoFileInputOutputIT.java
+++ b/api-ffmpeg/src/test/java/org/jmisb/api/video/VideoFileInputOutputIT.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import javax.imageio.ImageIO;
+import org.bytedeco.javacpp.Loader;
 import org.jmisb.api.klv.IMisbMessage;
 import org.jmisb.core.video.TimingUtils;
 import org.jmisb.st0102.Classification;
@@ -49,6 +50,7 @@ import org.jmisb.st0601.VerticalFov;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** Integration test for {@link VideoFileInput} and {@link VideoFileOutput} */
@@ -62,6 +64,12 @@ public class VideoFileInputOutputIT {
     private final String missionId = "Unit Testing";
     private final byte version0601 = 11;
     private final byte version0102 = 12;
+
+    @BeforeClass
+    public void loadPresets() {
+        // See https://github.com/WestRidgeSystems/jmisb/issues/403
+        Loader.load(org.bytedeco.ffmpeg.global.swscale.class);
+    }
 
     /** Video stream only test */
     @Test


### PR DESCRIPTION
## Motivation and Context

This is an attempt to resolve CI problems as reported at #403.

I'm not sure I understand the root cause, but its now happening pretty reliably, so possibly this is a useful workaround.

## Description

Pre-load the required class using extant javacpp-presets capability.

## How Has This Been Tested?
Ran it locally, no problems. Will check behaviour with CI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

