### PR TITLE
chore: bump Jackson Databind to 2.14.0-rc1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <googleformatter.maven.plugin.version>1.7.5</googleformatter.maven.plugin.version>
         <gstreamer.version>1.4.0</gstreamer.version>
         <guava.version>31.1-jre</guava.version>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.14.0-rc1</jackson.version>
         <jacoco.version>0.8.8</jacoco.version>
         <javacpp.logging.debug>false</javacpp.logging.debug>
         <jqf.plugin.version>1.9</jqf.plugin.version>


### PR DESCRIPTION
## Motivation and Context

2.x CI is failing with a QA check for a vulnerable dependency. I don't think we are exposed to it, but its worth fixing.

## Description

Update `jackson-databind` in managed dependencies. Use of 2.14.0-rc1 is undesirable, but 2.14.0 isn't released yet.

## How Has This Been Tested?
Full build, including unit tests (which is one place we use Jackson).

Ran moving features example (which is the other place we use it).

Both OK.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

