### PR TITLE
st1601: fix missing @Test annotations

### DIFF
--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -2,11 +2,4 @@
 <suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"
               xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-              <suppress base="true">
-                <notes><![CDATA[
-                False Positive per issue https://github.com/jeremylong/DependencyCheck/issues/5121 - fix for commons
-                ]]></notes>
-                <packageUrl regex="true">^(?!pkg:maven/commons-net/commons-net).*$</packageUrl>
-                <cpe>cpe:/a:apache:commons_net</cpe>
-             </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <maven.version>3.8.6</maven.version>
         <miglayout.version>11.0</miglayout.version>
         <nexus.staging.plugin.version>1.6.13</nexus.staging.plugin.version>
-        <owasp.dependency-check.version>7.1.0</owasp.dependency-check.version>
+        <owasp.dependency-check.version>8.0.1</owasp.dependency-check.version>
         <plexus.utils.version>3.5.0</plexus.utils.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.test.version>2.6.1</slf4j.test.version>

--- a/st1601/src/test/java/org/jmisb/st1601/GeoRegistrationKeyTest.java
+++ b/st1601/src/test/java/org/jmisb/st1601/GeoRegistrationKeyTest.java
@@ -42,45 +42,52 @@ public class GeoRegistrationKeyTest {
         assertEquals(key.getIdentifier(), 3);
     }
 
+    @Test
     public void Enum4Test() {
         GeoRegistrationKey key = GeoRegistrationKey.getKey(4);
         assertEquals(key, GeoRegistrationKey.CorrespondencePointsRowColumn);
         assertEquals(key.getIdentifier(), 4);
     }
 
+    @Test
     public void Enum5Test() {
         GeoRegistrationKey key = GeoRegistrationKey.getKey(5);
         assertEquals(key, GeoRegistrationKey.CorrespondencePointsLatLon);
         assertEquals(key.getIdentifier(), 5);
     }
 
+    @Test
     public void Enum6Test() {
         GeoRegistrationKey key = GeoRegistrationKey.getKey(6);
         assertEquals(key, GeoRegistrationKey.SecondImageName);
         assertEquals(key.getIdentifier(), 6);
     }
 
+    @Test
     public void Enum7Test() {
         GeoRegistrationKey key = GeoRegistrationKey.getKey(7);
         assertEquals(key, GeoRegistrationKey.AlgorithmConfigurationIdentifier);
         assertEquals(key.getIdentifier(), 7);
     }
 
+    @Test
     public void Enum8Test() {
         GeoRegistrationKey key = GeoRegistrationKey.getKey(8);
         assertEquals(key, GeoRegistrationKey.CorrespondencePointsElevation);
         assertEquals(key.getIdentifier(), 8);
     }
 
+    @Test
     public void Enum9Test() {
         GeoRegistrationKey key = GeoRegistrationKey.getKey(9);
         assertEquals(key, GeoRegistrationKey.CorrespondencePointsRowColumnSDCC);
         assertEquals(key.getIdentifier(), 9);
     }
 
+    @Test
     public void Enum10Test() {
         GeoRegistrationKey key = GeoRegistrationKey.getKey(10);
         assertEquals(key, GeoRegistrationKey.CorrespondencePointsLatLonElevSDCC);
-        assertEquals(key.getIdentifier(), 9);
+        assertEquals(key.getIdentifier(), 10);
     }
 }


### PR DESCRIPTION
## Motivation and Context
During work on another local set, I noticed that there was a broken test in ST 1601 (i.e. it couldn't have passed). That wasn't being run, because it was missing the `@Test` annotation. Several other unit tests in the same test class were also missing that annotation.

The original version of this PR failed dependency checks for https://nvd.nist.gov/vuln/detail/CVE-2021-4277 which is completely unrelated to anything we use - its a broken NVD entry. There is an updated version of the OWASP dependency
check plugin that suppresses that entry. Upgrading also brought in a fix for a previous false positive (https://github.com/jeremylong/DependencyCheck/issues/5121) and we no longer need our own suppression for that.

## Description
Added missing annotations and fix the broken test. There is no code changes - this only affects the tests.

Update dependency check plugin and remove redundant suppression.

## How Has This Been Tested?
Full build, including the `dependencycheck` profile.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

