### PR TITLE
docs: minor javadoc fix

### DIFF
--- a/api/src/main/java/org/jmisb/api/klv/ArrayBuilder.java
+++ b/api/src/main/java/org/jmisb/api/klv/ArrayBuilder.java
@@ -261,7 +261,7 @@ public class ArrayBuilder {
     }
 
     /**
-     * Concatenate a collection of byte arrays (chunks) sequentially into one big array
+     * Concatenate a collection of byte arrays (chunks) sequentially into one big array.
      *
      * @param chunks The collection of chunks
      * @param totalLength The total number of bytes in all chunks


### PR DESCRIPTION
## Motivation and Context

During work on #428, I noted a javadoc warning (missing a trailing full stop on the first line).

## Description

Add one full stop (period) character.

## How Has This Been Tested?

Build  checked, no more warning.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

