### PR TITLE
fix: adjust position for file videos with non-zero start time.

### DIFF
--- a/api/src/main/java/org/jmisb/api/video/VideoFileInput.java
+++ b/api/src/main/java/org/jmisb/api/video/VideoFileInput.java
@@ -31,6 +31,7 @@ public class VideoFileInput extends VideoInput implements IVideoFileInput {
     private final Set<IFileEventListener> fileEventListeners = new HashSet<>();
     private boolean open = false;
     private boolean playing = false;
+    private double startTime = 0.0;
     private double position = 0.0;
     private double duration = 0.0;
     private int numFrames = 0;
@@ -87,6 +88,7 @@ public class VideoFileInput extends VideoInput implements IVideoFileInput {
         AVStream videoStream = FfmpegUtils.getVideoStream(formatContext);
 
         duration = FfmpegUtils.getDuration(formatContext);
+        startTime = FfmpegUtils.getStartTime(formatContext);
 
         // Require a valid video stream
         if (videoStream == null) {
@@ -223,7 +225,7 @@ public class VideoFileInput extends VideoInput implements IVideoFileInput {
         if (logger.isDebugEnabled()) logger.debug("Seeking to " + pos + "s");
 
         // Seek the demuxer, this will also cause packet queues to be cleared
-        demuxer.seek(pos);
+        demuxer.seek(startTime + pos);
 
         // Stop notifiers & clear decodedFrameQueue & decodedMetadataQueue
         stopNotifiers();
@@ -272,7 +274,7 @@ public class VideoFileInput extends VideoInput implements IVideoFileInput {
         prevVideoTime = time;
 
         // TODO: good?
-        position = prevVideoPts;
+        position = pts - startTime;
 
         // logger.debug("Setting position = " + prevVideoPts);
     }

--- a/core/src/main/java/org/jmisb/core/video/FfmpegUtils.java
+++ b/core/src/main/java/org/jmisb/core/video/FfmpegUtils.java
@@ -115,6 +115,16 @@ public class FfmpegUtils {
     }
 
     /**
+     * Get the start time.
+     *
+     * @param context the format context
+     * @return The start time, in seconds
+     */
+    public static double getStartTime(AVFormatContext context) {
+        return (double) context.start_time() / AV_TIME_BASE;
+    }
+
+    /**
      * Get the frame rate
      *
      * @param context The format context


### PR DESCRIPTION
This pull request contains a fix for video files with a non-zero start time, ie. the first frame has pts > 0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, `FileVideoInput` may return a position that exceeds the duration and which may not be accepted by seek. This pull request fixes that issue (#467).

## Description
<!--- Describe your changes in detail -->
- When opening a file,`FileVideoInput` will store the start time.
- the start time is then used to normalize the position between 0 and duration.
- When seeking, the start time is used to convert the position back to pts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've used MisbViewer to load a video file that has a non-zero start time (ie. the pts of the very first frame is not 0). I've verified that it plays back correctly and seeking works as expected. Unfortunately, I cannot share the test file.

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

