### PR TITLE
chore: upgrade slf4j to 2.0.1

### DIFF
--- a/api-ffmpeg/pom.xml
+++ b/api-ffmpeg/pom.xml
@@ -44,7 +44,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/api-ffmpeg/src/test/java/org/jmisb/api/video/LoggerChecks.java
+++ b/api-ffmpeg/src/test/java/org/jmisb/api/video/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.api.video;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,7 +28,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/api/src/test/java/org/jmisb/api/klv/KlvParserTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/KlvParserTest.java
@@ -2,13 +2,13 @@ package org.jmisb.api.klv;
 
 import static org.testng.Assert.*;
 
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.jmisb.api.common.KlvParseException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /** Unit tests for KlvParser. */
 public class KlvParserTest {

--- a/api/src/test/java/org/jmisb/api/klv/LdsParserTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/LdsParserTest.java
@@ -2,6 +2,8 @@ package org.jmisb.api.klv;
 
 import static org.testng.Assert.*;
 
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.jmisb.api.common.InvalidDataHandler;
 import org.jmisb.api.common.KlvParseException;
@@ -9,8 +11,6 @@ import org.jmisb.api.common.LogOnInvalidDataStrategy;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /** Unit tests for LdsParser. */
 public class LdsParserTest {

--- a/api/src/test/java/org/jmisb/api/klv/LoggerChecks.java
+++ b/api/src/test/java/org/jmisb/api/klv/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.api.klv;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.
@@ -41,7 +41,7 @@ public abstract class LoggerChecks {
     }
 
     protected void verifyNoLoggerMessages() {
-        if (LOGGER.getLoggingEvents().size() > 0) {
+        if (!LOGGER.getLoggingEvents().isEmpty()) {
             List<LoggingEvent> events = LOGGER.getLoggingEvents();
             for (LoggingEvent event : events) {
                 System.out.println(event.getLevel().name() + ": " + event.getMessage().toString());

--- a/api/src/test/java/org/jmisb/api/klv/st1204/CoreIdentifierTortureTest.java
+++ b/api/src/test/java/org/jmisb/api/klv/st1204/CoreIdentifierTortureTest.java
@@ -2,10 +2,10 @@ package org.jmisb.api.klv.st1204;
 
 import static org.testng.Assert.*;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
 import java.util.UUID;
 import org.jmisb.api.klv.LoggerChecks;
 import org.testng.annotations.Test;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
 
 public class CoreIdentifierTortureTest extends LoggerChecks {
 

--- a/eg0104/pom.xml
+++ b/eg0104/pom.xml
@@ -36,7 +36,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/examples/annotations/src/main/java/module-info.java
+++ b/examples/annotations/src/main/java/module-info.java
@@ -6,4 +6,5 @@ module org.jmisb.examples.annotation {
     requires org.jmisb.st1301;
     requires commons.cli;
     requires java.desktop;
+    requires org.slf4j;
 }

--- a/examples/generator/src/main/java/module-info.java
+++ b/examples/generator/src/main/java/module-info.java
@@ -9,4 +9,5 @@ module org.jmisb.examples.generator {
     requires org.jmisb.st1602;
     requires commons.cli;
     requires java.desktop;
+    requires org.slf4j;
 }

--- a/examples/timetransfer/src/main/java/module-info.java
+++ b/examples/timetransfer/src/main/java/module-info.java
@@ -5,4 +5,5 @@ module org.jmisb.examples.timetransfer {
     requires commons.cli;
     requires java.desktop;
     requires net.frogmouth.chronyjava;
+    requires org.slf4j;
 }

--- a/mimd/pom.xml
+++ b/mimd/pom.xml
@@ -36,7 +36,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/mimd/src/test/java/org/jmisb/mimd/st1902/LoggerChecks.java
+++ b/mimd/src/test/java/org/jmisb/mimd/st1902/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.mimd.st1902;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <jqf.plugin.version>1.9</jqf.plugin.version>
         <jqf.version>1.9</jqf.version>
         <jxmapviewer.version>2.6</jxmapviewer.version>
-        <log4j.version>2.18.0</log4j.version>
+        <log4j.version>2.19.0</log4j.version>
         <maven.annotations.version>3.6.4</maven.annotations.version>
         <maven.assembly.plugin.version>3.3.0</maven.assembly.plugin.version>
         <maven.checkstyle.plugin>3.1.2</maven.checkstyle.plugin>
@@ -129,8 +129,8 @@
         <owasp.dependency-check.version>7.1.0</owasp.dependency-check.version>
         <plexus.utils.version>3.4.2</plexus.utils.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <slf4j.test.version>1.2.0</slf4j.test.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.test.version>2.6.1</slf4j.test.version>
+        <slf4j.version>2.0.1</slf4j.version>
         <sortpom.version>3.0.1</sortpom.version>
         <spotbugs.maven.version>4.6.0.0</spotbugs.maven.version>
         <spotbugs.version>4.7.1</spotbugs.version>
@@ -154,11 +154,21 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>uk.org.lidalia</groupId>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.valfirst</groupId>
                 <artifactId>slf4j-test</artifactId>
                 <version>${slf4j.test.version}</version>
             </dependency>

--- a/st0102/pom.xml
+++ b/st0102/pom.xml
@@ -25,7 +25,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st0102/src/test/java/org/jmisb/st0102/LoggerChecks.java
+++ b/st0102/src/test/java/org/jmisb/st0102/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st0102;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st0601/pom.xml
+++ b/st0601/pom.xml
@@ -55,7 +55,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st0601/src/test/java/org/jmisb/st0601/LoggerChecks.java
+++ b/st0601/src/test/java/org/jmisb/st0601/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st0601;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st0601/src/test/java/org/jmisb/st0601/ParserTest.java
+++ b/st0601/src/test/java/org/jmisb/st0601/ParserTest.java
@@ -1,5 +1,8 @@
 package org.jmisb.st0601;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
@@ -21,9 +24,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 public class ParserTest {
     TestLogger LOGGER = TestLoggerFactory.getTestLogger(KlvParser.class);

--- a/st0602/pom.xml
+++ b/st0602/pom.xml
@@ -35,7 +35,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st0602/src/test/java/org/jmisb/st0602/AnnotationMetadataUniversalSetTest.java
+++ b/st0602/src/test/java/org/jmisb/st0602/AnnotationMetadataUniversalSetTest.java
@@ -3,6 +3,8 @@ package org.jmisb.st0602;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -20,8 +22,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 public class AnnotationMetadataUniversalSetTest {
     private AnnotationMetadataUniversalSet minimalUniversalSet;

--- a/st0806/pom.xml
+++ b/st0806/pom.xml
@@ -25,7 +25,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st0806/src/test/java/org/jmisb/st0806/LoggerChecks.java
+++ b/st0806/src/test/java/org/jmisb/st0806/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st0806;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st0808/pom.xml
+++ b/st0808/pom.xml
@@ -35,7 +35,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st0808/src/test/java/org/jmisb/st0808/LoggerChecks.java
+++ b/st0808/src/test/java/org/jmisb/st0808/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st0808;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st0809/pom.xml
+++ b/st0809/pom.xml
@@ -35,7 +35,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st0809/src/test/java/org/jmisb/st0809/LoggerChecks.java
+++ b/st0809/src/test/java/org/jmisb/st0809/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st0809;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st0903/pom.xml
+++ b/st0903/pom.xml
@@ -25,7 +25,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st0903/src/test/java/org/jmisb/st0903/shared/LoggerChecks.java
+++ b/st0903/src/test/java/org/jmisb/st0903/shared/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st0903.shared;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st0903vtrack/pom.xml
+++ b/st0903vtrack/pom.xml
@@ -30,7 +30,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st0903vtrack/src/test/java/org/jmisb/st0903vtrack/LoggerChecks.java
+++ b/st0903vtrack/src/test/java/org/jmisb/st0903vtrack/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st0903vtrack;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st1108/pom.xml
+++ b/st1108/pom.xml
@@ -35,7 +35,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st1108/src/test/java/org/jmisb/st1108/InterpretabilityQualityLocalSetFactoryTest.java
+++ b/st1108/src/test/java/org/jmisb/st1108/InterpretabilityQualityLocalSetFactoryTest.java
@@ -2,6 +2,9 @@ package org.jmisb.st1108;
 
 import static org.testng.Assert.*;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import org.jmisb.api.common.KlvParseException;
 import org.jmisb.api.klv.IMisbMessage;
 import org.jmisb.st1108.st1108_2.LegacyIQLocalSet;
@@ -10,9 +13,6 @@ import org.jmisb.st1108.st1108_3.IQLocalSet;
 import org.jmisb.st1108.st1108_3.IQLocalSetTest;
 import org.testng.annotations.Test;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /** Tests for the ST 1108 Interpretability and Quality Local Set Factory. */
 public class InterpretabilityQualityLocalSetFactoryTest {

--- a/st1108/src/test/java/org/jmisb/st1108/LoggerChecks.java
+++ b/st1108/src/test/java/org/jmisb/st1108/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st1108;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st1206/pom.xml
+++ b/st1206/pom.xml
@@ -25,7 +25,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st1206/src/test/java/org/jmisb/st1206/LoggerChecks.java
+++ b/st1206/src/test/java/org/jmisb/st1206/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st1206;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st1301/pom.xml
+++ b/st1301/pom.xml
@@ -30,7 +30,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st1301/src/test/java/org/jmisb/st1301/LoggerChecks.java
+++ b/st1301/src/test/java/org/jmisb/st1301/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st1301;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st1601/pom.xml
+++ b/st1601/pom.xml
@@ -25,7 +25,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st1601/src/test/java/org/jmisb/st1601/LoggerChecks.java
+++ b/st1601/src/test/java/org/jmisb/st1601/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st1601;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st1602/pom.xml
+++ b/st1602/pom.xml
@@ -25,7 +25,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st1602/src/test/java/org/jmisb/st1602/LoggerChecks.java
+++ b/st1602/src/test/java/org/jmisb/st1602/LoggerChecks.java
@@ -1,14 +1,14 @@
 package org.jmisb.st1602;
 
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 import java.util.List;
 import org.slf4j.helpers.MessageFormatter;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/st1603/pom.xml
+++ b/st1603/pom.xml
@@ -21,7 +21,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uk.org.lidalia</groupId>
+            <groupId>com.github.valfirst</groupId>
             <artifactId>slf4j-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/st1603/src/test/java/org/jmisb/st1603/localset/LoggerChecks.java
+++ b/st1603/src/test/java/org/jmisb/st1603/localset/LoggerChecks.java
@@ -6,9 +6,9 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import uk.org.lidalia.slf4jext.Level;
-import uk.org.lidalia.slf4jtest.LoggingEvent;
-import uk.org.lidalia.slf4jtest.TestLogger;
-import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
 
 /**
  * Superclass for logging checks in a test case.

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -36,7 +36,15 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.miglayout</groupId>


### PR DESCRIPTION
## Motivation and Context

SLF4J facade has just reached 2.0.1.  This upgrades jmisb 2.x to use that.

There is a knock-on change to some of the module requires, and requires a different log4j implementation and a different slf4jtest implementation to deal with the changes.

## Description

Updates version in manage dependencies, modifies viewer dependencies, and adds module imports.

Test version is upgraded - requires different imports for namespace changes.

## How Has This Been Tested?
Unit tested.

Ran viewer application with test sample that generates log results. Checked OK.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

