### PR TITLE
deps: update dependency check plugin to 8.0.1

### DIFF
--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -2,11 +2,4 @@
 <suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"
               xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-              <suppress base="true">
-                <notes><![CDATA[
-                False Positive per issue https://github.com/jeremylong/DependencyCheck/issues/5121 - fix for commons
-                ]]></notes>
-                <packageUrl regex="true">^(?!pkg:maven/commons-net/commons-net).*$</packageUrl>
-                <cpe>cpe:/a:apache:commons_net</cpe>
-             </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <jqf.plugin.version>1.7</jqf.plugin.version>
         <jqf.version>1.7</jqf.version>
         <maven.assembly.plugin.version>3.3.0</maven.assembly.plugin.version>
-        <owasp.version>6.2.2</owasp.version>
+        <owasp.version>8.0.1</owasp.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.32</slf4j.version>
         <sortpom.version>3.0.0</sortpom.version>


### PR DESCRIPTION
## Motivation and Context
#448 failed QA checks for reasons unrelated to the actual change. Its hitting the same false-positive for "anything utils" that we hit on 2.x in #449.

This fix is equivalent to the dependency check upgrade part of #449, but for main.

## Description
Bump dependency-check-plugin to 8.0.1, which brings in suppression for the false positive. 8.0.1 also includes a suppression for the false-positive we were previously suppressing ourselves, so that gets removed.

No code changes.

## How Has This Been Tested?

Full build with the dependency check profile.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

