### PR TITLE
deps: version updates for guava and testng

### DIFF
--- a/.github/workflows/jdk8.yml
+++ b/.github/workflows/jdk8.yml
@@ -1,4 +1,4 @@
-name: JDK8 Build (Ubuntu 18.04)
+name: JDK8 Build (Ubuntu 20.04)
 
 on:
     push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/miml-maven-plugin/pom.xml
+++ b/miml-maven-plugin/pom.xml
@@ -68,7 +68,7 @@
             <!-- Override for CVE 2020-8908 -->
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1.1-android</version>
+            <version>32.0.0-android</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <spotbugs.version>4.3.0</spotbugs.version>
         <surefire.verbosity>0</surefire.verbosity>
         <surefire.version>3.0.0-M5</surefire.version>
-        <testng.version>7.5</testng.version>
+        <testng.version>7.5.1</testng.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Motivation and Context

We've previously tried an update on testng, but testng after 7.6 doesn't support JDK 8 (requires JDK 11+).
However there is now a 7.5.1 to fix the CVE (which we were not vulnerable to, but still got flagged).

Since that, there is a revised view of a CVE on tempdir in Guava (which we are also not vulnerable to, AFAICT), which breaks the dependency check.

Further, GH actions no longer supports Ubuntu 18.04, so we need to update that too.

## Description
Simple version updates. No code changes.

## How Has This Been Tested?

The testng and MIML code is only used in builds, so as long as that works, we should be fine.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

