### PR TITLE
deps: bump ffmpeg-platform to 5.1.2-1.5.8 (#448)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
             <dependency>
                 <groupId>org.bytedeco</groupId>
                 <artifactId>ffmpeg-platform</artifactId>
-                <version>4.3.1-1.5.4</version>
+                <version>5.1.2-1.5.8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
keeps build working on ARM macOS

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fixes #448 

## Description
Bumps the version of ffmpeg-platform to the latest one that works on macOS ARM machines.

## How Has This Been Tested?
Ran the standard test suite via `mvn install`. Also manually ran the example viewer on some MISB mpeg files. Only tested on macOS Ventura 13.1 on an M1 (ARM) Mac with JDK OpenJDK (Zulu 11, zulu11.60.19-ca-jdk11.0.17-macosx_aarch64).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

