### PR TITLE
qa: add suppression for false positive on Apache commons

### DIFF
--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+              <suppress base="true">
+                <notes><![CDATA[
+                False Positive per issue https://github.com/jeremylong/DependencyCheck/issues/5121 - fix for commons
+                ]]></notes>
+                <packageUrl regex="true">^(?!pkg:maven/commons-net/commons-net).*$</packageUrl>
+                <cpe>cpe:/a:apache:commons_net</cpe>
+             </suppress>
+</suppressions>

--- a/miml-maven-plugin/pom.xml
+++ b/miml-maven-plugin/pom.xml
@@ -256,6 +256,9 @@
                         <configuration>
                             <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                             <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                            <suppressionFiles>
+                                <suppressionFile>dependency-check-suppression.xml</suppressionFile>
+                            </suppressionFiles>
                         </configuration>
                         <executions>
                             <execution>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -178,6 +178,9 @@
                         <configuration>
                             <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                             <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                            <suppressionFiles>
+                                <suppressionFile>dependency-check-suppression.xml</suppressionFile>
+                            </suppressionFiles>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
## Motivation and Context

The dependency check (in QA CI build) is providing false positives for use of Apache Commons (that do not line up with the package that the CVE is against).

This is discussed in https://github.com/jeremylong/DependencyCheck/issues/5121

I have a similar fix for the 2.x branch in as part of https://github.com/WestRidgeSystems/jmisb/pull/436

## Description

Add suppression as proposed by the Dependency Check maintainers.

No code changes.

## How Has This Been Tested?
Full build. This is only a compile time check, so I think that is reasonable.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [N/A] My change requires a change to the documentation.
- [N/A] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [N/A] I have added tests to cover my changes.
- [X] All new and existing tests passed.

