### PR TITLE
#442 - Add KlvParser.parseStream(InputStream)

### DIFF
--- a/api/src/main/java/org/jmisb/api/common/KlvParseException.java
+++ b/api/src/main/java/org/jmisb/api/common/KlvParseException.java
@@ -1,7 +1,11 @@
 package org.jmisb.api.common;
 
+import java.util.Arrays;
+
 /** Indicates an error occurred during metadata parsing. */
 public class KlvParseException extends Exception {
+    private final byte[] buffer;
+
     /**
      * Constructor.
      *
@@ -10,5 +14,22 @@ public class KlvParseException extends Exception {
      */
     public KlvParseException(String message) {
         super(message);
+        this.buffer = null;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param exception the inner exception object
+     * @param buffer the buffer corresponding to the inner exception
+     */
+    public KlvParseException(KlvParseException exception, byte[] buffer) {
+        super(exception);
+        this.buffer = Arrays.copyOf(buffer, buffer.length);
+    }
+
+    /** @return a copy of the {@code byte[]} corresponding to the wrapped exception. */
+    public byte[] getBuffer() {
+        return Arrays.copyOf(buffer, buffer.length);
     }
 }

--- a/api/src/main/java/org/jmisb/api/klv/BerDecoder.java
+++ b/api/src/main/java/org/jmisb/api/klv/BerDecoder.java
@@ -1,7 +1,11 @@
 package org.jmisb.api.klv;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 /** Decode data using Basic Encoding Rules (BER). */
 public class BerDecoder {
+
     private BerDecoder() {}
 
     /**
@@ -10,7 +14,7 @@ public class BerDecoder {
      * @param data Array holding the BER-encoded data
      * @param offset Index of the first byte of the array to decode
      * @param isOid true if the data is encoded using BER-OID
-     * @return decoded The decoded field
+     * @return the decoded field
      * @throws IllegalArgumentException if the encoded data is invalid
      */
     public static BerField decode(byte[] data, int offset, boolean isOid)
@@ -75,6 +79,64 @@ public class BerDecoder {
             throw new IllegalArgumentException("BER: error decoding value");
         }
 
+        return new BerField(length, value);
+    }
+
+    /**
+     * Decode a field (length and value) from an InputStream.
+     *
+     * @param is InputStream with BER-encoded data at the tip
+     * @param isOid true if the data is encoded using BER-OID
+     * @return the decoded field
+     * @throws IllegalArgumentException if the encoded data is invalid
+     */
+    public static BerField decode(InputStream is, boolean isOid) throws IOException {
+        if (!isOid) {
+            return decodeBer(is);
+        }
+
+        return decodeBerOid(is);
+    }
+
+    private static BerField decodeBer(InputStream is) throws IOException {
+        int length = is.read();
+
+        if ((length & 0x80) == 0) {
+            // BER Short Form.  If the first bit of the BER is 0 then the BER is 1-byte.
+            return new BerField(1, length);
+        }
+
+        // BER Long Form (variable length)
+        int berLength = length & 0x7f;
+        if (berLength > 4) {
+            throw new IllegalArgumentException(
+                    "BER long form: BER length is >5 bytes; data is probably corrupt");
+        }
+        int fullBerSize = berLength + 1;
+        byte[] data = new byte[berLength];
+        int read = is.read(data, 0, data.length);
+        if (read != data.length) {
+            throw new IllegalArgumentException("BER parsing ran out of bytes");
+        }
+        int len = 0;
+        for (int i = 0; i < berLength; ++i) {
+            int b = 0x00FF & data[i];
+            len = (len << 8) | b;
+        }
+        return new BerField(fullBerSize, len);
+    }
+
+    private static BerField decodeBerOid(InputStream is) throws IOException {
+        int read;
+        int value = 0;
+        int length = 0;
+        do {
+            read = is.read();
+            int highbits = (value << 7);
+            int lowbits = (read & 0x7F);
+            value = highbits + lowbits;
+            length++;
+        } while ((read & 0x80) == 0x80);
         return new BerField(length, value);
     }
 }

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"
+              xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+              <suppress base="true">
+                <notes><![CDATA[
+                False Positive per issue https://github.com/jeremylong/DependencyCheck/issues/5121 - fix for commons
+                ]]></notes>
+                <packageUrl regex="true">^(?!pkg:maven/commons-net/commons-net).*$</packageUrl>
+                <cpe>cpe:/a:apache:commons_net</cpe>
+             </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -85,26 +85,26 @@
     <properties>
         <antlr4.version>4.11.1</antlr4.version>
         <appdirs.version>1.2.1</appdirs.version>
-        <checkstyle.version>10.3.4</checkstyle.version>
+        <checkstyle.version>10.5.0</checkstyle.version>
         <commons-cli.version>1.5.0</commons-cli.version>
         <commons-io.version>2.11.0</commons-io.version>
         <coveralls.version>4.3.0</coveralls.version>
         <cyclonedx.schema.version>1.3</cyclonedx.schema.version>
         <cyclonedx.version>2.6.2</cyclonedx.version>
         <failsafe.version>3.0.0-M6</failsafe.version>
-        <ffmpeg.platform.version>5.0-1.5.7</ffmpeg.platform.version>
+        <ffmpeg.platform.version>5.1.2-1.5.8</ffmpeg.platform.version>
         <freemarker.version>2.3.31</freemarker.version>
         <googleformatter.maven.plugin.version>1.7.5</googleformatter.maven.plugin.version>
         <gstreamer.version>1.4.0</gstreamer.version>
         <guava.version>31.1-jre</guava.version>
-        <jackson.version>2.14.0-rc1</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
         <jacoco.version>0.8.8</jacoco.version>
         <javacpp.logging.debug>false</javacpp.logging.debug>
         <jqf.plugin.version>1.9</jqf.plugin.version>
         <jqf.version>1.9</jqf.version>
         <jxmapviewer.version>2.6</jxmapviewer.version>
         <log4j.version>2.19.0</log4j.version>
-        <maven.annotations.version>3.6.4</maven.annotations.version>
+        <maven.annotations.version>3.7.0</maven.annotations.version>
         <maven.assembly.plugin.version>3.3.0</maven.assembly.plugin.version>
         <maven.checkstyle.plugin>3.1.2</maven.checkstyle.plugin>
         <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>
@@ -118,25 +118,25 @@
         <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
         <maven.javadoc.plugin.version>3.4.0</maven.javadoc.plugin.version>
         <maven.minimum.version>3.3.9</maven.minimum.version>
-        <maven.plugin.plugin.version>3.6.4</maven.plugin.plugin.version>
+        <maven.plugin.plugin.version>3.7.0</maven.plugin.plugin.version>
         <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
-        <maven.shade.plugin.version>3.3.0</maven.shade.plugin.version>
+        <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
         <maven.site.plugin.version>3.11.0</maven.site.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.version>3.8.6</maven.version>
         <miglayout.version>11.0</miglayout.version>
         <nexus.staging.plugin.version>1.6.13</nexus.staging.plugin.version>
         <owasp.dependency-check.version>7.1.0</owasp.dependency-check.version>
-        <plexus.utils.version>3.4.2</plexus.utils.version>
+        <plexus.utils.version>3.5.0</plexus.utils.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.test.version>2.6.1</slf4j.test.version>
-        <slf4j.version>2.0.2</slf4j.version>
+        <slf4j.version>2.0.5</slf4j.version>
         <sortpom.version>3.0.1</sortpom.version>
         <spotbugs.maven.version>4.6.0.0</spotbugs.maven.version>
-        <spotbugs.version>4.7.2</spotbugs.version>
+        <spotbugs.version>4.7.3</spotbugs.version>
         <surefire.verbosity>0</surefire.verbosity>
         <surefire.version>3.0.0-M6</surefire.version>
-        <svgSalamander.version>1.1.3</svgSalamander.version>
+        <svgSalamander.version>1.1.4</svgSalamander.version>
         <testng.version>7.6.1</testng.version>
         <versions.plugin.version>2.10.0</versions.plugin.version>
     </properties>
@@ -713,6 +713,11 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
+                        <configuration>
+                            <suppressionFiles>
+                                <suppressionFile>dependency-check-suppression.xml</suppressionFile>
+                            </suppressionFiles>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Motivation and Context
#442 - reference issue.  This is just a WIP attempt to provide InputStream parsing in KlvParser.

## Description
Added the below method to KlvParser.  
```java
    public static void parseStream(
            InputStream is,
            Consumer<IMisbMessage> handler,
            Consumer<KlvParseException> exceptionHandler)
```
Given that `parseBytes()` throws a KlvParseException on bad data, and when dealing with a stream, you may want the ability to continue processing, this required the ability to emit IMisbMessage and/or KlvParseExceptions without breaking the stream.

## How Has This Been Tested?
I tested with a mock application I'm developing where ffmpeg is running externally and its outputting the KLV data stream to stdout, which is being processed by KlvParser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

