### PR TITLE
fix: FrameConverter only copies upper square on portrait-format video

### DIFF
--- a/api-ffmpeg/src/main/java/org/jmisb/api/video/FrameConverter.java
+++ b/api-ffmpeg/src/main/java/org/jmisb/api/video/FrameConverter.java
@@ -53,7 +53,7 @@ public class FrameConverter {
         byte[] a = ((DataBufferByte) out).getData();
 
         ByteBuffer src =
-                frame.data(0).capacity((long) frame.width() * (long) frame.linesize(0)).asBuffer();
+                frame.data(0).capacity((long) frame.height() * (long) frame.linesize(0)).asBuffer();
         copy(src, frame.linesize(0), ByteBuffer.wrap(a, start, a.length - start), step);
 
         return bufferedImage;


### PR DESCRIPTION
FrameConverter should be copying lines for the height of the image, not the width. Width happened to work since most test videos are landscape.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Portrait videos do not play properly, only rendering the upper (width x width) part of the video.

## Description
<!--- Describe your changes in detail -->
The change is a one-line fix in the FrameConverter's convert method where a decoded frame is put into a ByteBuffer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a few different portrait-format videos I had handy and on a set of landscape video I usually work with. Not extensively tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

